### PR TITLE
Update contact nickname when receive a roster push

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Updated translations: af, cz, de, es, eu, ga, he, hi, ja, nb, nl_BE, zh_CN
 - New language supported: Esperanto
 - Accessibility: Tag the chat-content as an ARIA live region, for screen readers
+- Update contact nickname when receive a roster push
 - #1369 Don't wrongly interpret message with `subject` as a topic change.
 - #1408 new config option `roomconfig_whitelist`
 - #1417 Margin between nickname and badge

--- a/src/headless/converse-roster.js
+++ b/src/headless/converse-roster.js
@@ -628,6 +628,7 @@ converse.plugins.add('converse-roster', {
                     contact.save({
                         'subscription': subscription,
                         'ask': ask,
+                        'nickname': item.getAttribute("name"),
                         'requesting': null,
                         'groups': groups
                     });


### PR DESCRIPTION
When we change the roster item name in the server, the client receives a roster push but does not update the respective contact. 
This PR fix that.