### PR TITLE
fix LMC with Conversations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - #1479: Allow file upload by drag & drop also in MUCs
 - #1487: New config option [muc_respect_autojoin](https://conversejs.org/docs/html/configuration.html#muc-respect-autojoin)
 - #1501: Don't prompt for a reason if [auto_join_on_invite](https://conversejs.org/docs/html/configuration.html#auto-join-on-invite) is `true`
+- #1507: Make message id and origin-id identical in order to fix LMC with Conversations
 
 
 ## 4.1.2 (2019-02-22)

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -62474,7 +62474,7 @@ _converse_core__WEBPACK_IMPORTED_MODULE_2__["default"].plugins.add('converse-cha
               origin_id = _converse.connection.getUniqueId();
 
         return _.extend(this.toJSON(), {
-          'id': origin_id,
+          'msgid': origin_id,
           'origin_id': origin_id,
           'fullname': _converse.xmppstatus.get('fullname'),
           'from': _converse.bare_jid,

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -499,7 +499,7 @@ converse.plugins.add('converse-chatboxes', {
                       origin_id = _converse.connection.getUniqueId();
 
                 return _.extend(this.toJSON(), {
-                    'id': origin_id,
+                    'msgid': origin_id,
                     'origin_id': origin_id,
                     'fullname': _converse.xmppstatus.get('fullname'),
                     'from': _converse.bare_jid,


### PR DESCRIPTION
If I send a correction to Conversations the message will be rendered as a new message by Conversations. C seems to expect the message-id and the origin-id to be identical (I'm not 100% sure about it, but seems to work). This PR tries to fix it for conversejs.