### PR TITLE
Allow `http:` image URLs if Converse.js is loaded on an insecure origin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Allow setting of debug mode via URL with `/#converse?debug=true`
 - New config setting [locked_muc_domain](https://conversejs.org/docs/html/configuration.html#locked-muc-domain)
 - New config setting [show_client_info](https://conversejs.org/docs/html/configuration.html#show-client-info)
+- Render inline images served over HTTP if Converse itself was loaded on an unsecured (HTTP) page.
 - #1149: With `xhr_user_search_url`, contact requests are not being sent out
 - #1213: Switch roster filter input and icons
 - #1327: fix False mentions positives in URLs and Email addresses

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -90,7 +90,7 @@ u.isImageURL = function (url) {
         url = new URI(url);
     }
     const filename = url.filename().toLowerCase();
-    if (url.protocol().toLowerCase() !== "https") {
+    if (window.location.protocol === 'https:' && url.protocol().toLowerCase() !== "https") {
         return false;
     }
     return filename.endsWith('.jpg') || filename.endsWith('.jpeg') ||


### PR DESCRIPTION
Currently, in order for Converse.js to recognize a pasted URL as an
image, it must be an URL whose protocol is `https:` (`https` in the
URI.js library's notation). This is sensible, but means that any
non-HTTPS image URL is not recognized as a valid URL (and thus will not
be rendered inline, even if `show_images_inline` is set to `true`).

It is important to always check for HTTPS URLs when in a secure context
(i.e., the initial page load was requested via HTTPS) in order to ensure
that non-secured content does not mix with secured content. However, the
inverse is not true: if the original page was loaded over HTTP, then
enforcing HTTPS for images adds arguably no meaningful protection while
also breaking the `show_images_inline` feature for the edge cases where
Converse.js is deployed without HTTPS and a user pastes an HTTP URL.

This patch changes the behavior of the `isImageURL` method such that the
requirement for the pasted URL's protocol to be `https:` is enforced
only when the `window.location.protocol` itself is also `https:`. By
doing this, we ensure that secure origins (i.e., when Converse.js is
loaded over HTTPS initially) are still secured and cannot have non-HTTPS
content introduced to the page via a pasted non-HTTPS URL, however it
also allows non-HTTPS origins to render both HTTP and HTTPS image URLs.

Thanks for making a pull request to converse.js!

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.

I did not create a test because I did not find existing tests for `isImageURL()` and assume that this change is therefore minor enough not to require the addition of a new test spec?