### PR TITLE
prevent message delivery receipts for carbons and own

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Bugfix: MUC commands were being ignored
 - UI: Always show the OMEMO lock icon (grayed out if not available).
 - #1374 Can't load embedded chat when changing `view_mode` between page reloads
+- Bugfix: Message Delivery Receipts were being sent for carbons and own messages
 
 ## 4.0.6 (2018-12-07)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -62209,14 +62209,15 @@ _converse_core__WEBPACK_IMPORTED_MODULE_2__["default"].plugins.add('converse-cha
           return true;
         }
 
-        let from_jid = stanza.getAttribute('from');
+        let from_jid = stanza.getAttribute('from'),
+            is_carbon = false;
         const forwarded = stanza.querySelector('forwarded'),
               original_stanza = stanza;
 
         if (!_.isNull(forwarded)) {
           const forwarded_message = forwarded.querySelector('message'),
-                forwarded_from = forwarded_message.getAttribute('from'),
-                is_carbon = !_.isNull(stanza.querySelector(`received[xmlns="${Strophe.NS.CARBONS}"]`));
+                forwarded_from = forwarded_message.getAttribute('from');
+          is_carbon = !_.isNull(stanza.querySelector(`received[xmlns="${Strophe.NS.CARBONS}"]`));
 
           if (is_carbon && Strophe.getBareJidFromJid(forwarded_from) !== from_jid) {
             // Prevent message forging via carbons
@@ -62229,15 +62230,15 @@ _converse_core__WEBPACK_IMPORTED_MODULE_2__["default"].plugins.add('converse-cha
           to_jid = stanza.getAttribute('to');
         }
 
-        const requests_receipt = !_.isUndefined(sizzle(`request[xmlns="${Strophe.NS.RECEIPTS}"]`, stanza).pop());
-
-        if (requests_receipt) {
-          this.sendReceiptStanza(from_jid, stanza.getAttribute('id'));
-        }
-
         const from_bare_jid = Strophe.getBareJidFromJid(from_jid),
               from_resource = Strophe.getResourceFromJid(from_jid),
               is_me = from_bare_jid === _converse.bare_jid;
+        const requests_receipt = !_.isUndefined(sizzle(`request[xmlns="${Strophe.NS.RECEIPTS}"]`, stanza).pop());
+
+        if (requests_receipt && !is_carbon && !is_me) {
+          this.sendReceiptStanza(from_jid, stanza.getAttribute('id'));
+        }
+
         let contact_jid;
 
         if (is_me) {

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -746,14 +746,15 @@ converse.plugins.add('converse-chatboxes', {
                     return true;
                 }
 
-                let from_jid = stanza.getAttribute('from');
+                let from_jid = stanza.getAttribute('from'),
+                    is_carbon = false;
                 const forwarded = stanza.querySelector('forwarded'),
                       original_stanza = stanza;
 
                 if (!_.isNull(forwarded)) {
                     const forwarded_message = forwarded.querySelector('message'),
-                          forwarded_from = forwarded_message.getAttribute('from'),
-                          is_carbon = !_.isNull(stanza.querySelector(`received[xmlns="${Strophe.NS.CARBONS}"]`));
+                          forwarded_from = forwarded_message.getAttribute('from');
+                    is_carbon = !_.isNull(stanza.querySelector(`received[xmlns="${Strophe.NS.CARBONS}"]`));
 
                     if (is_carbon && Strophe.getBareJidFromJid(forwarded_from) !== from_jid) {
                         // Prevent message forging via carbons
@@ -765,14 +766,14 @@ converse.plugins.add('converse-chatboxes', {
                     to_jid = stanza.getAttribute('to');
                 }
 
-                const requests_receipt = !_.isUndefined(sizzle(`request[xmlns="${Strophe.NS.RECEIPTS}"]`, stanza).pop());
-                if (requests_receipt) {
-                    this.sendReceiptStanza(from_jid, stanza.getAttribute('id'));
-                }
-
                 const from_bare_jid = Strophe.getBareJidFromJid(from_jid),
                       from_resource = Strophe.getResourceFromJid(from_jid),
                       is_me = from_bare_jid === _converse.bare_jid;
+
+                const requests_receipt = !_.isUndefined(sizzle(`request[xmlns="${Strophe.NS.RECEIPTS}"]`, stanza).pop());
+                if (requests_receipt && !is_carbon && !is_me) {
+                    this.sendReceiptStanza(from_jid, stanza.getAttribute('id'));
+                }
 
                 let contact_jid;
                 if (is_me) {


### PR DESCRIPTION
dwd discovered that receipts were being sent for carbons. This PR prevents it.