### PR TITLE
Prevent duplicate messages on MUC join

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - #1422 Resurrect the `muc_show_join_leave` option
 - #1412 muc moderator commands can be disabled selectively by config
 - #1413 fix moderator commands that change affiliation
+- #1414 Prevent duplicate messages on MUC join
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -66163,7 +66163,7 @@ _converse_core__WEBPACK_IMPORTED_MODULE_6__["default"].plugins.add('converse-muc
         }).c("x", {
           'xmlns': Strophe.NS.MUC
         }).c("history", {
-          'maxstanzas': this.get('mam_enabled') ? 0 : _converse.muc_history_max_stanzas
+          'maxstanzas': this.features.get('mam_enabled') ? 0 : _converse.muc_history_max_stanzas
         }).up();
 
         if (password) {

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -293,7 +293,7 @@ converse.plugins.add('converse-muc', {
                     'from': _converse.connection.jid,
                     'to': this.getRoomJIDAndNick(nick)
                 }).c("x", {'xmlns': Strophe.NS.MUC})
-                  .c("history", {'maxstanzas': this.get('mam_enabled') ? 0 : _converse.muc_history_max_stanzas}).up();
+                  .c("history", {'maxstanzas': this.features.get('mam_enabled') ? 0 : _converse.muc_history_max_stanzas}).up();
                 if (password) {
                     stanza.cnode(Strophe.xmlElement("password", [], password));
                 }


### PR DESCRIPTION
Fixes #1414

This was broken in https://github.com/conversejs/converse.js/commit/a4d608dcdfe9c0d33ad65279369b0e6bd4a97def

Thanks for the hint @iNPUTmice