### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "converse",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "devDependencies": {
     "jasmine": "https://github.com/jcbrand/jasmine.git#1_3_x"
   },


### PR DESCRIPTION
The version specified in the bower.json of package converse mismatches the tag (0.5.2 vs 0.5.0)
