### PR TITLE
replace geoURIs (e.g. from Convesations) by links to openstreetmap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 The UI is now based on Bootstrap4 and Flexbox is used extensively.
 
+## New Features
+
+- geo-URIs (e.g. from Conversations) are now replaced by links to openstreetmap (works in reverse also)
+
 ## Configuration changes 
 
 * Removed the `xhr_custom_status` and `xhr_custom_status_url` configuration

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -651,6 +651,21 @@ logged in user, otherwise the user's vCard will be fetched.
 
 .. _`hide_muc_server`:
 
+geouri_regex
+----------------
+
+* Default:  ``/https:\/\/www.openstreetmap.org\/.*#map=[0-9]+\/([\-0-9.]+)\/([\-0-9.]+)\S*/g``
+
+Regular expression used to extract geo coordinates from links to openstreetmap.
+
+geouri_replacement
+----------------
+
+* Default:  ``'https://www.openstreetmap.org/?mlat=$1&mlon=$2#map=18/$1/$2'``
+
+String used to replace geo-URIs with. Ought to be a link to osm or similar. ``$1`` and ``$2`` is replaced by
+latitude and longitude respectively.
+
 hide_muc_server
 ---------------
 

--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -2687,6 +2687,33 @@
                 expect($unreadMsgCount.html()).toBe('1');
                 done();
             }));
+
+            it("will render Openstreetmap-URL from geo-URI",
+                    mock.initConverseWithPromises(
+                        null, ['rosterGroupsFetched'], {},
+                        function (done, _converse) {
+
+                    test_utils.createContacts(_converse, 'current');
+                    var base_url = document.URL.split(window.location.pathname)[0];
+                    var message = "geo:37.786971,-122.399677";
+                    var contact_jid = mock.cur_names[0].replace(/ /g,'.').toLowerCase() + '@localhost';
+                    test_utils.openChatBoxFor(_converse, contact_jid);
+                    var view = _converse.chatboxviews.get(contact_jid);
+                    spyOn(view, 'sendMessage').and.callThrough();
+                    test_utils.sendMessage(view, message);
+
+                    test_utils.waitUntil(function () {
+                        return $(view.el).find('.chat-content').find('.chat-message').length;
+                    }, 1000).then(function () {
+                        expect(view.sendMessage).toHaveBeenCalled();
+                        var msg = $(view.el).find('.chat-content').find('.chat-message').last().find('.chat-msg-content');
+                        expect(msg.html()).toEqual(
+                            '<a target="_blank" rel="noopener" href="https://www.openstreetmap.org/?mlat=37.786971&amp;'+
+                            'mlon=-122.399677#map=18/37.786971/-122.399677">https://www.openstreetmap.org/?mlat=37.7869'+
+                            '71&amp;mlon=-122.399677#map=18/37.786971/-122.399677</a>');
+                        done();
+                    });
+                }));
         });
     });
 }));

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -615,6 +615,8 @@
                         template = attrs.is_spoiler ? tpl_spoiler_message : tpl_message;
                     }
 
+                    text = u.geoUriToHttp(text, _converse);
+
                     const msg_time = moment(attrs.time) || moment;
                     const msg = u.stringToElement(template(
                         _.extend(this.getExtraMessageTemplateAttributes(attrs), {
@@ -846,7 +848,7 @@
                             'fullname': _.isEmpty(fullname) ? _converse.bare_jid : fullname,
                             'sender': 'me',
                             'time': moment().format(),
-                            'message': emojione.shortnameToUnicode(text),
+                            'message': u.httpToGeoUri(emojione.shortnameToUnicode(text), _converse),
                             'is_spoiler': is_spoiler
                         };
                     if (is_spoiler) {

--- a/src/converse-core.js
+++ b/src/converse-core.js
@@ -306,6 +306,8 @@
             expose_rid_and_sid: false,
             filter_by_resource: false,
             forward_messages: false,
+            geouri_regex: /https:\/\/www.openstreetmap.org\/.*#map=[0-9]+\/([\-0-9.]+)\/([\-0-9.]+)\S*/g,
+            geouri_replacement: 'https://www.openstreetmap.org/?mlat=$1&mlon=$2#map=18/$1/$2',
             hide_offline_users: false,
             include_offline_state: false,
             jid: undefined,

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -675,7 +675,7 @@
                      * Parameters:
                      *  (String) text: The message text to be sent.
                      */
-                    text = emojione.shortnameToUnicode(text)
+                    text = u.httpToGeoUri(emojione.shortnameToUnicode(text), _converse)
                     const msgid = _converse.connection.getUniqueId();
                     const msg = $msg({
                         to: this.model.get('jid'),

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -705,5 +705,15 @@
         evt.initEvent(name, bubbles, cancelable);
         el.dispatchEvent(evt);
     };
+
+    u.geoUriToHttp = function(text, _converse) {
+        const regex = /geo:([\-0-9.]+),([\-0-9.]+)(?:,([\-0-9.]+))?(?:\?(.*))?/g;
+        return text.replace(regex, _converse.geouri_replacement);
+    };
+
+    u.httpToGeoUri = function(text, _converse) {
+        const replacement = 'geo:$1,$2';
+        return text.replace(_converse.geouri_regex, replacement);
+    };
     return u;
 }));


### PR DESCRIPTION
This will replace geoURIs (e.g. from Convesations) by links to openstreetmap. Will also work the other way round.

If you like to use other websites instead of openstreetmap, this can be configured.