### PR TITLE
Dont run fetchRosterContacts async

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - #1412 muc moderator commands can be disabled selectively by config
 - #1413 fix moderator commands that change affiliation
 - #1414 Prevent duplicate messages on MUC join
+- #1405 Status of contacts list are not displayed properly
 
 ## 4.1.0 (2019-01-11)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -68005,11 +68005,15 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
         }
       } else {
         try {
-          await _converse.rostergroups.fetchRosterGroups().then(() => {
-            _converse.emit('rosterGroupsFetched');
+          /* Make sure not to run fetchRosterContacts async, since we need
+           * the contacts to exist before processing contacts presence,
+           * which might come in the same BOSH request.
+           */
+          await _converse.rostergroups.fetchRosterGroups();
 
-            return _converse.roster.fetchRosterContacts();
-          });
+          _converse.emit('rosterGroupsFetched');
+
+          await _converse.roster.fetchRosterContacts();
 
           _converse.emit('rosterContactsFetched');
         } catch (reason) {

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -68362,8 +68362,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
 
         if (collection.length === 0 || this.rosterVersioningSupported() && !_converse.session.get('roster_fetched')) {
           _converse.send_initial_presence = true;
-
-          _converse.roster.fetchFromServer();
+          await _converse.roster.fetchFromServer();
         } else {
           _converse.emit('cachedRoster', collection);
         }

--- a/src/headless/converse-roster.js
+++ b/src/headless/converse-roster.js
@@ -407,7 +407,7 @@ converse.plugins.add('converse-roster', {
                 if (collection.length === 0 ||
                         (this.rosterVersioningSupported() && !_converse.session.get('roster_fetched'))) {
                     _converse.send_initial_presence = true;
-                    _converse.roster.fetchFromServer();
+                    await _converse.roster.fetchFromServer();
                 } else {
                     _converse.emit('cachedRoster', collection);
                 }

--- a/src/headless/converse-roster.js
+++ b/src/headless/converse-roster.js
@@ -88,10 +88,14 @@ converse.plugins.add('converse-roster', {
                 }
             } else {
                 try {
-                    await _converse.rostergroups.fetchRosterGroups().then(() => {
-                        _converse.emit('rosterGroupsFetched');
-                        return _converse.roster.fetchRosterContacts();
-                    });
+                    /* Make sure not to run fetchRosterContacts async, since we need
+                     * the contacts to exist before processing contacts presence,
+                     * which might come in the same BOSH request.
+                     */
+                    await _converse.rostergroups.fetchRosterGroups();
+                    _converse.emit('rosterGroupsFetched');
+
+                    await _converse.roster.fetchRosterContacts();
                     _converse.emit('rosterContactsFetched');
                 } catch (reason) {
                     _converse.log(reason, Strophe.LogLevel.ERROR);


### PR DESCRIPTION
Fixes #1405

The problem I observed was as follows: upon login, your roster as well as your contacts' presence are contained in a single BOSH response. Converse would process the roster (`fetchRosterContacts`) async and move on to processing the presence in the mean time. Because of this, in `presenceHandler` the roster contacts would not exist yet (`contact = this.get(bare_jid)` returning NULL) causing the presence to be ignored. As a result, the contact would never show online until logging off & on.

This change makes sure we wait for `fetchRosterContacts` to be completed. There are a few possible ways to go about this, but I think this works well. Correct me if I'm wrong :)