### PR TITLE
Fix missing checkmarks in old muc messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.6 (unreleased)
+
+- #1331 Fix missing checkmarks in old muc messages
+
 ## 4.0.5 (2018-11-15)
 
 - Error `FATAL: TypeError: Cannot read property 'extend' of undefined` when using `embedded` view mode.

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -66943,6 +66943,13 @@ _converse_core__WEBPACK_IMPORTED_MODULE_6__["default"].plugins.add('converse-muc
           }
 
           const msg = await this.createMessage(stanza, original_stanza);
+
+          if (!_.isNull(forwarded) && msg && msg.get('sender') === 'me') {
+            msg.save({
+              'received': moment().format()
+            });
+          }
+
           this.incrementUnreadMsgCounter(msg);
         }
 

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -974,6 +974,9 @@ converse.plugins.add('converse-muc', {
                         u.safeSave(this, {'subject': {'author': sender, 'text': subject}});
                     }
                     const msg = await this.createMessage(stanza, original_stanza);
+                    if (!_.isNull(forwarded) && msg && msg.get('sender')  === 'me') {
+                        msg.save({'received': moment().format()});
+                    }
                     this.incrementUnreadMsgCounter(msg);
                 }
                 if (sender !== this.get('nick')) {


### PR DESCRIPTION
I see missing checkmarks in older muc messages. This tries to fix it.