### PR TITLE
Specify utf-8 charset in documentation so minified builds will work across platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ The UI is now based on Bootstrap4 and Flexbox is used extensively.
 ### Bugfixes
 
 - Spoiler messages didn't include the message author's name.
-
+- Documentation includes utf-8 charset to make minfied versions compatible across platforms. #1017
 
 ## 3.3.4 (2018-03-05)
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -31,7 +31,7 @@ via the *script* and *link* tags:
 .. code-block:: html
 
     <link rel="stylesheet" type="text/css" media="screen" href="https://cdn.conversejs.org/css/converse.min.css">
-    <script src="https://cdn.conversejs.org/dist/converse.min.js"></script>
+    <script src="https://cdn.conversejs.org/dist/converse.min.js" charset="utf-8"></script>
 
 
 .. note:: For the fullscreen version of converse.js, replace


### PR DESCRIPTION
Documentation fix makes minified versions work across platforms - Addresses #1017