### PR TITLE
fix direct invite for membersonly room

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 4.1.1 (unreleased)
 
 - #1408 new config option `roomconfig_whitelist`
+- #1421 fix direct invite for membersonly room
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -66542,7 +66542,7 @@ _converse_core__WEBPACK_IMPORTED_MODULE_6__["default"].plugins.add('converse-muc
          *    (String) recipient - JID of the person being invited
          *    (String) reason - Optional reason for the invitation
          */
-        if (this.get('membersonly')) {
+        if (this.features.get('membersonly')) {
           // When inviting to a members-only groupchat, we first add
           // the person to the member list by giving them an
           // affiliation of 'member' (if they're not affiliated

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -464,7 +464,7 @@ converse.plugins.add('converse-muc', {
                  *    (String) recipient - JID of the person being invited
                  *    (String) reason - Optional reason for the invitation
                  */
-                if (this.get('membersonly')) {
+                if (this.features.get('membersonly')) {
                     // When inviting to a members-only groupchat, we first add
                     // the person to the member list by giving them an
                     // affiliation of 'member' (if they're not affiliated


### PR DESCRIPTION
Direct invite for a members only room must make sure that the invited user is added to the member list. This is currently not working.

This PR fixes it.