### PR TITLE
Upload files on drag-and-drop to the textarea

### DIFF
--- a/dist/converse.js
+++ b/dist/converse.js
@@ -59022,7 +59022,9 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_5__["default"].plugins
         'click .toggle-smiley': 'toggleEmojiMenu',
         'click .upload-file': 'toggleFileUpload',
         'input .chat-textarea': 'inputChanged',
-        'keydown .chat-textarea': 'keyPressed'
+        'keydown .chat-textarea': 'keyPressed',
+        'dragover .chat-textarea': 'onDragOver',
+        'drop .chat-textarea': 'onDrop'
       },
 
       initialize() {
@@ -59126,6 +59128,19 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_5__["default"].plugins
 
       onFileSelection(evt) {
         this.model.sendFiles(evt.target.files);
+      },
+
+      onDragOver(evt) {
+        evt.preventDefault();
+      },
+
+      onDrop(evt) {
+        /* There are no files to be dropped, this isn’t a file transfer
+         * operation.
+         */
+        if (evt.dataTransfer.files.length == 0) return;
+        evt.preventDefault();
+        this.model.sendFiles(evt.dataTransfer.files);
       },
 
       async addFileUploadButton(options) {

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -70980,8 +70980,17 @@ _converse_core__WEBPACK_IMPORTED_MODULE_2__["default"].plugins.add('converse-cha
 
       async sendFiles(files) {
         const result = await _converse.api.disco.supports(Strophe.NS.HTTPUPLOAD, _converse.domain),
-              item = result.pop(),
-              data = item.dataforms.where({
+              item = result.pop();
+
+        if (!item) {
+          this.messages.create({
+            'message': __("Sorry, looks like file upload is not supported by your server."),
+            'type': 'error'
+          });
+          return;
+        }
+
+        const data = item.dataforms.where({
           'FORM_TYPE': {
             'value': Strophe.NS.HTTPUPLOAD,
             'type': "hidden"

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -296,7 +296,9 @@ converse.plugins.add('converse-chatview', {
                 'click .toggle-smiley': 'toggleEmojiMenu',
                 'click .upload-file': 'toggleFileUpload',
                 'input .chat-textarea': 'inputChanged',
-                'keydown .chat-textarea': 'keyPressed'
+                'keydown .chat-textarea': 'keyPressed',
+                'dragover .chat-textarea': 'onDragOver',
+                'drop .chat-textarea': 'onDrop',
             },
 
             initialize () {
@@ -396,6 +398,20 @@ converse.plugins.add('converse-chatview', {
 
             onFileSelection (evt) {
                 this.model.sendFiles(evt.target.files);
+            },
+
+            onDragOver (evt) {
+                evt.preventDefault();
+            },
+
+            onDrop (evt) {
+                /* There are no files to be dropped, this isn’t a file transfer
+                 * operation.
+                 */
+                if (evt.dataTransfer.files.length == 0)
+                    return;
+                evt.preventDefault();
+                this.model.sendFiles(evt.dataTransfer.files);
             },
 
             async addFileUploadButton (options) {

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -418,8 +418,17 @@ converse.plugins.add('converse-chatboxes', {
 
             async sendFiles (files) {
                 const result = await _converse.api.disco.supports(Strophe.NS.HTTPUPLOAD, _converse.domain),
-                      item = result.pop(),
-                      data = item.dataforms.where({'FORM_TYPE': {'value': Strophe.NS.HTTPUPLOAD, 'type': "hidden"}}).pop(),
+                      item = result.pop();
+
+                if (!item) {
+                    this.messages.create({
+                        'message': __("Sorry, looks like file upload is not supported by your server."),
+                        'type': 'error'
+                    });
+                    return;
+                }
+
+                const data = item.dataforms.where({'FORM_TYPE': {'value': Strophe.NS.HTTPUPLOAD, 'type': "hidden"}}).pop(),
                       max_file_size = window.parseInt(_.get(data, 'attributes.max-file-size.value')),
                       slot_request_url = _.get(item, 'id');
 


### PR DESCRIPTION
When one or more files are dropped on the textarea, they get uploaded or an error is printed if this isn’t possible.

There is also a fix to correctly displays an error when XEP-0363 isn’t supported by the server.

Fixes #1188.