### PR TITLE
Fix build targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ BUILDS = dist/converse.js \
 		 dist/converse-headless.min.js \
 		 dist/converse-no-dependencies.min.js \
 		 dist/converse-no-dependencies.js \
-		 dist/converse-no-dependencies-es5.js
+		 dist/converse-no-dependencies-es2015.js
 
 dist/converse.js: src webpack.config.js stamp-npm
 	./node_modules/.bin/npx  webpack --mode=development


### PR DESCRIPTION
The 'dist/converse-no-dependencies-es5.js' rule is called
'dist/converse-no-dependencies-es2015.js'.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>

---

Before submitting your request, please make sure the following conditions are met:

- [ ] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.

Do you still want a commit in `CHANGES.md`? This is just a quick fix in between a release :)