### PR TITLE
Rename “room” and “chat room” to “groupchat” in all user-facing strings.

### DIFF
--- a/src/converse-bookmarks.js
+++ b/src/converse-bookmarks.js
@@ -76,7 +76,7 @@
                           { __ } = _converse;
                     const bookmark_button = tpl_chatroom_bookmark_toggle(
                         _.assignIn(this.model.toJSON(), {
-                            info_toggle_bookmark: __('Bookmark this room'),
+                            info_toggle_bookmark: __('Bookmark this groupchat'),
                             bookmarked: this.model.get('bookmarked')
                         }));
                     const close_button = this.el.querySelector('.close-chatbox-button');
@@ -152,10 +152,10 @@
                     body.insertAdjacentHTML(
                         'beforeend',
                         tpl_chatroom_bookmark_form({
-                            heading: __('Bookmark this room'),
+                            heading: __('Bookmark this groupchat'),
                             label_name: __('The name for this bookmark:'),
-                            label_autojoin: __('Would you like this room to be automatically joined upon startup?'),
-                            label_nick: __('What should your nickname for this room be?'),
+                            label_autojoin: __('Would you like this groupchat to be automatically joined upon startup?'),
+                            label_nick: __('What should your nickname for this groupchat be?'),
                             default_nick: this.model.get('nick'),
                             label_submit: __('Save'),
                             label_cancel: __('Cancel')
@@ -422,13 +422,13 @@
                         'hidden': _converse.hide_open_bookmarks &&
                                   _converse.chatboxes.where({'jid': this.model.get('jid')}).length,
                         'bookmarked': true,
-                        'info_leave_room': __('Leave this room'),
+                        'info_leave_room': __('Leave this groupchat'),
                         'info_remove': __('Remove this bookmark'),
-                        'info_remove_bookmark': __('Unbookmark this room'),
-                        'info_title': __('Show more information on this room'),
+                        'info_remove_bookmark': __('Unbookmark this groupchat'),
+                        'info_title': __('Show more information on this groupchat'),
                         'jid': this.model.get('jid'),
                         'name': Strophe.xmlunescape(this.model.get('name')),
-                        'open_title': __('Click to open this room')
+                        'open_title': __('Click to open this groupchat')
                     });
                 }
             });

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -194,24 +194,24 @@
              */
             _converse.muc = {
                 info_messages: {
-                    100: __('This room is not anonymous'),
-                    102: __('This room now shows unavailable members'),
-                    103: __('This room does not show unavailable members'),
-                    104: __('The room configuration has changed'),
-                    170: __('Room logging is now enabled'),
-                    171: __('Room logging is now disabled'),
-                    172: __('This room is now no longer anonymous'),
-                    173: __('This room is now semi-anonymous'),
-                    174: __('This room is now fully-anonymous'),
-                    201: __('A new room has been created')
+                    100: __('This groupchat is not anonymous'),
+                    102: __('This groupchat now shows unavailable members'),
+                    103: __('This groupchat does not show unavailable members'),
+                    104: __('The groupchat configuration has changed'),
+                    170: __('Groupchat logging is now enabled'),
+                    171: __('Groupchat logging is now disabled'),
+                    172: __('This groupchat is now no longer anonymous'),
+                    173: __('This groupchat is now semi-anonymous'),
+                    174: __('This groupchat is now fully-anonymous'),
+                    201: __('A new groupchat has been created')
                 },
 
                 disconnect_messages: {
-                    301: __('You have been banned from this room'),
-                    307: __('You have been kicked from this room'),
-                    321: __("You have been removed from this room because of an affiliation change"),
-                    322: __("You have been removed from this room because the room has changed to members-only and you're not a member"),
-                    332: __("You have been removed from this room because the MUC (Multi-user chat) service is being shut down")
+                    301: __('You have been banned from this groupchat'),
+                    307: __('You have been kicked from this groupchat'),
+                    321: __("You have been removed from this groupchat because of an affiliation change"),
+                    322: __("You have been removed from this groupchat because the groupchat has changed to members-only and you're not a member"),
+                    332: __("You have been removed from this groupchat because the MUC (Multi-user chat) service is being shut down")
                 },
 
                 action_info_messages: {
@@ -269,7 +269,7 @@
                         'temporary': sizzle('feature[var="muc_temporary"]', stanza).length,
                         'unmoderated': sizzle('feature[var="muc_unmoderated"]', stanza).length,
                         'label_desc': __('Description:'),
-                        'label_jid': __('Room Address (JID):'),
+                        'label_jid': __('Groupchat address (JID):'),
                         'label_occ': __('Occupants:'),
                         'label_features': __('Features:'),
                         'label_requires_auth': __('Requires authentication'),
@@ -277,11 +277,11 @@
                         'label_requires_invite': __('Requires an invitation'),
                         'label_moderated': __('Moderated'),
                         'label_non_anon': __('Non-anonymous'),
-                        'label_open_room': __('Open room'),
-                        'label_permanent_room': __('Permanent room'),
+                        'label_open_room': __('Open groupchat'),
+                        'label_permanent_room': __('Permanent groupchat'),
                         'label_public': __('Public'),
                         'label_semi_anon':  __('Semi-anonymous'),
-                        'label_temp_room':  __('Temporary room'),
+                        'label_temp_room':  __('Temporary groupchat'),
                         'label_unmoderated': __('Unmoderated')
                     }));
             }
