### PR TITLE
Fix locale set during initialize not being used in utils.translation

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -300,7 +300,7 @@
 
         // Translation machinery
         // ---------------------
-        var __ = utils.__;
+        var __ = $.proxy(utils.__, this);
         var ___ = utils.___;
         // Translation aware constants
         // ---------------------------

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ define(["jquery"], function ($) {
     var utils = {
         // Translation machinery
         // ---------------------
-        __: $.proxy(function (str) {
+        __: function (str) {
             // Translation factory
             if (this.i18n === undefined) {
                 this.i18n = locales.en;
@@ -41,7 +41,7 @@ define(["jquery"], function ($) {
             } else {
                 return t.fetch();
             }
-        }, this),
+        },
 
         ___: function (str) {
             /* XXX: This is part of a hack to get gettext to scan strings to be


### PR DESCRIPTION
I'm using Spanish translation in one of the sites I'm developing but when I switched from 0.8.3 to -master it wasn't being honored.
It seems when the translation stuff was refactored to utils it stopped working, this makes it work correctly.

Cheers,
Guillermo
