### PR TITLE
Use compliance.conversations.im for server recommendation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - New config setting [enable_muc_push](https://conversejs.org/docs/html/configuration.html#enable-muc-push)
 - #1182 MUC occupants without nick or JID created
 - #1184 Notification error when message has no body
+- Use https://compliance.conversations.im instead of (dead) https://xmpp.net
 
 ## 4.0.0 (2018-09-07)
 

--- a/src/converse-register.js
+++ b/src/converse-register.js
@@ -146,7 +146,7 @@
             _converse.api.settings.update({
                 'allow_registration': true,
                 'domain_placeholder': __(" e.g. conversejs.org"),  // Placeholder text shown in the domain input on the registration form
-                'providers_link': 'https://xmpp.net/directory.php', // Link to XMPP providers shown on registration page
+                'providers_link': 'https://compliance.conversations.im/', // Link to XMPP providers shown on registration page
                 'registration_domain': ''
             });
 


### PR DESCRIPTION
Changed xmpp.net/directory.php links to compliance.conversations.im

Haven't updated the manual, though - can do that, if required. Will need to remove the bit about security grading of servers.