### PR TITLE
Keep multiple whitespace characters as is

### DIFF
--- a/sass/_messages.scss
+++ b/sass/_messages.scss
@@ -150,6 +150,7 @@
                 padding: 0;
                 color: $message-text-color;
                 width: 100%;
+                white-space: pre-wrap;
                 a {
                     word-wrap: break-word;
                     word-break: break-all;


### PR DESCRIPTION
Currently multiple consecutive spaces or tabs were being transformed into a single space, rendering some ASCII art unreadable.  This patch fixes it by giving each message text the CSS behaviour of <pre/>.