### PR TITLE
new config option "roomconfig_whitelist"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1 (unreleased)
+
+- #1408 new config option `roomconfig_whitelist`
+
 ## 4.1.0 (2019-01-11)
 
 - Bugfix: MUC commands were being ignored

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -53521,6 +53521,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
     _converse.api.settings.update({
       'auto_list_rooms': false,
       'muc_disable_moderator_commands': false,
+      'roomconfig_whitelist': [],
       'visible_toolbar_buttons': {
         'toggle_occupants': true
       }
@@ -54608,7 +54609,11 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
           fieldset_el.insertAdjacentHTML('beforeend', `<p class="form-help">${instructions}</p>`);
         }
 
-        _.each(fields, field => fieldset_el.insertAdjacentHTML('beforeend', u.xForm2webForm(field, stanza))); // Render save/cancel buttons
+        _.each(fields, field => {
+          if (_converse.roomconfig_whitelist.length === 0 || _.includes(_converse.roomconfig_whitelist, field.getAttribute('var'))) {
+            fieldset_el.insertAdjacentHTML('beforeend', u.xForm2webForm(field, stanza));
+          }
+        }); // Render save/cancel buttons
 
 
         const last_fieldset_el = document.createElement('fieldset');

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1169,6 +1169,23 @@ For example:
             }]
         });
 
+
+.. _`roomconfig_whitelist`:
+
+roomconfig_whitelist
+--------------------
+
+* Default: ``[]``
+
+A list of room config-option names. If this list is non-empty, only the corresponding room
+config-options will be shown in the room configuration form. The default will show all options.
+
+In the following example the user can only see (and thus change) the roomname and nothing else:
+
+.. code-block:: javascript
+
+    roomconfig_whitelist: ['muc#roomconfig_roomname'],
+
 root
 ----
 

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -100,6 +100,7 @@ converse.plugins.add('converse-muc-views', {
         _converse.api.settings.update({
             'auto_list_rooms': false,
             'muc_disable_moderator_commands': false,
+            'roomconfig_whitelist': [],
             'visible_toolbar_buttons': {
                 'toggle_occupants': true
             }
@@ -1115,7 +1116,12 @@ converse.plugins.add('converse-muc-views', {
                 if (instructions && instructions !== title) {
                     fieldset_el.insertAdjacentHTML('beforeend', `<p class="form-help">${instructions}</p>`);
                 }
-                _.each(fields, field => fieldset_el.insertAdjacentHTML('beforeend', u.xForm2webForm(field, stanza)));
+                _.each(fields, field => {
+                    if (_converse.roomconfig_whitelist.length === 0 ||
+                            _.includes(_converse.roomconfig_whitelist, field.getAttribute('var'))) {
+                        fieldset_el.insertAdjacentHTML('beforeend', u.xForm2webForm(field, stanza));
+                    }
+                });
 
                 // Render save/cancel buttons
                 const last_fieldset_el = document.createElement('fieldset');


### PR DESCRIPTION
I'd like to be able to limit the amount of room config options that are presented to the user. Therefore I created a new config option `roomconfig_whitelist`.