### PR TITLE
Force avatar refetch if new hash received

### DIFF
--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -1138,7 +1138,7 @@ converse.plugins.add('converse-muc', {
 
                 _.forEach(_.filter(vcards, undefined), (vcard) => {
                     if (hash && vcard.get('image_hash') !== hash) {
-                        _converse.api.vcard.update(vcard);
+                        _converse.api.vcard.update(vcard, true);
                     }
                 });
             },


### PR DESCRIPTION
A very simple change that fixes #1334.
Tested it for some time now, didn't notice any issue.