### PR TITLE
muc moderator commands can be disabled selectively

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - #1417 Margin between nickname and badge
 - #1421 fix direct invite for membersonly room
 - #1422 Resurrect the `muc_show_join_leave` option
+- #1412 muc moderator commands can be disabled selectively by config
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -54113,13 +54113,18 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
       },
 
       parseMessageForCommands(text) {
-        if (_converse.muc_disable_moderator_commands) {
+        if (_converse.muc_disable_moderator_commands && !_.isArray(_converse.muc_disable_moderator_commands)) {
           return _converse.ChatBoxView.prototype.parseMessageForCommands.apply(this, arguments);
         }
 
         const match = text.replace(/^\s*/, "").match(/^\/(.*?)(?: (.*))?$/) || [false, '', ''],
               args = match[2] && match[2].splitOnce(' ').filter(s => s) || [],
-              command = match[1].toLowerCase();
+              command = match[1].toLowerCase(),
+              disabled_commands = _.isArray(_converse.muc_disable_moderator_commands) ? _converse.muc_disable_moderator_commands : [];
+
+        if (_.includes(disabled_commands, command)) {
+          return false;
+        }
 
         switch (command) {
           case 'admin':
@@ -54161,7 +54166,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
             break;
 
           case 'help':
-            this.showHelpMessages([`<strong>/admin</strong>: ${__("Change user's affiliation to admin")}`, `<strong>/ban</strong>: ${__('Ban user from groupchat')}`, `<strong>/clear</strong>: ${__('Remove messages')}`, `<strong>/deop</strong>: ${__('Change user role to participant')}`, `<strong>/destroy</strong>: ${__('Destroy room')}`, `<strong>/help</strong>: ${__('Show this menu')}`, `<strong>/kick</strong>: ${__('Kick user from groupchat')}`, `<strong>/me</strong>: ${__('Write in 3rd person')}`, `<strong>/member</strong>: ${__('Grant membership to a user')}`, `<strong>/mute</strong>: ${__("Remove user's ability to post messages")}`, `<strong>/nick</strong>: ${__('Change your nickname')}`, `<strong>/op</strong>: ${__('Grant moderator role to user')}`, `<strong>/owner</strong>: ${__('Grant ownership of this groupchat')}`, `<strong>/register</strong>: ${__("Register a nickname for this groupchat")}`, `<strong>/revoke</strong>: ${__("Revoke user's membership")}`, `<strong>/subject</strong>: ${__('Set groupchat subject')}`, `<strong>/topic</strong>: ${__('Set groupchat subject (alias for /subject)')}`, `<strong>/voice</strong>: ${__('Allow muted user to post messages')}`]);
+            this.showHelpMessages(_.filter([`<strong>/admin</strong>: ${__("Change user's affiliation to admin")}`, `<strong>/ban</strong>: ${__('Ban user from groupchat')}`, `<strong>/clear</strong>: ${__('Remove messages')}`, `<strong>/deop</strong>: ${__('Change user role to participant')}`, `<strong>/destroy</strong>: ${__('Destroy room')}`, `<strong>/help</strong>: ${__('Show this menu')}`, `<strong>/kick</strong>: ${__('Kick user from groupchat')}`, `<strong>/me</strong>: ${__('Write in 3rd person')}`, `<strong>/member</strong>: ${__('Grant membership to a user')}`, `<strong>/mute</strong>: ${__("Remove user's ability to post messages")}`, `<strong>/nick</strong>: ${__('Change your nickname')}`, `<strong>/op</strong>: ${__('Grant moderator role to user')}`, `<strong>/owner</strong>: ${__('Grant ownership of this groupchat')}`, `<strong>/register</strong>: ${__("Register a nickname for this groupchat")}`, `<strong>/revoke</strong>: ${__("Revoke user's membership")}`, `<strong>/subject</strong>: ${__('Set groupchat subject')}`, `<strong>/topic</strong>: ${__('Set groupchat subject (alias for /subject)')}`, `<strong>/voice</strong>: ${__('Allow muted user to post messages')}`], line => _.every(disabled_commands, element => !line.startsWith(element + '<', 9))));
             break;
 
           case 'kick':

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -918,6 +918,16 @@ muc_disable_moderator_commands
 * Default: ``false``
 
 Allows you to disable the moderator commands such as ``/kick`` or ``/ban``.
+Ìf set to ``true`` all commands will be disabled.
+
+You can also selectively disable some moderator commands by setting it to an
+array of commands you don't want.
+
+The following example will disable 'mute' and 'voice' command:
+
+.. code-block:: javascript
+
+    muc_disable_moderator_commands: ['mute', 'voice'],
 
 muc_domain
 ----------

--- a/spec/muc.js
+++ b/spec/muc.js
@@ -2581,6 +2581,42 @@
                 done();
             }));
 
+            it("takes /help to show the available commands and commands can be disabled by config",
+                mock.initConverseWithPromises(
+                    null, ['rosterGroupsFetched'], {muc_disable_moderator_commands: ['mute', 'voice']},
+                    async function (done, _converse) {
+
+                await test_utils.openAndEnterChatRoom(_converse, 'lounge', 'localhost', 'dummy');
+                const view = _converse.chatboxviews.get('lounge@localhost');
+                var textarea = view.el.querySelector('.chat-textarea');
+                textarea.value = '/help This is the groupchat subject';
+                view.keyPressed({
+                    target: textarea,
+                    preventDefault: _.noop,
+                    keyCode: 13
+                });
+
+                const info_messages = Array.prototype.slice.call(view.el.querySelectorAll('.chat-info'), 0);
+                expect(info_messages.length).toBe(17);
+                expect(info_messages.pop().textContent).toBe('/topic: Set groupchat subject (alias for /subject)');
+                expect(info_messages.pop().textContent).toBe('/subject: Set groupchat subject');
+                expect(info_messages.pop().textContent).toBe('/revoke: Revoke user\'s membership');
+                expect(info_messages.pop().textContent).toBe('/register: Register a nickname for this groupchat');
+                expect(info_messages.pop().textContent).toBe('/owner: Grant ownership of this groupchat');
+                expect(info_messages.pop().textContent).toBe('/op: Grant moderator role to user');
+                expect(info_messages.pop().textContent).toBe('/nick: Change your nickname');
+                expect(info_messages.pop().textContent).toBe('/member: Grant membership to a user');
+                expect(info_messages.pop().textContent).toBe('/me: Write in 3rd person');
+                expect(info_messages.pop().textContent).toBe('/kick: Kick user from groupchat');
+                expect(info_messages.pop().textContent).toBe('/help: Show this menu');
+                expect(info_messages.pop().textContent).toBe('/destroy: Destroy room');
+                expect(info_messages.pop().textContent).toBe('/deop: Change user role to participant');
+                expect(info_messages.pop().textContent).toBe('/clear: Remove messages');
+                expect(info_messages.pop().textContent).toBe('/ban: Ban user from groupchat');
+                expect(info_messages.pop().textContent).toBe('/admin: Change user\'s affiliation to admin');
+                done();
+            }));
+
             it("takes /member to make an occupant a member",
                 mock.initConverseWithPromises(
                     null, ['rosterGroupsFetched'], {},


### PR DESCRIPTION
I'd like to be able to selectively disable some muc moderator commands.