### PR TITLE
Support sending files from clipboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 - #1576: Converse gets stuck with spinner when logging out with `auto_login` set to `true`
 - #1579: Trim spaces at the beginning and end of a JID (when adding contact)
 - #1586: Not possible to kick someone with a space in their nickname
+- #1585: Upload files by pasting from clipboard
 
 ### Breaking changes
 

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -972,6 +972,15 @@ converse.plugins.add('converse-chatview', {
             },
 
             onPaste (ev) {
+                if (ev.clipboardData.files.length !== 0) {
+                    ev.preventDefault();
+                    // Workaround for quirk in at least Firefox 60.7 ESR:
+                    // It seems that pasted files disappear from the event payload after
+                    // the event has finished, which apparently happens during async
+                    // processing in sendFiles(). So we copy the array here.
+                    this.model.sendFiles(Array.from(ev.clipboardData.files));
+                    return;
+                }
                 this.updateCharCounter(ev.clipboardData.getData('text/plain'));
             },
 


### PR DESCRIPTION
Allows fancy things like taking a screenshot and pasting into chat.

Tested in Firefox 60.7 ESR