### PR TITLE
fix moderator commands that change affiliation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - #1421 fix direct invite for membersonly room
 - #1422 Resurrect the `muc_show_join_leave` option
 - #1412 muc moderator commands can be disabled selectively by config
+- #1413 fix moderator commands that change affiliation
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -53223,6 +53223,7 @@ const _converse$env = _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_
       $msg = _converse$env.$msg,
       $pres = _converse$env.$pres;
 const u = _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].env.utils;
+const AFFILIATION_CHANGE_COMANDS = ['admin', 'ban', 'owner', 'member', 'revoke'];
 _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins.add('converse-muc-views', {
   /* Dependencies are other plugins which might be
    * overridden or relied upon, and therefore need to be loaded before
@@ -54093,7 +54094,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
           return false;
         }
 
-        if (!this.model.occupants.findWhere({
+        if (!(_.includes(AFFILIATION_CHANGE_COMANDS, command) && u.isValidJID(args[0])) && !this.model.occupants.findWhere({
           'nick': args[0]
         }) && !this.model.occupants.findWhere({
           'jid': args[0]
@@ -54196,11 +54197,11 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
                 'jid': args[0]
               }),
                     attrs = {
-                'jid': occupant.get('jid'),
+                'jid': occupant ? occupant.get('jid') : args[0],
                 'reason': args[1]
               };
 
-              if (_converse.auto_register_muc_nickname) {
+              if (_converse.auto_register_muc_nickname && occupant) {
                 attrs['nick'] = occupant.get('nick');
               }
 

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -35,7 +35,7 @@ import xss from "xss";
 
 const { Backbone, Promise, Strophe, b64_sha1, moment, f, sizzle, _, $build, $iq, $msg, $pres } = converse.env;
 const u = converse.env.utils;
-
+const AFFILIATION_CHANGE_COMANDS = ['admin', 'ban', 'owner', 'member', 'revoke'];
 
 converse.plugins.add('converse-muc-views', {
     /* Dependencies are other plugins which might be
@@ -841,7 +841,9 @@ converse.plugins.add('converse-muc-views', {
                     );
                     return false;
                 }
-                if (!this.model.occupants.findWhere({'nick': args[0]}) && !this.model.occupants.findWhere({'jid': args[0]})) {
+                if (!(_.includes(AFFILIATION_CHANGE_COMANDS, command) && u.isValidJID(args[0])) &&
+                        !this.model.occupants.findWhere({'nick': args[0]}) &&
+                            !this.model.occupants.findWhere({'jid': args[0]})) {
                     this.showErrorMessage(__('Error: couldn\'t find a groupchat participant "%1$s"', args[0]));
                     return false;
                 }
@@ -953,10 +955,10 @@ converse.plugins.add('converse-muc-views', {
                         const occupant = this.model.occupants.findWhere({'nick': args[0]}) ||
                                          this.model.occupants.findWhere({'jid': args[0]}),
                               attrs = {
-                                'jid': occupant.get('jid'),
+                                'jid': occupant ? occupant.get('jid') : args[0],
                                 'reason': args[1]
                               };
-                        if (_converse.auto_register_muc_nickname) {
+                        if (_converse.auto_register_muc_nickname && occupant) {
                             attrs['nick'] = occupant.get('nick');
                         }
                         this.model.setAffiliation('member', [attrs])


### PR DESCRIPTION
I believe it should be possible to change affiliation of non-occupants. Currently converse rejects this. This tries to fix it.