@@ -321,9 +321,9 @@
 
                 toHTML () {
                     return tpl_list_chatrooms_modal(_.extend(this.model.toJSON(), {
-                        'heading_list_chatrooms': __('Query for Chatrooms'),
+                        'heading_list_chatrooms': __('Query for groupchat'),
                         'label_server_address': __('Server address'),
-                        'label_query': __('Show rooms'),
+                        'label_query': __('Show groupchat'),
                         'server_placeholder': __('conference.example.org')
                     }));
                 },
@@ -362,8 +362,8 @@
                     div.innerHTML = tpl_room_item({
                         'name': Strophe.xmlunescape(name),
                         'jid': room.getAttribute('jid'),
-                        'open_title': __('Click to open this room'),
-                        'info_title': __('Show more information on this room')
+                        'open_title': __('Click to open this groupchat'),
+                        'info_title': __('Show more information on this groupchat')
                     });
                     return div.firstChild;
                 },
@@ -377,7 +377,7 @@
                 informNoRoomsFound () {
                     const chatrooms_el = this.el.querySelector('.available-chatrooms');
                     chatrooms_el.innerHTML = tpl_rooms_results({
-                        'feedback_text': __('No rooms found')
+                        'feedback_text': __('No groupchat found')
                     });
                     const input_el = this.el.querySelector('input[name="server"]');
                     input_el.classList.remove('hidden')
@@ -394,7 +394,7 @@
                         // For translators: %1$s is a variable and will be
                         // replaced with the XMPP server name
                         available_chatrooms.innerHTML = tpl_rooms_results({
-                            'feedback_text': __('Rooms found:')
+                            'feedback_text': __('Groupchat found:')
                         });
                         const fragment = document.createDocumentFragment();
                         const children = _.reject(_.map(this.rooms, this.roomStanzaItemToHTMLElement), _.isNil)
@@ -447,8 +447,8 @@
 
                 toHTML () {
                     return tpl_add_chatroom_modal(_.extend(this.model.toJSON(), {
-                        'heading_new_chatroom': __('Enter a new Chatroom'),
-                        'label_room_address': __('Room address'),
+                        'heading_new_chatroom': __('Enter a new groupchat'),
+                        'label_room_address': __('Groupchat address'),
                         'label_nickname': __('Optional nickname'),
                         'chatroom_placeholder': __('name@conference.example.org'),
                         'label_join': __('Join'),
@@ -622,8 +622,8 @@
                     return tpl_chatroom_head(
                         _.extend(this.model.toJSON(), {
                             Strophe: Strophe,
-                            info_close: __('Close and leave this room'),
-                            info_configure: __('Configure this room'),
+                            info_close: __('Close and leave this groupchat'),
+                            info_configure: __('Configure this groupchat'),
                             description: this.model.get('description') || ''
                     }));
                 },
@@ -799,20 +799,20 @@
                         case 'help':
                             this.showHelpMessages([
                                 `<strong>/admin</strong>: ${__("Change user's affiliation to admin")}`,
-                                `<strong>/ban</strong>: ${__('Ban user from room')}`,
+                                `<strong>/ban</strong>: ${__('Ban user from this groupchat')}`,
                                 `<strong>/clear</strong>: ${__('Remove messages')}`,
                                 `<strong>/deop</strong>: ${__('Change user role to participant')}`,
                                 `<strong>/help</strong>: ${__('Show this menu')}`,
-                                `<strong>/kick</strong>: ${__('Kick user from room')}`,
+                                `<strong>/kick</strong>: ${__('Kick user from this groupchat')}`,
                                 `<strong>/me</strong>: ${__('Write in 3rd person')}`,
                                 `<strong>/member</strong>: ${__('Grant membership to a user')}`,
                                 `<strong>/mute</strong>: ${__("Remove user's ability to post messages")}`,
                                 `<strong>/nick</strong>: ${__('Change your nickname')}`,
                                 `<strong>/op</strong>: ${__('Grant moderator role to user')}`,
-                                `<strong>/owner</strong>: ${__('Grant ownership of this room')}`,
+                                `<strong>/owner</strong>: ${__('Grant ownership of this groupchat')}`,
                                 `<strong>/revoke</strong>: ${__("Revoke user's membership")}`,
-                                `<strong>/subject</strong>: ${__('Set room subject')}`,
-                                `<strong>/topic</strong>: ${__('Set room subject (alias for /subject)')}`,
+                                `<strong>/subject</strong>: ${__('Set groupchat subject')}`,
+                                `<strong>/topic</strong>: ${__('Set groupchat subject (alias for /subject)')}`,
                                 `<strong>/voice</strong>: ${__('Allow muted user to post messages')}`
                             ]);
                             break;
@@ -1138,7 +1138,7 @@
                         tpl_chatroom_nickname_form({
                             heading: __('Please choose your nickname'),
                             label_nickname: __('Nickname'),
-                            label_join: __('Enter room'),
+                            label_join: __('Enter groupchat'),
                             validation_message: message
                         }));
                     this.model.save('connection_status', converse.ROOMSTATUS.NICKNAME_REQUIRED);
@@ -1161,7 +1161,7 @@
 
                     container_el.insertAdjacentHTML('beforeend',
                         tpl_chatroom_password_form({
-                            heading: __('This chatroom requires a password'),
+                            heading: __('This groupchat requires a password'),
                             label_password: __('Password: '),
                             label_submit: __('Submit')
                         }));
@@ -1301,14 +1301,14 @@
                                 'data': `data-leavejoin="${nick}"`,
                                 'isodate': moment().format(),
                                 'extra_classes': 'chat-event',
-                                'message': __('%1$s has left and re-entered the room', nick)
+                                'message': __('%1$s has left and re-entered the groupchat', nick)
                             });
                     } else {
                         let  message;
                         if (_.isNil(stat)) {
-                            message = __('%1$s has entered the room', nick);
+                            message = __('%1$s has entered the groupchat', nick);
                         } else {
-                            message = __('%1$s has entered the room. "%2$s"', nick, stat);
+                            message = __('%1$s has entered the groupchat. "%2$s"', nick, stat);
                         }
                         const data = {
                             'data': `data-join="${nick}"`,
@@ -1338,9 +1338,9 @@
 
                         let message;
                         if (_.isNil(stat)) {
-                            message = __('%1$s has entered and left the room', nick);
+                            message = __('%1$s has entered and left the groupchat', nick);
                         } else {
-                            message = __('%1$s has entered and left the room. "%2$s"', nick, stat);
+                            message = __('%1$s has entered and left the groupchat. "%2$s"', nick, stat);
                         }
                         last_el.outerHTML =
                             tpl_info({
@@ -1352,9 +1352,9 @@
                     } else {
                         let message;
                         if (_.isNil(stat)) {
-                            message = __('%1$s has left the room', nick);
+                            message = __('%1$s has left the groupchat', nick);
                         } else {
-                            message = __('%1$s has left the room. "%2$s"', nick, stat);
+                            message = __('%1$s has left the groupchat. "%2$s"', nick, stat);
                         }
                         const data = {
                             'message': message,
@@ -1397,9 +1397,9 @@
                         if (!_.isNull(error.querySelector('not-authorized'))) {
                             this.renderPasswordForm();
                         } else if (!_.isNull(error.querySelector('registration-required'))) {
-                            this.showDisconnectMessage(__('You are not on the member list of this room.'));
+                            this.showDisconnectMessage(__('You are not on the member list of this groupchat.'));
                         } else if (!_.isNull(error.querySelector('forbidden'))) {
-                            this.showDisconnectMessage(__('You have been banned from this room.'));
+                            this.showDisconnectMessage(__('You have been banned from this groupchat.'));
                         }
                     } else if (error.getAttribute('type') === 'modify') {
                         if (!_.isNull(error.querySelector('jid-malformed'))) {
@@ -1407,15 +1407,15 @@
                         }
                     } else if (error.getAttribute('type') === 'cancel') {
                         if (!_.isNull(error.querySelector('not-allowed'))) {
-                            this.showDisconnectMessage(__('You are not allowed to create new rooms.'));
+                            this.showDisconnectMessage(__('You are not allowed to create a new groupchat.'));
                         } else if (!_.isNull(error.querySelector('not-acceptable'))) {
-                            this.showDisconnectMessage(__("Your nickname doesn't conform to this room's policies."));
+                            this.showDisconnectMessage(__("Your nickname doesn't conform to this groupchat's policies."));
                         } else if (!_.isNull(error.querySelector('conflict'))) {
                             this.onNicknameClash(presence);
                         } else if (!_.isNull(error.querySelector('item-not-found'))) {
-                            this.showDisconnectMessage(__("This room does not (yet) exist."));
+                            this.showDisconnectMessage(__("This groupchat does not (yet) exist."));
                         } else if (!_.isNull(error.querySelector('service-unavailable'))) {
-                            this.showDisconnectMessage(__("This room has reached its maximum number of occupants."));
+                            this.showDisconnectMessage(__("This groupchat has reached its maximum number of occupants."));
                         }
                     }
                 },
@@ -1501,9 +1501,9 @@
 
                 render () {
                     this.el.innerHTML = tpl_room_panel({
-                        'heading_chatrooms': __('Chatrooms'),
-                        'title_new_room': __('Add a new room'),
-                        'title_list_rooms': __('Query for rooms')
+                        'heading_chatrooms': __('Groupchat'),
+                        'title_new_room': __('Add a new groupchat'),
+                        'title_list_rooms': __('Query for groupchat')
                     });
                     return this;
                 },
@@ -1544,8 +1544,8 @@
                               'hint_show': _converse.PRETTY_CHAT_STATUS[show],
                               'hint_occupant': __('Click to mention %1$s in your message.', this.model.get('nick')),
                               'desc_moderator': __('This user is a moderator.'),
-                              'desc_occupant': __('This user can send messages in this room.'),
-                              'desc_visitor': __('This user can NOT send messages in this room.')
+                              'desc_occupant': __('This user can send messages in this groupchat.'),
+                              'desc_visitor': __('This user can NOT send messages in this groupchat.')
                             }, this.model.toJSON())
                     );
                 },
