### PR TITLE
New build that does not include jQuery

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,6 +100,8 @@ module.exports = function(grunt) {
         };
         exec('./node_modules/requirejs/bin/r.js -o src/build.js && ' +
              './node_modules/requirejs/bin/r.js -o src/build.js optimize=none out=builds/converse.js && ' +
+             './node_modules/requirejs/bin/r.js -o src/build-no-jquery.js &&' +
+             './node_modules/requirejs/bin/r.js -o src/build-no-jquery.js optimize=none out=builds/converse.nojquery.js && ' +
              './node_modules/requirejs/bin/r.js -o src/build-no-locales-no-otr.js && ' +
              './node_modules/requirejs/bin/r.js -o src/build-no-locales-no-otr.js optimize=none out=builds/converse-no-locales-no-otr.js && ' +
              './node_modules/requirejs/bin/r.js -o src/build-no-otr.js &&' +

--- a/src/build-no-jquery.js
+++ b/src/build-no-jquery.js
@@ -1,0 +1,28 @@
+({
+    baseUrl: "../",
+    name: "components/almond/almond.js",
+    out: "../builds/converse.nojquery.min.js",
+    include: ['main'],
+    tpl: {
+        // Use Mustache style syntax for variable interpolation
+        templateSettings: {
+            evaluate : /\{\[([\s\S]+?)\]\}/g,
+            interpolate : /\{\{([\s\S]+?)\}\}/g
+        }
+    },
+    map: {
+        // '*' means all modules will get 'jquery-private'
+        // for their 'jquery' dependency.
+        '*': { 'jquery': 'jquery-private' },
+        // 'jquery-private' wants the real jQuery module
+        // though. If this line was not here, there would
+        // be an unresolvable cyclic dependency.
+        'jquery-private': { 'jquery': 'jquery' }
+    },
+    mainConfigFile: '../main.js',
+    paths: {
+        "converse-dependencies":    "src/deps-full",
+        "jquery":                   "src/jquery-external",
+        "jquery-private":           "src/jquery-private-external",
+    }
+})

--- a/src/jquery-external.js
+++ b/src/jquery-external.js
@@ -1,0 +1,3 @@
+define('jquery', [], function () {
+    return jQuery;
+});

--- a/src/jquery-private-external.js
+++ b/src/jquery-private-external.js
@@ -1,0 +1,3 @@
+define(['jquery'], function (jq) {
+    return jq;
+});


### PR DESCRIPTION
This is useful when you already have jQuery loaded in your page, for
example on a Wordpress site.
