### PR TITLE
new value 'all' for 'show_desktop_notifications'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - #1268 Switch from SASS variables to CSS custom properties
 - #1278 Replace the default avatar with a SVG version
 - #1306 added option `notification_delay`
+- #1305 added value 'all' for 'show_desktop_notifications' to notifiy even if converse.js is open
 
 ## 4.0.4 (2018-10-29)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1247,11 +1247,14 @@ show_desktop_notifications
 
 Should HTML5 desktop notifications be shown?
 
-Notification will be shown in the following cases:
+If set to ``true``, notifications will be shown in the following cases:
 
 * the browser is not visible nor focused and a private message is received.
 * the browser is not visible nor focused and a groupchat message is received which mentions you.
 * `auto_subscribe` is set to `false` and a new contact request is received.
+
+If set to ``all``, notifications will be shown even if the above conditions are
+not fulfilled.
 
 Requires the `src/converse-notification.js` plugin.
 

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -100,7 +100,7 @@ converse.plugins.add('converse-notification', {
                     message.getAttribute('from')) === _converse.bare_jid;
             return !_converse.isOnlyChatStateNotification(message) &&
                 !is_me &&
-                _converse.isMessageToHiddenChat(message);
+                (_converse.show_desktop_notifications === 'all' || _converse.isMessageToHiddenChat(message));
         };
 
 


### PR DESCRIPTION
I propose that we add an option `notify_in_view` which defaults to `false`. Enabling it would make converse.js show notifications even if the tab of converse.js is shown to the user.