### PR TITLE
Multiple bind

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -3079,6 +3079,7 @@
                 if (ev && ev.preventDefault) {
                     ev.preventDefault();
                 }
+                this.model.messages.off('add',null,this);
                 this.remove();
                 this.model.maximize();
             }, 200)


### PR DESCRIPTION
Restoring a chatbox wasnt unbinding event then the unread counter for a chatbox was multiply by the time you minized it.
