### PR TITLE
remove "?" from user-search-query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@
   [statusMessageChanged](https://conversejs.org/docs/html/events.html#contactstatusmessagechanged)
   event and make the XMLHttpRequest yourself.
 - Removed  `xhr_user_search` in favor of only accepting `xhr_user_search_url` as configuration option.
+- `xhr_user_search_url` has to include the `?` character now in favor of more
+flexibility. See example in the documentation.
 - The data returned from the `xhr_user_search_url` must now include the user's
   `jid` instead of just an `id`.
 - New configuration settings [nickname](https://conversejs.org/docs/html/configurations.html#nickname)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1587,3 +1587,18 @@ This is the URL to which an XHR GET request will be made to fetch user data from
 The query string will be included in the request with ``q`` as its key.
 
 The data returned must be a JSON encoded list of user JIDs.
+
+.. note::
+    converse.js will construct the XHR get URL by simply appending
+    ``q=<query string entered>`` to the URL given by ``xhr_user_search_url``.
+    It is therefore important that the necessary question mark (``?``) preceding the
+    URL's query component or necessary delimiters (``&``) are included. See valid
+    examples below.
+
+Examples:
+
+.. code-block:: javascript
+
+    xhr_user_search_url: 'https://some.url/some_path?',
+
+    xhr_user_search_url: 'https://some.url/some_path?api_key=somekey&',

--- a/src/converse-rosterview.js
+++ b/src/converse-rosterview.js
@@ -191,7 +191,7 @@
                         }
                     };
                     name_input.addEventListener('input', _.debounce(() => {
-                        xhr.open("GET", `${_converse.xhr_user_search_url}?q=${name_input.value}`, true);
+                        xhr.open("GET", `${_converse.xhr_user_search_url}q=${name_input.value}`, true);
                         xhr.send()
                     } , 300));
                     this.el.addEventListener('awesomplete-selectcomplete', (ev) => {


### PR DESCRIPTION
I'd like to remove the trailing "?" from the call to `xhr.open` in src/converse-rosterview.js when using `xhr_user_search_url` because of increased flexibility.

You might for example add more parameters to the API call (e.g. for supplying an API_KEY or similar). In this case, the already included "?" needs to be removed from the code.