### PR TITLE
Resurrect muc_show_join_leave option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - #1408 new config option `roomconfig_whitelist`
 - #1421 fix direct invite for membersonly room
+- #1422 Resurrect the `muc_show_join_leave` option
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -55035,7 +55035,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
       },
 
       showJoinNotification(occupant) {
-        if (this.model.get('connection_status') !== _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].ROOMSTATUS.ENTERED) {
+        if (!_converse.muc_show_join_leave || this.model.get('connection_status') !== _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].ROOMSTATUS.ENTERED) {
           return;
         }
 
@@ -55095,7 +55095,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_3__["default"].plugins
       },
 
       showLeaveNotification(occupant) {
-        if (_.includes(occupant.get('states'), '303') || _.includes(occupant.get('states'), '307')) {
+        if (!_converse.muc_show_join_leave || _.includes(occupant.get('states'), '303') || _.includes(occupant.get('states'), '307')) {
           return;
         }
 

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -1523,7 +1523,8 @@ converse.plugins.add('converse-muc-views', {
             },
 
             showJoinNotification (occupant) {
-                if (this.model.get('connection_status') !==  converse.ROOMSTATUS.ENTERED) {
+                if (!_converse.muc_show_join_leave ||
+                        this.model.get('connection_status') !==  converse.ROOMSTATUS.ENTERED) {
                     return;
                 }
                 const nick = occupant.get('nick'),
@@ -1576,7 +1577,9 @@ converse.plugins.add('converse-muc-views', {
             },
 
             showLeaveNotification (occupant) {
-                if (_.includes(occupant.get('states'), '303') || _.includes(occupant.get('states'), '307')) {
+                if (!_converse.muc_show_join_leave ||
+                        _.includes(occupant.get('states'), '303') ||
+                        _.includes(occupant.get('states'), '307')) {
                     return;
                 }
                 const nick = occupant.get('nick'),


### PR DESCRIPTION
Re-add the `muc_show_join_leave` option.  It got lost in commit 9528d81c00bc4a876fecbd5cb72cac0f35f24b75.