### PR TITLE
fix comparator in case nick is undefined

### DIFF
--- a/src/converse-muc.js
+++ b/src/converse-muc.js
@@ -1006,8 +1006,18 @@
                     const role1 = occupant1.get('role') || 'none';
                     const role2 = occupant2.get('role') || 'none';
                     if (MUC_ROLE_WEIGHTS[role1] === MUC_ROLE_WEIGHTS[role2]) {
-                        const nick1 = occupant1.get('nick').toLowerCase();
-                        const nick2 = occupant2.get('nick').toLowerCase();
+                        var nick1 = occupant1.get('nick');
+                        if (typeof nick1 == "undefined") {
+                            nick1 = occupant1.get('jid').toLowerCase();
+                        } else {
+                            nick1 = nick1.toLowerCase();
+                        }
+                        var nick2 = occupant2.get('nick');
+                        if (typeof nick2 == "undefined") {
+                            nick2 = occupant2.get('jid').toLowerCase();
+                        } else {
+                            nick2 = nick2.toLowerCase();
+                        }
                         return nick1 < nick2 ? -1 : (nick1 > nick2? 1 : 0);
                     } else  {
                         return MUC_ROLE_WEIGHTS[role1] < MUC_ROLE_WEIGHTS[role2] ? -1 : 1;


### PR DESCRIPTION
I found that 'nick' is not always defined (e.g. if a member is currently _absent_ from a room he has no nick). To prevent an exception in that case I suggest to use the user's jid for comparing instead.