### PR TITLE
Don't prompt for reason if auto_join_on_invite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - #1457: Wrong tooltip shown for "unbookmark" icon
 - #1479: Allow file upload by drag & drop also in MUCs
 - #1487: New config option [muc_respect_autojoin](https://conversejs.org/docs/html/configuration.html#muc-respect-autojoin)
+- #1501: Don't prompt for a reason if [auto_join_on_invite](https://conversejs.org/docs/html/configuration.html#auto-join-on-invite) is `true`
 
 
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -55708,7 +55708,11 @@ _converse_headless_converse_core__WEBPACK_IMPORTED_MODULE_6__["default"].plugins
       },
 
       promptForInvite(suggestion) {
-        const reason = prompt(__('You are about to invite %1$s to the groupchat "%2$s". ' + 'You may optionally include a message, explaining the reason for the invitation.', suggestion.text.label, this.model.get('id')));
+        let reason = '';
+
+        if (!_converse.auto_join_on_invite) {
+          reason = prompt(__('You are about to invite %1$s to the groupchat "%2$s". ' + 'You may optionally include a message, explaining the reason for the invitation.', suggestion.text.label, this.model.get('id')));
+        }
 
         if (reason !== null) {
           this.chatroomview.model.directInvite(suggestion.text.value, reason);

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -363,6 +363,7 @@ auto_join_on_invite
 * Default:  ``false``
 
 If true, the user will automatically join a chatroom on invite without any confirm.
+Also inviting users won't be prompted for a reason.
 
 
 auto_join_private_chats

--- a/src/converse-muc-views.js
+++ b/src/converse-muc-views.js
@@ -1948,11 +1948,14 @@ converse.plugins.add('converse-muc-views', {
 
 
             promptForInvite (suggestion) {
-                const reason = prompt(
-                    __('You are about to invite %1$s to the groupchat "%2$s". '+
-                       'You may optionally include a message, explaining the reason for the invitation.',
-                       suggestion.text.label, this.model.get('id'))
-                );
+                let reason = '';
+                if (!_converse.auto_join_on_invite) {
+                    reason = prompt(
+                        __('You are about to invite %1$s to the groupchat "%2$s". '+
+                           'You may optionally include a message, explaining the reason for the invitation.',
+                           suggestion.text.label, this.model.get('id'))
+                    );
+                }
                 if (reason !== null) {
                     this.chatroomview.model.directInvite(suggestion.text.value, reason);
                 }


### PR DESCRIPTION
I believe Converse shouldn't prompt for a reason if `auto_join_on_invite` is `true` because the inivted user won't see it anyway.