### PR TITLE
Fix num_unread*2 on minimized chat

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -3034,7 +3034,9 @@
             },
 
             initialize: function () {
-                this.model.messages.on('add', this.updateUnreadMessagesCounter, this);
+                this.model.messages.on('add', function(msg) {
+                        if (!msg.attributes.composing) {this.updateUnreadMessagesCounter();}
+                    } , this);
                 this.model.on('showSentOTRMessage', this.updateUnreadMessagesCounter, this);
                 this.model.on('showReceivedOTRMessage', this.updateUnreadMessagesCounter, this);
                 this.model.on('change:minimized', this.clearUnreadMessagesCounter, this);


### PR DESCRIPTION
When chat was minimized the counter num_unread of unread message was increment when receiving a compose message so the number of unread messages was doubled.
