### PR TITLE
Set immediate to true when calling _.debounce

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -3091,7 +3091,7 @@
                 this.model.messages.off('add',null,this);
                 this.remove();
                 this.model.maximize();
-            }, 200)
+            }, 200, true)
         });
 
         this.MinimizedChats = Backbone.Overview.extend({


### PR DESCRIPTION
When clicking on restore button for a minimized chat, the page's hash will change to `#`. It may cause problems for web apps that listen to changes in page's hash.

When `immediate` argument of `debounce` function is not set, `ev` is null and `ev.preventDefault()` will not be called.
