### PR TITLE
set store hint on receipts and type='chat'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - #1376 Fixed some alignment issues in the sidebar
 - #1378 Message Delivery Receipts were being sent for carbons and own messages
 - #1379 MUC unread messages indicator is failing
+- #1382 Message Delivery Receipts: Set store hint and type='chat'
 
 ## 4.0.6 (2018-12-07)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -62193,10 +62193,13 @@ _converse_core__WEBPACK_IMPORTED_MODULE_2__["default"].plugins.add('converse-cha
         const receipt_stanza = $msg({
           'from': _converse.connection.jid,
           'id': _converse.connection.getUniqueId(),
-          'to': to_jid
+          'to': to_jid,
+          'type': 'chat'
         }).c('received', {
           'xmlns': Strophe.NS.RECEIPTS,
           'id': id
+        }).up().c('store', {
+          'xmlns': Strophe.NS.HINTS
         }).up();
 
         _converse.api.send(receipt_stanza);

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -729,7 +729,9 @@ converse.plugins.add('converse-chatboxes', {
                     'from': _converse.connection.jid,
                     'id': _converse.connection.getUniqueId(),
                     'to': to_jid,
-                }).c('received', {'xmlns': Strophe.NS.RECEIPTS, 'id': id}).up();
+                    'type': 'chat',
+                }).c('received', {'xmlns': Strophe.NS.RECEIPTS, 'id': id}).up()
+                .c('store', {'xmlns': Strophe.NS.HINTS}).up();
                 _converse.api.send(receipt_stanza);
             },
 


### PR DESCRIPTION
I believe it's necesary to store receipts. Otherwise they might not reach the original sender (e.g. in case sender and receiver are not online at the same time). If they are stored in the archive, they will be retrieved later.