### PR TITLE
Allow manual entry of jid with xhr_user_search_url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - #1501: Don't prompt for a reason if [auto_join_on_invite](https://conversejs.org/docs/html/configuration.html#auto-join-on-invite) is `true`
 - #1507: Make message id and origin-id identical in order to fix LMC with Conversations
 - #1508: Minimized bookmarked chatboxes should not be always maximized after page reload.
+- #1512: Allow manual entry of jid even with [xhr_user_search_url](https://conversejs.org/docs/html/configuration.html#xhr-user-search-url)
 
 ## 4.1.2 (2019-02-22)
 

--- a/dist/converse.js
+++ b/dist/converse.js
@@ -92162,11 +92162,7 @@ var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
 function print() { __p += __j.call(arguments, '') }
 __p += '<!-- src/templates/add_contact_modal.html -->\n<!-- Add contact Modal -->\n<div class="modal fade" id="add-contact-modal" tabindex="-1" role="dialog" aria-labelledby="addContactModalLabel" aria-hidden="true">\n    <div class="modal-dialog" role="document">\n        <div class="modal-content">\n            <div class="modal-header">\n                <h5 class="modal-title" id="addContactModalLabel">' +
 __e(o.heading_new_contact) +
-'</h5>\n                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>\n            </div>\n            <form class="converse-form add-xmpp-contact">\n                <div class="modal-body">\n                    <div class="form-group ';
- if (o._converse.xhr_user_search_url) { ;
-__p += ' hidden ';
- } ;
-__p += '">\n                        <label class="clearfix" for="jid">' +
+'</h5>\n                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>\n            </div>\n            <form class="converse-form add-xmpp-contact">\n                <div class="modal-body">\n                    <div class="form-group">\n                        <label class="clearfix" for="jid">' +
 __e(o.label_xmpp_address) +
 ':</label>\n                        <div class="suggestion-box suggestion-box__jid">\n                            <ul class="suggestion-box__results suggestion-box__results--above" hidden=""></ul>\n                            <input type="text" name="jid"\n                                   ';
  if (!o._converse.xhr_user_search_url) { ;

--- a/src/templates/add_contact_modal.html
+++ b/src/templates/add_contact_modal.html
@@ -8,7 +8,7 @@
             </div>
             <form class="converse-form add-xmpp-contact">
                 <div class="modal-body">
-                    <div class="form-group {[ if (o._converse.xhr_user_search_url) { ]} hidden {[ } ]}">
+                    <div class="form-group">
                         <label class="clearfix" for="jid">{{{o.label_xmpp_address}}}:</label>
                         <div class="suggestion-box suggestion-box__jid">
                             <ul class="suggestion-box__results suggestion-box__results--above" hidden=""></ul>


### PR DESCRIPTION
I'd like to be able to manually entry a JID even if using xhr_user_search_url.

Therfore I propose to show the JID field.