### PR TITLE
Put the colons in the translatable message.

### DIFF
--- a/dist/converse.js
+++ b/dist/converse.js
@@ -103623,28 +103623,28 @@ __e(o.image) +
 __p += '\n                ';
  if (o.fullname) { ;
 __p += '\n                <p><label>' +
-__e(o.__('Full Name')) +
-':</label>&nbsp;' +
+__e(o.__('Full Name:')) +
+'</label>&nbsp;' +
 __e(o.fullname) +
 '</p>\n                ';
  } ;
 __p += '\n                <p><label>' +
-__e(o.__('XMPP Address')) +
-':</label>&nbsp;' +
+__e(o.__('XMPP Address:')) +
+'</label>&nbsp;' +
 __e(o.jid) +
 '</p>\n                ';
  if (o.nickname) { ;
 __p += '\n                <p><label>' +
-__e(o.__('Nickname')) +
-':</label>&nbsp;' +
+__e(o.__('Nickname:')) +
+'</label>&nbsp;' +
 __e(o.nickname) +
 '</p>\n                ';
  } ;
 __p += '\n                ';
  if (o.url) { ;
 __p += '\n                <p><label>' +
-__e(o.__('URL')) +
-':</label>&nbsp;<a target="_blank" rel="noopener" href="' +
+__e(o.__('URL:')) +
+'</label>&nbsp;<a target="_blank" rel="noopener" href="' +
 __e(o.url) +
 '">' +
 __e(o.url) +
@@ -103653,8 +103653,8 @@ __e(o.url) +
 __p += '\n                ';
  if (o.email) { ;
 __p += '\n                <p><label>' +
-__e(o.__('Email')) +
-':</label>&nbsp;<a href="mailto:' +
+__e(o.__('Email:')) +
+'</label>&nbsp;<a href="mailto:' +
 __e(o.email) +
 '">' +
 __e(o.email) +
@@ -103663,8 +103663,8 @@ __e(o.email) +
 __p += '\n                ';
  if (o.role) { ;
 __p += '\n                <p><label>' +
-__e(o.__('Role')) +
-':</label>&nbsp;' +
+__e(o.__('Role:')) +
+'</label>&nbsp;' +
 __e(o.role) +
 '</p>\n                ';
  } ;

--- a/src/templates/user_details_modal.html
+++ b/src/templates/user_details_modal.html
@@ -12,20 +12,20 @@
                     height="100" width="100" src="data:{{{o.image_type}}};base64,{{{o.image}}}"/>
                 {[ } ]}
                 {[ if (o.fullname) { ]}
-                <p><label>{{{o.__('Full Name')}}}:</label>&nbsp;{{{o.fullname}}}</p>
+                <p><label>{{{o.__('Full Name:')}}}</label>&nbsp;{{{o.fullname}}}</p>
                 {[ } ]}
-                <p><label>{{{o.__('XMPP Address')}}}:</label>&nbsp;{{{o.jid}}}</p>
+                <p><label>{{{o.__('XMPP Address:')}}}</label>&nbsp;{{{o.jid}}}</p>
                 {[ if (o.nickname) { ]}
-                <p><label>{{{o.__('Nickname')}}}:</label>&nbsp;{{{o.nickname}}}</p>
+                <p><label>{{{o.__('Nickname:')}}}</label>&nbsp;{{{o.nickname}}}</p>
                 {[ } ]}
                 {[ if (o.url) { ]}
-                <p><label>{{{o.__('URL')}}}:</label>&nbsp;<a target="_blank" rel="noopener" href="{{{o.url}}}">{{{o.url}}}</a></p>
+                <p><label>{{{o.__('URL:')}}}</label>&nbsp;<a target="_blank" rel="noopener" href="{{{o.url}}}">{{{o.url}}}</a></p>
                 {[ } ]}
                 {[ if (o.email) { ]}
-                <p><label>{{{o.__('Email')}}}:</label>&nbsp;<a href="mailto:{{{o.email}}}">{{{o.email}}}</a></p>
+                <p><label>{{{o.__('Email:')}}}</label>&nbsp;<a href="mailto:{{{o.email}}}">{{{o.email}}}</a></p>
                 {[ } ]}
                 {[ if (o.role) { ]}
-                <p><label>{{{o.__('Role')}}}:</label>&nbsp;{{{o.role}}}</p>
+                <p><label>{{{o.__('Role:')}}}</label>&nbsp;{{{o.role}}}</p>
                 {[ } ]}
 
                 {[ if (o._converse.pluggable.plugins['converse-omemo'].enabled(o._converse)) { ]}


### PR DESCRIPTION
This helps languages which use a different typography for the colon, such as French which has a narrow non-breakable space before it, or Japanese which uses a full-width colon character.