### PR TITLE
added values 'on' and 'off' for 'trusted' option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - #1306 added option `notification_delay`
 - #1305 added value 'all' for 'show_desktop_notifications' to notifiy even if converse.js is open
 - #1312 Error `unrecognized expression` in Safari
+- #1318 added values 'on' and 'off' for 'trusted' option which removes the "This is a trusted device" checkbox from the login form
 
 ## 4.0.4 (2018-10-29)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1399,6 +1399,11 @@ open, what features the XMPP server supports and what your online status was.
 Clearing the cache makes Converse much slower when the user logs
 in again, because all data needs to be fetch anew.
 
+If ``trusted`` is set to ``on`` or ``off`` the "This is a trusted device"
+checkbox in the login form will not appear at all and cannot be changed by the user.
+``on`` means to trust the device as stated above and use ``localStorage``. ``off``
+means to not trust the device (cache is cleared when the user logs out) and to use
+``sessionStorage``.
 
 time_format
 -----------

--- a/src/converse-controlbox.js
+++ b/src/converse-controlbox.js
@@ -403,6 +403,7 @@ converse.plugins.add('converse-controlbox', {
                         'conn_feedback_message': _converse.connfeedback.get('message'),
                         'placeholder_username': (_converse.locked_domain || _converse.default_domain) &&
                                                 __('Username') || __('user@domain'),
+                        'show_trust_checkbox': _converse.trusted !== 'on' && _converse.trusted !== 'off'
                     })
                 );
             },
@@ -442,10 +443,18 @@ converse.plugins.add('converse-controlbox', {
                 if (!this.validate()) { return; }
 
                 const form_data = new FormData(ev.target);
-                _converse.config.save({
-                    'trusted': form_data.get('trusted') && true || false,
-                    'storage': form_data.get('trusted') ? 'local' : 'session'
-                });
+
+                if (_converse.trusted === 'on' || _converse.trusted === 'off') {
+                    _converse.config.save({
+                        'trusted': _converse.trusted === 'on',
+                        'storage': _converse.trusted === 'on' ? 'local' : 'session'
+                    });
+                } else {
+                    _converse.config.save({
+                        'trusted': form_data.get('trusted') && true || false,
+                        'storage': form_data.get('trusted') ? 'local' : 'session'
+                    });
+                }
 
                 let jid = form_data.get('jid');
                 if (_converse.locked_domain) {

--- a/src/templates/login_panel.html
+++ b/src/templates/login_panel.html
@@ -18,13 +18,15 @@
                     <input id="converse-login-password" class="form-control" required="required" type="password" name="password" placeholder="{{{o.__('password')}}}">
                 </div>
                 {[ } ]}
-                <div class="form-group form-check login-trusted">
-                    <input id="converse-login-trusted" type="checkbox" class="form-check-input" name="trusted" {[ if (o._converse.config.get('trusted')) { ]} checked="checked" {[ } ]}>
-                    <label for="converse-login-trusted" class="form-check-label login-trusted__desc">{{{o.__('This is a trusted device')}}}</label>
-                    <i class="fa fa-info-circle" data-toggle="popover"
-                       data-title="Trusted device?"
-                       data-content="{{{o.__('To improve performance, we cache your data in this browser. Uncheck this box if this is a public computer or if you want your data to be deleted when you log out. It\'s important that you explicitly log out, otherwise not all cached data might be deleted. Please note, when using an untrusted device, OMEMO encryption is NOT available.')}}}"></i>
-                </div>
+                {[ if (o.show_trust_checkbox) { ]}
+                    <div class="form-group form-check login-trusted">
+                        <input id="converse-login-trusted" type="checkbox" class="form-check-input" name="trusted" {[ if (o._converse.config.get('trusted')) { ]} checked="checked" {[ } ]}>
+                        <label for="converse-login-trusted" class="form-check-label login-trusted__desc">{{{o.__('This is a trusted device')}}}</label>
+                        <i class="fa fa-info-circle" data-toggle="popover"
+                           data-title="Trusted device?"
+                           data-content="{{{o.__('To improve performance, we cache your data in this browser. Uncheck this box if this is a public computer or if you want your data to be deleted when you log out. It\'s important that you explicitly log out, otherwise not all cached data might be deleted. Please note, when using an untrusted device, OMEMO encryption is NOT available.')}}}"></i>
+                    </div>
+                {[ } ]}
 
                 <fieldset class="buttons">
                     <input class="btn btn-primary" type="submit" value="{{{o.__('Log in')}}}">


### PR DESCRIPTION
This PR introduces values `on` and `off` for the `trusted` option. This can be used to hide the "This is a trusted device" checkbox from the user.