@@ -1650,19 +1650,19 @@
                                 'label_temporary': __('Temporary'),
                                 'label_unmoderated': __('Unmoderated'),
                                 'label_unsecured': __('No password'),
-                                'tt_hidden': __('This room is not publicly searchable'),
+                                'tt_hidden': __('This groupchat is not publicly searchable'),
                                 'tt_mam_enabled': __('Messages are archived on the server'),
-                                'tt_membersonly': __('This room is restricted to members only'),
-                                'tt_moderated': __('This room is being moderated'),
-                                'tt_nonanonymous': __('All other room occupants can see your XMPP username'),
-                                'tt_open': __('Anyone can join this room'),
-                                'tt_passwordprotected': __('This room requires a password before entry'),
-                                'tt_persistent': __('This room persists even if it\'s unoccupied'),
-                                'tt_public': __('This room is publicly searchable'),
+                                'tt_membersonly': __('This groupchat is restricted to members only'),
+                                'tt_moderated': __('This groupchat is being moderated'),
+                                'tt_nonanonymous': __('All other groupchat occupants can see your XMPP username'),
+                                'tt_open': __('Anyone can join this groupchat'),
+                                'tt_passwordprotected': __('This groupchat requires a password before entry'),
+                                'tt_persistent': __('This groupchat persists even if it\'s unoccupied'),
+                                'tt_public': __('This groupchat is publicly searchable'),
                                 'tt_semianonymous': __('Only moderators can see your XMPP username'),
