### PR TITLE
Fix old roster.js missing route parameter on connect

### DIFF
--- a/src/strophe.roster.js
+++ b/src/strophe.roster.js
@@ -72,7 +72,7 @@ Strophe.addConnectionPlugin('roster',
                 oldCallback.apply(this, arguments);
             }
         };
-        conn.connect = function(jid, pass, callback, wait, hold)
+        conn.connect = function(jid, pass, callback, wait, hold, route)
         {
             oldCallback = callback;
             if (typeof jid  == "undefined")
@@ -80,7 +80,7 @@ Strophe.addConnectionPlugin('roster',
             if (typeof pass == "undefined")
                 pass = null;
             callback = newCallback;
-            _connect.apply(conn, [jid, pass, callback, wait, hold]);
+            _connect.apply(conn, [jid, pass, callback, wait, hold, route]);
         };
         conn.attach = function(jid, sid, rid, callback, wait, hold, wind)
         {


### PR DESCRIPTION
The roster version that converse.js uses is missing the route parameter on connect (it's present inside the newer version inside strophejs-plugins).
This change adds that parameter to be sent to Strophe.
