### PR TITLE
Minimized bookmarked chatboxes should not be always maximized after page reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 - #1487: New config option [muc_respect_autojoin](https://conversejs.org/docs/html/configuration.html#muc-respect-autojoin)
 - #1501: Don't prompt for a reason if [auto_join_on_invite](https://conversejs.org/docs/html/configuration.html#auto-join-on-invite) is `true`
 - #1507: Make message id and origin-id identical in order to fix LMC with Conversations
-
+- #1508: Minimized bookmarked chatboxes should not be always maximized after page reload.
 
 ## 4.1.2 (2019-02-22)
 

--- a/src/converse-bookmarks.js
+++ b/src/converse-bookmarks.js
@@ -253,7 +253,7 @@ converse.plugins.add('converse-bookmarks', {
             openBookmarkedRoom (bookmark) {
                 if ( _converse.muc_respect_autojoin && bookmark.get('autojoin')) {
                     const groupchat = _converse.api.rooms.create(bookmark.get('jid'), bookmark.get('nick'));
-                    if (!groupchat.get('hidden')) {
+                    if (!groupchat.get('hidden') && !groupchat.get('minimized')) {
                         groupchat.trigger('show');
                     }
                 }


### PR DESCRIPTION
This is a fix for https://github.com/conversejs/converse.js/issues/1508
