### PR TITLE
Remove references to unsupported OTR encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ which shows you how to use the CDN (content delivery network) to quickly get a d
 -   Hidden Messages (aka Spoilers) [XEP 382](https://xmpp.org/extensions/xep-0382.html)
 -   Client state indication [XEP 352](https://xmpp.org/extensions/xep-0352.html)
 -   Last Message Correction [XEP 308](https://xmpp.org/extensions/xep-0308.html)
--   Off-the-record encryption
 -   OMEMO encrypted messaging [XEP 384](https://xmpp.org/extensions/xep-0384.html")
 -   Supports anonymous logins, see the [anonymous login demo](https://conversejs.org/demo/anonymous.html).
 -   Translated into 28 languages

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -192,13 +192,6 @@ federated server), while setting it to `false` means that people not on your
 roster can't contact you unless one (or both) of you subscribe to one another's
 presence (i.e. adding as a roster contact).
 
-allow_otr
----------
-
-* Default:  ``true``
-
-Allow Off-the-record encryption of single-user chat messages.
-
 allow_public_bookmarks
 ----------------------
 
@@ -435,7 +428,6 @@ The core, and by default whitelisted, plugins are::
     converse-muc
     converse-muc-embedded
     converse-notification
-    converse-otr
     converse-ping
     converse-profile
     converse-register
@@ -478,29 +470,6 @@ For more information, read this blog post: `Which BOSH server do you need? <http
 
 A more modern alternative to BOSH is to use `websockets <https://developer.mozilla.org/en/docs/WebSockets>`_.
 Please see the :ref:`websocket-url` configuration setting.
-
-cache_otr_key
--------------
-
-* Default:  ``false``
-
-Let the `OTR (Off-the-record encryption) <https://otr.cypherpunks.ca>`_ private
-key be cached in your browser's session storage.
-
-The browser's session storage persists across page loads but is deleted once
-the tab or window is closed.
-
-If this option is set to ``false``, a new OTR private key will be generated
-for each page load. While more inconvenient, this is a much more secure option.
-
-This setting can only be used together with ``allow_otr = true``.
-
-.. note::
-    A browser window's session storage is accessible by all javascript that
-    is served from the same domain. So if there is malicious javascript served by
-    the same server (or somehow injected via an attacker), then they will be able
-    to retrieve your private key and read your all the chat messages in your
-    current session. Previous sessions however cannot be decrypted.
 
 chatstate_notification_blacklist
 --------------------------------
@@ -769,7 +738,7 @@ The translations for that locale must be available in JSON format at the
 `locales_url`_
 
 If an explicit locale is specified via the ``i18n`` setting and the
-translations for that locale are not found at the `locales_url``, then 
+translations for that locale are not found at the `locales_url``, then
 then Converse will fall back to trying to determine the browser's language
 and fetching those translations, or if that fails the default English texts
 will be used.
@@ -1539,14 +1508,6 @@ description of time-format options available for `DayJS` you can check the
 `default formatting options <https://github.com/iamkun/dayjs/blob/dev/docs/en/API-reference.md#displaying>`_ and the
 `advanced options <https://github.com/iamkun/dayjs/blob/master/docs/en/Plugin.md#advancedformat>`_.
 
-use_otr_by_default
-------------------
-
-* Default:  ``false``
-
-If set to ``true``, Converse will automatically try to initiate an OTR (off-the-record)
-encrypted chat session every time you open a chatbox.
-
 visible_toolbar_buttons
 -----------------------
 
@@ -1703,7 +1664,6 @@ These are::
     converse-muc
     converse-muc-embedded
     converse-notification
-    converse-otr
     converse-ping
     converse-profile
     converse-register

--- a/docs/source/developer_api.rst
+++ b/docs/source/developer_api.rst
@@ -68,7 +68,6 @@ Example:
 .. code-block:: javascript
 
     converse.initialize({
-            allow_otr: true,
             auto_list_rooms: false,
             auto_subscribe: false,
             bosh_service_url: 'https://bind.example.com',

--- a/docs/source/other_frameworks.rst
+++ b/docs/source/other_frameworks.rst
@@ -58,7 +58,6 @@ Below is an example code that wraps converse.js as an angular.js service.
             "converse-mam",          // XEP-0313 Message Archive Management
             "converse-muc",          // XEP-0045 Multi-user chat
             "converse-vcard",        // XEP-0054 VCard-temp
-            "converse-otr",          // Off-the-record encryption for one-on-one messages
             "converse-register",     // XEP-0077 In-band registration
             "converse-ping",         // XEP-0199 XMPP Ping
             "converse-notification", // HTML5 Notifications

--- a/index.html
+++ b/index.html
@@ -201,7 +201,6 @@
                             <li>Hidden messages (aka Spoilers) (<a href="https://xmpp.org/extensions/xep-0382.html" target="_blank" rel="noopener">XEP 382</a>)</li>
                             <li>Client state indication (<a href="https://xmpp.org/extensions/xep-0352.html" target="_blank" rel="noopener">XEP 352</a>)</li>
                             <li>Last Message Correction (<a href="https://xmpp.org/extensions/xep-0308.html" target="_blank" rel="noopener">XEP 308</a>)</li>
-                            <li>Off-the-record encryption</li>
                             <li>OMEMO encrypted messaging (<a href="https://xmpp.org/extensions/xep-0384.html" target="_blank" rel="noopener">XEP 384</a>)</li>
                             <li>Supports anonymous logins, see the <a href="https://conversejs.org/demo/anonymous.html" target="_blank" rel="noopener">anonymous login demo</a>.</li>
                             <li>Translated into 28 languages</li>

--- a/mobile.html
+++ b/mobile.html
@@ -169,7 +169,6 @@
                             <li>Hidden messages (aka Spoilers) (<a href="https://xmpp.org/extensions/xep-0382.html" target="_blank" rel="noopener">XEP 382</a>)</li>
                             <li>Client state indication (<a href="https://xmpp.org/extensions/xep-0352.html" target="_blank" rel="noopener">XEP 352</a>)</li>
                             <li>Last Message Correction (<a href="https://xmpp.org/extensions/xep-0308.html" target="_blank" rel="noopener">XEP 308</a>)</li>
-                            <li>Off-the-record encryption</li>
                             <li>OMEMO encrypted messaging (<a href="https://xmpp.org/extensions/xep-0384.html" target="_blank" rel="noopener">XEP 384</a>)</li>
                             <li>Supports anonymous logins, see the <a href="https://conversejs.org/demo/anonymous.html" target="_blank" rel="noopener">anonymous login demo</a>.</li>
                             <li>Translated into 17 languages</li>
@@ -321,7 +320,7 @@
 </body>
 
 <script>
-    /* 
+    /*
     @licstart
     This is free and unencumbered software released into the public domain.
 


### PR DESCRIPTION
Relates to issue #1565, "documentation mentions non-existent OTR support repeatedly".

Should i add an item to CHANGES.md for a doc-only change?
