### PR TITLE
added option "notification_requires_interaction"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - #1188 Feature request: drag and drop file to HTTP Upload
 - #1268 Switch from SASS variables to CSS custom properties
 - #1278 Replace the default avatar with a SVG version
+- #1306 added option `notification_delay`
 
 ## 4.0.4 (2018-10-29)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1005,6 +1005,15 @@ notified of all messages received in a room.
 You can also pass an array of room JIDs to this option, to only apply it to
 certain rooms.
 
+notification_delay
+------------------
+
+* Default: ``5000``
+
+Desktop notifications will be shown for a time of ``notification_delay``
+ms. Setting this to ``0`` will make the notification stay until dismissed by
+the user (requires browser support).
+
 notification_icon
 -----------------
 
@@ -1012,7 +1021,6 @@ notification_icon
 
 This option specifies which icon is shown in HTML5 notifications, as provided
 by the ``src/converse-notification.js`` plugin.
-
 
 oauth_providers
 ---------------

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -33,7 +33,8 @@ converse.plugins.add('converse-notification', {
             // ^ a list of JIDs to ignore concerning chat state notifications
             play_sounds: true,
             sounds_path: 'sounds/',
-            notification_icon: 'logo/conversejs-filled.svg'
+            notification_icon: 'logo/conversejs-filled.svg',
+            notification_delay: 5000
         });
 
         _converse.isOnlyChatStateNotification = (msg) =>
@@ -180,9 +181,12 @@ converse.plugins.add('converse-notification', {
             const n = new Notification(title, {
                 'body': body,
                 'lang': _converse.locale,
-                'icon': _converse.notification_icon
+                'icon': _converse.notification_icon,
+                'requireInteraction': !_converse.notification_delay
             });
-            setTimeout(n.close.bind(n), 5000);
+            if (_converse.notification_delay) {
+                setTimeout(n.close.bind(n), _converse.notification_delay);
+            }
         };
 
         _converse.showChatStateNotification = function (contact) {


### PR DESCRIPTION
This PR introduces an option `notification_requires_interaction` which if enabled makes the notifications stay until explicitly dismissed by the user.