### PR TITLE
remove last comma in credentials_url example

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -551,7 +551,7 @@ The server behind ``credentials_url`` should return a JSON encoded object::
 
     {
         "jid": "me@example.com/resource",
-        "password": "Ilikecats!",
+        "password": "Ilikecats!"
     }
 
 


### PR DESCRIPTION
Last comma  forbidden in JSON, example doesn't work as is.

