### PR TITLE
Always show pending/requesting users in roster

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -3228,18 +3228,10 @@
 
             showInRoster: function () {
                 var chatStatus = this.get('chat_status');
-                if (converse.show_only_online_users && chatStatus !== 'online') {
+                if ((converse.show_only_online_users && chatStatus !== 'online')
+                    || (converse.hide_offline_users && chatStatus === 'offline')) {
                     // If pending or requesting, show
                     if ((this.get('ask') === 'subscribe')
-                        || (this.get('subscription') === 'from')
-                        || (this.get('requesting') === true)) {
-                        return true;
-                    }
-                    return false;
-                }
-                if (converse.hide_offline_users && chatStatus === 'offline') {
-                    // If pending or requesting, show
-                    if ((this.get('ask') === 'subscribe') 
                         || (this.get('subscription') === 'from')
                         || (this.get('requesting') === true)) {
                         return true;

--- a/spec/controlbox.js
+++ b/spec/controlbox.js
@@ -436,7 +436,6 @@
                 });
                 waits(50);
                 spyOn(this.rosterview, 'update').andCallThrough();
-                waits(50);
                 runs($.proxy(function () {
                     expect(this.rosterview.$el.is(':visible')).toEqual(true);
                     expect(this.rosterview.update).toHaveBeenCalled();


### PR DESCRIPTION
Even if show_only_online_users or hide_offline_users
are set, show users that are pending or requesting
