### PR TITLE
Remove `sudo: false` in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ before_install:
 install: make stamp-npm
 before_script: make serve_bg
 script: make check
-sudo: false


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

`sudo: false` is getting deprecated and support for it will soon be
removed entirely. They seem to be moving to using VMs entirely for their
service.

Converse doesn't seem to be using Travis' features extensively so I
don't think anything would break if we left the sudo clause as is, but it
will become useless in less than a month, (quite a tight timeline).

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>
