### PR TITLE
Put timestamp in a <time> tag for better semantics and easier styling

### DIFF
--- a/src/templates/message.html
+++ b/src/templates/message.html
@@ -1,4 +1,5 @@
 <div class="message chat-message {{{o.extra_classes}}}" data-isodate="{{{o.isodate}}}" data-msgid="{{{o.msgid}}}">
-    <span class="chat-msg-author chat-msg-{{{o.sender}}}">{{{o.time}}} {{{o.username}}}:&nbsp;</span>
+    <time timestamp="{{{o.isodate}}}">{{{o.time}}}</time>
+    <span class="chat-msg-author chat-msg-{{{o.sender}}}">{{{o.username}}}:&nbsp;</span>
     <span class="chat-msg-content"><!-- message gets added here via renderMessage --></span>
 </div>


### PR DESCRIPTION
I wanted to experiment with styling and positioning of the timestamp, but was hindered by it being lumped together with the nickname.

I'm assuming that this initial change breaks existing styling, so consider this a feature request with an attached patch to show what I meant.