### PR TITLE
Improve XEP-0245 support

### DIFF
--- a/dist/converse.js
+++ b/dist/converse.js
@@ -61735,7 +61735,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
 
         if (text && text !== url) {
           if (is_me_message) {
-            text = text.replace(/^\/me/, '');
+            text = text.substring(4);
           }
 
           text = xss__WEBPACK_IMPORTED_MODULE_9___default.a.filterXSS(text, {
@@ -61833,8 +61833,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
           return false;
         }
 
-        const match = text.match(/^\/(.*?)(?: (.*))?$/);
-        return match && match[1] === 'me';
+        return text.startsWith('/me ');
       },
 
       processMessageText() {

--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -80,12 +80,12 @@
                 await new Promise((resolve, reject) => view.once('messageInserted', resolve));
                 expect(view.el.querySelectorAll('.chat-msg--action').length).toBe(1);
                 expect(_.includes(view.el.querySelector('.chat-msg__author').textContent, '**Max Frankfurter')).toBeTruthy();
-                expect(view.el.querySelector('.chat-msg__text').textContent).toBe(' is tired');
+                expect(view.el.querySelector('.chat-msg__text').textContent).toBe('is tired');
                 message = '/me is as well';
                 await test_utils.sendMessage(view, message);
                 expect(view.el.querySelectorAll('.chat-msg--action').length).toBe(2);
                 await test_utils.waitUntil(() => $(view.el).find('.chat-msg__author:last').text().trim() === '**Max Mustermann');
-                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe(' is as well');
+                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe('is as well');
                 expect($(view.el).find('.chat-msg:last').hasClass('chat-msg--followup')).toBe(false);
                 // Check that /me messages after a normal message don't
                 // get the 'chat-msg--followup' class.
@@ -97,7 +97,7 @@
                 await test_utils.sendMessage(view, message);
                 message_el = view.el.querySelector('.message:last-child');
                 expect(view.el.querySelectorAll('.chat-msg--action').length).toBe(3);
-                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe(' wrote a 3rd person message');
+                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe('wrote a 3rd person message');
                 expect(u.isVisible(sizzle('.chat-msg__author:last', view.el).pop())).toBeTruthy();
                 expect(u.hasClass('chat-msg--followup', message_el)).toBeFalsy();
                 done();

--- a/spec/chatroom.js
+++ b/spec/chatroom.js
@@ -1180,7 +1180,7 @@
                 view.model.onMessage(msg);
                 await new Promise((resolve, reject) => view.once('messageInserted', resolve));
                 expect(_.includes(view.el.querySelector('.chat-msg__author').textContent, '**Dyon van de Wege')).toBeTruthy();
-                expect(view.el.querySelector('.chat-msg__text').textContent).toBe(' is tired');
+                expect(view.el.querySelector('.chat-msg__text').textContent).toBe('is tired');
 
                 message = '/me is as well';
                 msg = $msg({
@@ -1192,7 +1192,7 @@
                 view.model.onMessage(msg);
                 await new Promise((resolve, reject) => view.once('messageInserted', resolve));
                 expect(_.includes(sizzle('.chat-msg__author:last', view.el).pop().textContent, '**Max Mustermann')).toBeTruthy();
-                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe(' is as well');
+                expect(sizzle('.chat-msg__text:last', view.el).pop().textContent).toBe('is as well');
                 done();
             }));
 

--- a/src/converse-message-view.js
+++ b/src/converse-message-view.js
@@ -144,7 +144,7 @@ converse.plugins.add('converse-message-view', {
                 const msg_content = msg.querySelector('.chat-msg__text');
                 if (text && text !== url) {
                     if (is_me_message) {
-                        text = text.replace(/^\/me/, '');
+                        text = text.substring(4);
                     }
                     text = xss.filterXSS(text, {'whiteList': {}});
                     msg_content.innerHTML = _.flow(
@@ -239,8 +239,7 @@ converse.plugins.add('converse-message-view', {
                 if (!text) {
                     return false;
                 }
-                const match = text.match(/^\/(.*?)(?: (.*))?$/);
-                return match && match[1] === 'me';
+                return text.startsWith('/me ');
             },
 
             processMessageText () {


### PR DESCRIPTION
Namely:
- Only match messages which start with exactly "/me ".
- Simplify the match, checking a string instead of a complex regex.
- Always remove the first four characters in the case of a match, to not
leave an extra leading space.