### PR TITLE
make it configurable whether to respect autojoin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - #1437: List of groupchats in modal doesn't scroll
 - #1457: Wrong tooltip shown for "unbookmark" icon
 - #1479: Allow file upload by drag & drop also in MUCs
+- #1487: New config option [muc_respect_autojoin](https://conversejs.org/docs/html/configuration.html#muc-respect-autojoin)
 
 
 ## 4.1.2 (2019-02-22)

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -48619,7 +48619,8 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
     _converse.api.settings.update({
       allow_bookmarks: true,
       allow_public_bookmarks: false,
-      hide_open_bookmarks: true
+      hide_open_bookmarks: true,
+      muc_respect_autojoin: true
     }); // Promises exposed by this plugin
 
 
@@ -48676,7 +48677,7 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_0__["default"].plugins
       },
 
       openBookmarkedRoom(bookmark) {
-        if (bookmark.get('autojoin')) {
+        if (_converse.muc_respect_autojoin && bookmark.get('autojoin')) {
           const groupchat = _converse.api.rooms.create(bookmark.get('jid'), bookmark.get('nick'));
 
           if (!groupchat.get('hidden')) {

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1014,6 +1014,16 @@ automatically be "john". If now john@differentdomain.com tries to join the
 room, his nickname will be "john-2", and if john@somethingelse.com joins, then
 his nickname will be "john-3", and so forth.
 
+muc_respect_autojoin
+--------------------
+
+* Default; ``true``
+
+Determines whether Converse will respect the autojoin-attribute of bookmarks. Per default
+all MUCs with set autojoin flag in their respective bookmarks will be joined on
+startup of Converse. When set to ``false`` no MUCs are automatically joined based on
+their bookmarks.
+
 muc_show_join_leave
 -------------------
 

--- a/src/converse-bookmarks.js
+++ b/src/converse-bookmarks.js
@@ -202,7 +202,8 @@ converse.plugins.add('converse-bookmarks', {
         _converse.api.settings.update({
             allow_bookmarks: true,
             allow_public_bookmarks: false,
-            hide_open_bookmarks: true
+            hide_open_bookmarks: true,
+            muc_respect_autojoin: true
         });
         // Promises exposed by this plugin
         _converse.api.promises.add('bookmarksInitialized');
@@ -250,7 +251,7 @@ converse.plugins.add('converse-bookmarks', {
             },
 
             openBookmarkedRoom (bookmark) {
-                if (bookmark.get('autojoin')) {
+                if ( _converse.muc_respect_autojoin && bookmark.get('autojoin')) {
                     const groupchat = _converse.api.rooms.create(bookmark.get('jid'), bookmark.get('nick'));
                     if (!groupchat.get('hidden')) {
                         groupchat.trigger('show');


### PR DESCRIPTION
I'd like to be able to turn off converse.js' behaviour of autojoining MUCs bases on their bookmarks. This PR adds a new config option `muc_respect_autojoin` which allows this.