### PR TITLE
using span with css instead of img

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -1161,7 +1161,7 @@
                     '<p class="chatroom-topic"><p/>' +
                 '</div>' +
                 '<div class="chat-body">' +
-                '<img class="spinner centered" src="images/spinner.gif"/>' +
+                '<span class="spinner centered"/>' +
                 '</div>'),
 
             chatarea_template: _.template(
@@ -1246,7 +1246,7 @@
                     'hidden': 'hidden',
                     'list-single': 'dropdown'
                 };
-                $form.find('img.spinner').remove();
+                $form.find('span.spinner').remove();
                 $form.append($('<legend>').text(title));
                 if (instructions != title) {
                     $form.append($('<p>').text(instructions));
@@ -1355,7 +1355,7 @@
                 this.$el.find('.chat-body').append(
                     $('<div class="chatroom-form-container">'+
                         '<form class="chatroom-form">'+
-                        '<img class="spinner centered" src="images/spinner.gif"/>'+
+                        '<span class="spinner centered"/>'+
                         '</form>'+
                     '</div>'));
                 converse.connection.muc.configure(
@@ -1368,12 +1368,12 @@
                 ev.preventDefault();
                 var password = this.$el.find('.chatroom-form').find('input[type=password]').val();
                 this.$el.find('.chatroom-form-container').replaceWith(
-                    '<img class="spinner centered" src="images/spinner.gif"/>');
+                    '<span class="spinner centered"/>');
                 this.connect(password);
             },
 
             renderPasswordForm: function () {
-                this.$el.find('img.centered.spinner').remove();
+                this.$el.find('span.centered.spinner').remove();
                 this.$el.find('.chat-body').append(
                     $('<div class="chatroom-form-container">'+
                         '<form class="chatroom-form">'+
@@ -1388,7 +1388,7 @@
             showDisconnectMessage: function (msg) {
                 this.$el.find('.chat-area').remove();
                 this.$el.find('.participants').remove();
-                this.$el.find('img.centered.spinner').remove();
+                this.$el.find('span.centered.spinner').remove();
                 this.$el.find('.chat-body').append($('<p>'+msg+'</p>'));
             },
 
@@ -2509,7 +2509,7 @@
                     connection = new Strophe.Connection(converse.bosh_service_url);
                 if ($form) {
                     $button = $form.find('input[type=submit]');
-                    $button.hide().after('<img class="spinner login-submit" src="images/spinner.gif"/>');
+                    $button.hide().after('<span class="spinner login-submit"/>');
                 }
                 connection.connect(jid, password, $.proxy(function (status, message) {
                     if (status === Strophe.Status.CONNECTED) {


### PR DESCRIPTION
using span instead of img to avoid problems with relative paths.

I was trying to use the converse.js on different urls but the html was trying to get the spinner.gif in diferrents paths so the image wa broken. Changing to css using span was a way to fix this problem and show the spinner all over the system.
