### PR TITLE
Fix disco#info result stanza

### DIFF
--- a/src/converse-disco.js
+++ b/src/converse-disco.js
@@ -297,6 +297,7 @@
                 if (from !== null) {
                     iqresult.attrs({'to': from});
                 }
+                iqresult.c('query', attrs);
                 _.each(plugin._identities, (identity) => {
                     const attrs = {
                         'category': identity.category,


### PR DESCRIPTION
Converse forgot to add the wrapping query element, making the iq [invalid](https://pastebin.com/raw/T7h3FKHu).

Thanks to @lovetox for reporting this bug!