### PR TITLE
improve self-contact features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 5.0.0 (Unreleased)
+- automatically subscribe self-contact and show correct xmpp-status
+- prevent duplicate messages in chat-history (mainly for self-contact)
 - BOSH support has been moved to a plugin.
 - Support for XEP-0410 to check whether we're still present in a room
 - Initial support for the [CredentialsContainer](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer) web API

--- a/src/converse-profile.js
+++ b/src/converse-profile.js
@@ -257,7 +257,21 @@ converse.plugins.add('converse-profile', {
             },
 
             afterRender () {
+                this.updateStatusDisplayForSelfContact();
                 this.renderAvatar();
+            },
+
+            updateStatusDisplayForSelfContact () {
+                const self = this;
+                // changing the status-display of the self-contact after the user changed the xmpp-status
+                const contacts = _converse.roster.models;
+                _.each(contacts, function(contact) {
+                    const contact_jid = contact.get('id');
+                    if (u.isSameBareJID(contact_jid, _converse.connection.jid)) {
+                        const chat_status = self.model.get('status') || 'offline';
+                        contact.presence.set('show', chat_status);
+                    }
+                });
             },
 
             showProfileModal (ev) {

--- a/src/converse-rosterview.js
+++ b/src/converse-rosterview.js
@@ -354,10 +354,20 @@ converse.plugins.add('converse-rosterview', {
                     u.hideElement(this.el);
                     return this;
                 }
-                const ask = this.model.get('ask'),
-                    show = this.model.presence.get('show'),
-                    requesting  = this.model.get('requesting'),
-                    subscription = this.model.get('subscription');
+
+                const contact_jid = this.model.get('jid'),
+                    requesting = this.model.get('requesting'),
+                    subscription = u.isSameBareJID(contact_jid, _converse.connection.jid) ? 'both' : this.model.get('subscription'),
+                    ask = u.isSameBareJID(contact_jid, _converse.connection.jid) ? 'none' : this.model.get('ask');
+                let show = this.model.presence.get('show');
+                
+                // set status of self-contact to current xmpp-status
+                // without this the self-contact will always be offline after login
+                if (u.isSameBareJID(contact_jid, _converse.connection.jid) && show === 'offline') {
+                    const status_self = _converse.xmppstatus.get('status');
+                    this.model.presence.set('show', status_self);
+                    show = status_self;
+                }
 
                 const classes_to_remove = [
                     'current-xmpp-contact',


### PR DESCRIPTION
This commit adds some advanced functionality to the self-contact. When adding yourself as a contact the subscription will be completed automatically. Furthermore the xmpp-status will be tracked and correctly displayed for the self-contact roster-element.