-                                'tt_temporary': __('This room will disappear once the last person leaves'),
-                                'tt_unmoderated': __('This room is not being moderated'),
-                                'tt_unsecured': __('This room does not require a password upon entry')
+                                'tt_temporary': __('This groupchat will disappear once the last person leaves'),
+                                'tt_unmoderated': __('This groupchat is not being moderated'),
+                                'tt_unsecured': __('This groupchat does not require a password upon entry')
                             }));
                     this.setOccupantsHeight();
                     return this;
@@ -1702,7 +1702,7 @@
 
                 promptForInvite (suggestion) {
                     const reason = prompt(
-                        __('You are about to invite %1$s to the chat room "%2$s". '+
+                        __('You are about to invite %1$s to the groupchat "%2$s". '+
                            'You may optionally include a message, explaining the reason for the invitation.',
                            suggestion.text.label, this.model.get('id'))
                     );

--- a/src/converse-muc.js
+++ b/src/converse-muc.js
@@ -1053,11 +1053,11 @@
                     contact = contact? contact.get('fullname'): Strophe.getNodeFromJid(from);
                     if (!reason) {
                         result = confirm(
-                            __("%1$s has invited you to join a chat room: %2$s", contact, room_jid)
+                            __("%1$s has invited you to join a groupchat: %2$s", contact, room_jid)
                         );
                     } else {
                         result = confirm(
-                            __('%1$s has invited you to join a chat room: %2$s, and left the following reason: "%3$s"',
+                            __('%1$s has invited you to join a groupchat: %2$s, and left the following reason: "%3$s"',
                                 contact, room_jid, reason)
                         );
                     }

--- a/src/converse-roomslist.js
+++ b/src/converse-roomslist.js
@@ -123,12 +123,12 @@
                             // supported by the XMPP server. So we can use it
                             // as a check for support (other ways of checking are async).
                             'allow_bookmarks': _converse.allow_bookmarks && _converse.bookmarks,
-                            'info_leave_room': __('Leave this room'),
-                            'info_remove_bookmark': __('Unbookmark this room'),
-                            'info_add_bookmark': __('Bookmark this room'),
-                            'info_title': __('Show more information on this room'),
+                            'info_leave_room': __('Leave this groupchat'),
+                            'info_remove_bookmark': __('Unbookmark this groupchat'),
+                            'info_add_bookmark': __('Bookmark this groupchat'),
+                            'info_title': __('Show more information on this groupchat'),
                             'name': this.getRoomsListElementName(),
-                            'open_title': __('Click to open this room')
+                            'open_title': __('Click to open this groupchat')
                         }));
                 }
             });
@@ -167,8 +167,8 @@
                 render () {
                     this.el.innerHTML = tpl_rooms_list({
                         'toggle_state': this.list_model.get('toggle-state'),
-                        'desc_rooms': __('Click to toggle the rooms list'),
-                        'label_rooms': __('Open Rooms'),
+                        'desc_rooms': __('Click to toggle the groupchat list'),
+                        'label_rooms': __('Open groupchat'),
                         '_converse': _converse
                     });
                     if (this.list_model.get('toggle-state') !== _converse.OPENED) {
@@ -212,7 +212,7 @@
                     ev.preventDefault();
                     const name = ev.target.getAttribute('data-room-name');
                     const jid = ev.target.getAttribute('data-room-jid');
-                    if (confirm(__("Are you sure you want to leave the room %1$s?", name))) {
+                    if (confirm(__("Are you sure you want to leave the groupchat %1$s?", name))) {
                         // TODO: replace with API call
                         _converse.chatboxviews.get(jid).close();
                     }


### PR DESCRIPTION
This was decided on the 30th of April (see the groupchat’s logs) in order to use an uniform name for this concept across clients.