### PR TITLE
Send presences according to XEP-0319: Last User Interaction in Presence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - #1306 added option `notification_delay`
 - #1305 added value 'all' for 'show_desktop_notifications' to notifiy even if converse.js is open
 - #1312 Error `unrecognized expression` in Safari
+- #1319 Implement sending of presences according to XEP-0319: Last User Interaction in Presence
 
 ## 4.0.4 (2018-10-29)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -757,6 +757,16 @@ then Converse will fall back to trying to determine the browser's language
 and fetching those translations, or if that fails the default English texts
 will be used.
 
+idle_presence_timeout
+---------------------
+
+* Default:  ``300``
+
+The amount of seconds after which the user is considered to be idle
+and an idle presence according to XEP-0319 is sent.
+
+If the given value is negative or ``0``, this feature is disabled.
+
 jid
 ---
 

--- a/spec/presence.js
+++ b/spec/presence.js
@@ -47,7 +47,7 @@
                 `<presence xmlns="jabber:client">`+
                     `<status>Hello world</status>`+
                     `<priority>0</priority>`+
-                    `<c hash="sha-1" node="https://conversejs.org" ver="K7kn/M6VtmdMyo61pgn/jkZlax8=" xmlns="http://jabber.org/protocol/caps"/>`+
+                    `<c hash="sha-1" node="https://conversejs.org" ver="Hxbsr5fazs62i+O0GxIXf2OEDNs=" xmlns="http://jabber.org/protocol/caps"/>`+
                 `</presence>`
             );
             _converse.priority = 2;
@@ -57,7 +57,7 @@
                     `<show>away</show>`+
                     `<status>Going jogging</status>`+
                     `<priority>2</priority>`+
-                    `<c hash="sha-1" node="https://conversejs.org" ver="K7kn/M6VtmdMyo61pgn/jkZlax8=" xmlns="http://jabber.org/protocol/caps"/>`+
+                    `<c hash="sha-1" node="https://conversejs.org" ver="Hxbsr5fazs62i+O0GxIXf2OEDNs=" xmlns="http://jabber.org/protocol/caps"/>`+
                 `</presence>`
             );
 
@@ -68,7 +68,7 @@
                     `<show>dnd</show>`+
                     `<status>Doing taxes</status>`+
                     `<priority>0</priority>`+
-                    `<c hash="sha-1" node="https://conversejs.org" ver="K7kn/M6VtmdMyo61pgn/jkZlax8=" xmlns="http://jabber.org/protocol/caps"/>`+
+                    `<c hash="sha-1" node="https://conversejs.org" ver="Hxbsr5fazs62i+O0GxIXf2OEDNs=" xmlns="http://jabber.org/protocol/caps"/>`+
                 `</presence>`
             );
         }));
@@ -97,7 +97,7 @@
                     .toBe(`<presence xmlns="jabber:client">`+
                           `<status>My custom status</status>`+
                           `<priority>0</priority>`+
-                          `<c hash="sha-1" node="https://conversejs.org" ver="K7kn/M6VtmdMyo61pgn/jkZlax8=" xmlns="http://jabber.org/protocol/caps"/>`+
+                          `<c hash="sha-1" node="https://conversejs.org" ver="Hxbsr5fazs62i+O0GxIXf2OEDNs=" xmlns="http://jabber.org/protocol/caps"/>`+
                           `</presence>`)
 
                 return test_utils.waitUntil(() => modal.el.getAttribute('aria-hidden') === "true");
@@ -109,7 +109,7 @@
                 modal.el.querySelector('[type="submit"]').click();
                 expect(_converse.connection.send.calls.mostRecent().args[0].toLocaleString())
                     .toBe(`<presence xmlns="jabber:client"><show>dnd</show><status>My custom status</status><priority>0</priority>`+
-                          `<c hash="sha-1" node="https://conversejs.org" ver="K7kn/M6VtmdMyo61pgn/jkZlax8=" xmlns="http://jabber.org/protocol/caps"/>`+
+                          `<c hash="sha-1" node="https://conversejs.org" ver="Hxbsr5fazs62i+O0GxIXf2OEDNs=" xmlns="http://jabber.org/protocol/caps"/>`+
                           `</presence>`)
                 done();
             });


### PR DESCRIPTION
This implements sending of idle presences according to XEP-0319: Last User Interaction in Presence. Using this, other clients can show at what time the user has been last active:

<img src="https://user-images.githubusercontent.com/15179432/48368773-ea0ca880-e6b4-11e8-9dea-2b7fe8ed6632.png" alt="screenshot_20181112-194846 " width="200" />
