### PR TITLE
Remove position:relative in embedded CSS

### DIFF
--- a/sass/_embedded.scss
+++ b/sass/_embedded.scss
@@ -8,7 +8,6 @@
 
     bottom: auto;
     height: 100%; // When embedded, it fills the containing element
-    position: relative;
     right: auto;
     width: 100%;
 


### PR DESCRIPTION
This was rendering the content outside of the viewport, rendering Converse.js unusable.