### PR TITLE
Don't leak the real JIDs of participants when using mentions in semi-anonymous rooms.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Bugfix. Prevent duplicate messages by comparing MAM archive id to XEP-0359 stanza ids.
 - Bugfix. Open groupchats not shown when logging in after disconnection.
 - #1406: `TypeError: e.devicelists is undefined` when unchecking the "trusted device" checkbox
+- Bugfix. Don't send real jids in mentions in a semi-anonymous or anonymous room when we are a moderator.
+- Bugfix. Always set the "uri" field in reference tags, as required by the XEP.
 
 ## 4.1.1 (2019-02-18)
 

--- a/spec/messages.js
+++ b/spec/messages.js
@@ -2686,6 +2686,9 @@
                         })));
                 });
 
+                // This room is not anonymous, so real JIDs can be used.
+                view.model.features.save({'nonanonymous': true, 'semianonymous': false});
+
                 // Run a few unit tests for the parseTextForReferences method
                 let [text, references] = view.model.parseTextForReferences('hello z3r0')
                 expect(references.length).toBe(0);
@@ -2694,15 +2697,17 @@
                 [text, references] = view.model.parseTextForReferences('hello @z3r0')
                 expect(references.length).toBe(1);
                 expect(text).toBe('hello z3r0');
-                expect(JSON.stringify(references))
-                    .toBe('[{"begin":6,"end":10,"value":"z3r0","type":"mention","uri":"xmpp:z3r0@localhost"}]');
+                expect(references)
+                    .toEqual([{"begin":6,"end":10,"value":"z3r0","type":"mention","uri":"xmpp:z3r0@localhost"}]);
 
                 [text, references] = view.model.parseTextForReferences('hello @some1 @z3r0 @gibson @mr.robot, how are you?')
                 expect(text).toBe('hello @some1 z3r0 gibson mr.robot, how are you?');
-                expect(JSON.stringify(references))
-                    .toBe('[{"begin":13,"end":17,"value":"z3r0","type":"mention","uri":"xmpp:z3r0@localhost"},'+
-                            '{"begin":18,"end":24,"value":"gibson","type":"mention","uri":"xmpp:gibson@localhost"},'+
-                            '{"begin":25,"end":33,"value":"mr.robot","type":"mention","uri":"xmpp:mr.robot@localhost"}]');
+                expect(references)
+                    .toEqual([
+                        {"begin":13,"end":17,"value":"z3r0","type":"mention","uri":"xmpp:z3r0@localhost"},
+                        {"begin":18,"end":24,"value":"gibson","type":"mention","uri":"xmpp:gibson@localhost"},
+                        {"begin":25,"end":33,"value":"mr.robot","type":"mention","uri":"xmpp:mr.robot@localhost"}
+                    ]);
 
                 [text, references] = view.model.parseTextForReferences('yo @gib')
                 expect(text).toBe('yo @gib');
@@ -2715,14 +2720,14 @@
                 [text, references] = view.model.parseTextForReferences('@gibson')
                 expect(text).toBe('gibson');
                 expect(references.length).toBe(1);
-                expect(JSON.stringify(references))
-                    .toBe('[{"begin":0,"end":6,"value":"gibson","type":"mention","uri":"xmpp:gibson@localhost"}]');
+                expect(references)
+                    .toEqual([{"begin":0,"end":6,"value":"gibson","type":"mention","uri":"xmpp:gibson@localhost"}]);
 
                 [text, references] = view.model.parseTextForReferences('hi @Link Mauve how are you?')
                 expect(text).toBe('hi Link Mauve how are you?');
                 expect(references.length).toBe(1);
-                expect(JSON.stringify(references))
-                    .toBe('[{"begin":3,"end":13,"value":"Link Mauve","type":"mention","uri":"xmpp:Link-Mauve@localhost"}]');
+                expect(references)
+                    .toEqual([{"begin":3,"end":13,"value":"Link Mauve","type":"mention","uri":"xmpp:Link-Mauve@localhost"}]);
                 done();
             }));
 
@@ -2746,6 +2751,9 @@
                             'role': 'participant'
                         })));
                 });
+
+                // This room is not anonymous, so real JIDs can be used.
+                view.model.features.save({'nonanonymous': true, 'semianonymous': false});
 
                 const textarea = view.el.querySelector('textarea.chat-textarea');
                 textarea.value = 'hello @z3r0 @gibson @mr.robot, how are you?'
@@ -2849,6 +2857,9 @@
                                 'role': 'participant'
                             })));
                     });
+
+                    // This room is not anonymous, so real JIDs can be used.
+                    view.model.features.save({'nonanonymous': true, 'semianonymous': false});
 
                     spyOn(_converse.connection, 'send');
                     const textarea = view.el.querySelector('textarea.chat-textarea');

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -356,15 +356,22 @@ converse.plugins.add('converse-muc', {
                 if (!occupant) {
                     return null;
                 }
+                const roomJid = this.get('jid');
+                const nonanon = this.features.get('nonanonymous');
+                let uri;
+                if (occupant.get('jid') && nonanon) {
+                    uri = `xmpp:${occupant.get('jid')}`;
+                }
+                else {
+                    uri = `xmpp:${roomJid}/${occupant.get('nick')}`;
+                }
                 const obj = {
                     'begin': index,
                     'end': index + longest_match.length,
                     'value': longest_match,
-                    'type': 'mention'
+                    'type': 'mention',
+                    'uri': uri,
                 };
-                if (occupant.get('jid')) {
-                    obj.uri = `xmpp:${occupant.get('jid')}`
-                }
                 return obj;
             },
 


### PR DESCRIPTION
Converse is leaking real JIDs of participants in semi-anonymous MUCs when a moderator mentions anyone, it also will sometimes not include a "uri" attribute, even though the XEP states that this is required.

I've fixed both of these issues, though I'm not sure if this is a good way of doing so.