### PR TITLE
Add Broadcast-/MOTD-Message functionality (XEP-0133)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 6.0.0 (Unreleased)
 
+- Add Broadcast-Message (Announcements/MOTD) functionality
 - [enable_smacks](https://conversejs.org/docs/html/configuration.html#enable-smacks) is not set to `true` by default.
 - Refactor some presence and status handling code from `converse-core` into `@converse/headless/converse-status`.
 

--- a/locale/converse.pot
+++ b/locale/converse.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Converse.js 5.0.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-17 12:22+0200\n"
+"POT-Creation-Date: 2019-11-27 19:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,90 +17,106 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: dist/converse-no-dependencies.js:7899
+#: dist/converse-no-dependencies.js:5738
+msgid "OK"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:5740 dist/converse-no-dependencies.js:9237
+#: dist/converse-no-dependencies.js:10161
+#: dist/converse-no-dependencies.js:46293
+#: dist/converse-no-dependencies.js:52748
+msgid "Cancel"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:7807
 msgid "Uploading file:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8008
+#: dist/converse-no-dependencies.js:7931
 msgid "This message has been edited"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8014
+#: dist/converse-no-dependencies.js:7937
 msgid "Edit this message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8030
+#: dist/converse-no-dependencies.js:7943
+msgid "Retract this message"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:7959
 msgid "Message versions"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8044 dist/converse-no-dependencies.js:8321
-#: dist/converse-no-dependencies.js:8435 dist/converse-no-dependencies.js:9009
-#: dist/converse-no-dependencies.js:49890
-#: dist/converse-no-dependencies.js:49979
+#: dist/converse-no-dependencies.js:7973 dist/converse-no-dependencies.js:8250
+#: dist/converse-no-dependencies.js:8364 dist/converse-no-dependencies.js:9069
+#: dist/converse-no-dependencies.js:52657
+#: dist/converse-no-dependencies.js:52746
+#: dist/converse-no-dependencies.js:58460
 msgid "Close"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8325
+#: dist/converse-no-dependencies.js:8254
 msgid "The User's Profile Image"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8335
+#: dist/converse-no-dependencies.js:8264
 msgid "Full Name:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8341 dist/converse-no-dependencies.js:8517
+#: dist/converse-no-dependencies.js:8270 dist/converse-no-dependencies.js:8570
 msgid "XMPP Address:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8349
+#: dist/converse-no-dependencies.js:8278
 msgid "Nickname:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8357
+#: dist/converse-no-dependencies.js:8286
 msgid "URL:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8367
+#: dist/converse-no-dependencies.js:8296
 msgid "Email:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8377
+#: dist/converse-no-dependencies.js:8306
 msgid "Role:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8385
+#: dist/converse-no-dependencies.js:8314
 msgid "OMEMO Fingerprints"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8409
+#: dist/converse-no-dependencies.js:8338
 msgid "Trusted"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8423
+#: dist/converse-no-dependencies.js:8352
 msgid "Untrusted"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8437
+#: dist/converse-no-dependencies.js:8366
 msgid "Refresh"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8441
+#: dist/converse-no-dependencies.js:8370
 msgid "Remove as contact"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8523
+#: dist/converse-no-dependencies.js:8576
 msgid "Password:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8525
+#: dist/converse-no-dependencies.js:8578
 msgid "password"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8535
+#: dist/converse-no-dependencies.js:8588
 msgid "This is a trusted device"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8537
+#: dist/converse-no-dependencies.js:8590
 msgid ""
 "To improve performance, we cache your data in this browser. Uncheck this box "
 "if this is a public computer or if you want your data to be deleted when you "
@@ -109,214 +125,208 @@ msgid ""
 "OMEMO encryption is NOT available."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8541
+#: dist/converse-no-dependencies.js:8594
 msgid "Log in"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8547
+#: dist/converse-no-dependencies.js:8600
 msgid "Click here to log in anonymously"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8593
+#: dist/converse-no-dependencies.js:8646
 msgid "Search"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8627
+#: dist/converse-no-dependencies.js:8680
 msgid "Search results"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8777
+#: dist/converse-no-dependencies.js:8830
 msgid "Enter a new Groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8785 dist/converse-no-dependencies.js:49013
-#: dist/converse-no-dependencies.js:49894
+#: dist/converse-no-dependencies.js:8838 dist/converse-no-dependencies.js:51675
+#: dist/converse-no-dependencies.js:52661
 msgid "Nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8787
+#: dist/converse-no-dependencies.js:8840
 msgid "This field is required"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8793
+#: dist/converse-no-dependencies.js:8846
 msgid "Join"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8833
+#: dist/converse-no-dependencies.js:8891
 msgid "You're not allowed to send messages in this room"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8847
+#: dist/converse-no-dependencies.js:8907
 msgid "This groupchat no longer exists"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8853
+#: dist/converse-no-dependencies.js:8913
 msgid "The conversation has moved. Click below to enter."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8875
+#: dist/converse-no-dependencies.js:8935
 msgid "Name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8879
+#: dist/converse-no-dependencies.js:8939
 msgid "Groupchat address (JID)"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8883
+#: dist/converse-no-dependencies.js:8943
 msgid "Description"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8889
+#: dist/converse-no-dependencies.js:8949
 msgid "Topic"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8893
+#: dist/converse-no-dependencies.js:8953
 msgid "Topic author"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8899
+#: dist/converse-no-dependencies.js:8959
 msgid "Online users"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8903 dist/converse-no-dependencies.js:9043
+#: dist/converse-no-dependencies.js:8963 dist/converse-no-dependencies.js:9103
 msgid "Features"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8907 dist/converse-no-dependencies.js:9049
+#: dist/converse-no-dependencies.js:8967 dist/converse-no-dependencies.js:9109
 msgid "Password protected"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8909 dist/converse-no-dependencies.js:9047
+#: dist/converse-no-dependencies.js:8969 dist/converse-no-dependencies.js:9107
 msgid "This groupchat requires a password before entry"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8915
+#: dist/converse-no-dependencies.js:8975
 msgid "No password required"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8917 dist/converse-no-dependencies.js:9055
+#: dist/converse-no-dependencies.js:8977 dist/converse-no-dependencies.js:9115
 msgid "This groupchat does not require a password upon entry"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8923 dist/converse-no-dependencies.js:9065
-#: dist/converse-no-dependencies.js:47132
+#: dist/converse-no-dependencies.js:8983 dist/converse-no-dependencies.js:9125
+#: dist/converse-no-dependencies.js:49564
 msgid "Hidden"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8925 dist/converse-no-dependencies.js:9063
+#: dist/converse-no-dependencies.js:8985 dist/converse-no-dependencies.js:9123
 msgid "This groupchat is not publicly searchable"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8931 dist/converse-no-dependencies.js:9073
-#: dist/converse-no-dependencies.js:47138
+#: dist/converse-no-dependencies.js:8991 dist/converse-no-dependencies.js:9133
+#: dist/converse-no-dependencies.js:49570
 msgid "Public"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8933 dist/converse-no-dependencies.js:9071
+#: dist/converse-no-dependencies.js:8993 dist/converse-no-dependencies.js:9131
 msgid "This groupchat is publicly searchable"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8939 dist/converse-no-dependencies.js:9081
+#: dist/converse-no-dependencies.js:8999 dist/converse-no-dependencies.js:9141
 msgid "Members only"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8941
+#: dist/converse-no-dependencies.js:9001
 msgid "This groupchat is restricted to members only"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8947 dist/converse-no-dependencies.js:9089
-#: dist/converse-no-dependencies.js:47136
+#: dist/converse-no-dependencies.js:9007 dist/converse-no-dependencies.js:9149
+#: dist/converse-no-dependencies.js:49568
 msgid "Open"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8949 dist/converse-no-dependencies.js:9087
+#: dist/converse-no-dependencies.js:9009 dist/converse-no-dependencies.js:9147
 msgid "Anyone can join this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8955 dist/converse-no-dependencies.js:9097
+#: dist/converse-no-dependencies.js:9015 dist/converse-no-dependencies.js:9157
 msgid "Persistent"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8957 dist/converse-no-dependencies.js:9095
+#: dist/converse-no-dependencies.js:9017 dist/converse-no-dependencies.js:9155
 msgid "This groupchat persists even if it's unoccupied"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8963 dist/converse-no-dependencies.js:9105
-#: dist/converse-no-dependencies.js:47140
+#: dist/converse-no-dependencies.js:9023 dist/converse-no-dependencies.js:9165
+#: dist/converse-no-dependencies.js:49572
 msgid "Temporary"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8965 dist/converse-no-dependencies.js:9103
+#: dist/converse-no-dependencies.js:9025 dist/converse-no-dependencies.js:9163
 msgid "This groupchat will disappear once the last person leaves"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8971 dist/converse-no-dependencies.js:9113
+#: dist/converse-no-dependencies.js:9031 dist/converse-no-dependencies.js:9173
 msgid "Not anonymous"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8973 dist/converse-no-dependencies.js:9111
+#: dist/converse-no-dependencies.js:9033 dist/converse-no-dependencies.js:9171
 msgid "All other groupchat participants can see your XMPP address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8979 dist/converse-no-dependencies.js:9121
-#: dist/converse-no-dependencies.js:47139
+#: dist/converse-no-dependencies.js:9039 dist/converse-no-dependencies.js:9181
+#: dist/converse-no-dependencies.js:49571
 msgid "Semi-anonymous"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8981 dist/converse-no-dependencies.js:9119
+#: dist/converse-no-dependencies.js:9041 dist/converse-no-dependencies.js:9179
 msgid "Only moderators can see your XMPP address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8987 dist/converse-no-dependencies.js:9129
-#: dist/converse-no-dependencies.js:47134
+#: dist/converse-no-dependencies.js:9047 dist/converse-no-dependencies.js:9189
+#: dist/converse-no-dependencies.js:49566
 msgid "Moderated"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8989 dist/converse-no-dependencies.js:9127
+#: dist/converse-no-dependencies.js:9049 dist/converse-no-dependencies.js:9187
 msgid ""
 "Participants entering this groupchat need to request permission to write"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8995 dist/converse-no-dependencies.js:9137
+#: dist/converse-no-dependencies.js:9055 dist/converse-no-dependencies.js:9197
 msgid "Not moderated"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:8997 dist/converse-no-dependencies.js:9135
+#: dist/converse-no-dependencies.js:9057 dist/converse-no-dependencies.js:9195
 msgid "Participants entering this groupchat can write right away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9003 dist/converse-no-dependencies.js:9145
+#: dist/converse-no-dependencies.js:9063 dist/converse-no-dependencies.js:9205
 msgid "Message archiving"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9005 dist/converse-no-dependencies.js:9143
+#: dist/converse-no-dependencies.js:9065 dist/converse-no-dependencies.js:9203
 msgid "Messages are archived on the server"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9057
+#: dist/converse-no-dependencies.js:9117
 msgid "No password"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9079
+#: dist/converse-no-dependencies.js:9139
 msgid "this groupchat is restricted to members only"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9175 dist/converse-no-dependencies.js:40373
-#: dist/converse-no-dependencies.js:49985
+#: dist/converse-no-dependencies.js:9235 dist/converse-no-dependencies.js:46296
+#: dist/converse-no-dependencies.js:52752
 msgid "Save"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9177 dist/converse-no-dependencies.js:10101
-#: dist/converse-no-dependencies.js:40370
-#: dist/converse-no-dependencies.js:49981
-msgid "Cancel"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:9312
+#: dist/converse-no-dependencies.js:9372
 msgid "Moderator Tools"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9314
+#: dist/converse-no-dependencies.js:9374
 msgid ""
 "Roles are assigned to users to grant or deny them certain abilities in a "
 "multi-user chat. They're assigned either explicitly or implicitly as part of "
@@ -324,893 +334,952 @@ msgid ""
 "the duration of the user's session."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9316 dist/converse-no-dependencies.js:49895
+#: dist/converse-no-dependencies.js:9376 dist/converse-no-dependencies.js:52662
 msgid "Role"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9328 dist/converse-no-dependencies.js:9352
+#: dist/converse-no-dependencies.js:9388 dist/converse-no-dependencies.js:9412
 msgid ""
 "Moderators are privileged users who can change the roles of other users "
 "(except those with admin or owner affiliations."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9334 dist/converse-no-dependencies.js:9358
+#: dist/converse-no-dependencies.js:9394 dist/converse-no-dependencies.js:9418
 msgid "The default role, implies that you can read and write messages."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9340 dist/converse-no-dependencies.js:9364
+#: dist/converse-no-dependencies.js:9400 dist/converse-no-dependencies.js:9424
 msgid ""
 "Visitors aren't allowed to write messages in a moderated multi-user chat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9348 dist/converse-no-dependencies.js:9444
+#: dist/converse-no-dependencies.js:9408 dist/converse-no-dependencies.js:9504
 msgid "Show users"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9374
+#: dist/converse-no-dependencies.js:9434
 msgid "No users with that role found."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9390
+#: dist/converse-no-dependencies.js:9450
 msgid "New Role"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9404 dist/converse-no-dependencies.js:9504
+#: dist/converse-no-dependencies.js:9464 dist/converse-no-dependencies.js:9564
 msgid "Reason"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9406
+#: dist/converse-no-dependencies.js:9466
 msgid "Change role"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9410
+#: dist/converse-no-dependencies.js:9470
 msgid ""
 "An affiliation is a long-lived entitlement which typically implies a certain "
 "role and which grants privileges and responsibilities. For example admins "
 "and owners automatically have the moderator role."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9412
+#: dist/converse-no-dependencies.js:9472
 msgid "Affiliation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9424 dist/converse-no-dependencies.js:9448
+#: dist/converse-no-dependencies.js:9484 dist/converse-no-dependencies.js:9508
 msgid ""
 "Owner is the highest affiliation. Owners can modify roles and affiliations "
 "of all other users."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9430 dist/converse-no-dependencies.js:9454
+#: dist/converse-no-dependencies.js:9490 dist/converse-no-dependencies.js:9514
 msgid ""
 "Admin is the 2nd highest affiliation. Admins can modify roles and "
 "affiliations of all other users except owners."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9436 dist/converse-no-dependencies.js:9460
+#: dist/converse-no-dependencies.js:9496 dist/converse-no-dependencies.js:9520
 msgid "To ban a user, you give them the affiliation of \"outcast\"."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9470
+#: dist/converse-no-dependencies.js:9530
 msgid "No users with that affiliation found."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9490
+#: dist/converse-no-dependencies.js:9550
 msgid "New affiliation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9506
+#: dist/converse-no-dependencies.js:9566
 msgid "Change affiliation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9865
+#: dist/converse-no-dependencies.js:9925
 msgid "Save and close"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9869
+#: dist/converse-no-dependencies.js:9929
 msgid "This device's OMEMO fingerprint"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9879
+#: dist/converse-no-dependencies.js:9939
 msgid "Generate new keys and fingerprint"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9883
+#: dist/converse-no-dependencies.js:9943
 msgid "Select all"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9885
+#: dist/converse-no-dependencies.js:9945
 msgid "Checkbox to select fingerprints of all other OMEMO devices"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9887
+#: dist/converse-no-dependencies.js:9947
 msgid "Other OMEMO-enabled devices"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9895 dist/converse-no-dependencies.js:9903
+#: dist/converse-no-dependencies.js:9955 dist/converse-no-dependencies.js:9963
 msgid "Checkbox for selecting the following fingerprint"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9905
+#: dist/converse-no-dependencies.js:9965
 msgid "Device without a fingerprint"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9911
+#: dist/converse-no-dependencies.js:9971
 msgid "Remove checked devices and close"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:9993
+#: dist/converse-no-dependencies.js:10053
 msgid "Messages are being sent in plaintext"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10009
+#: dist/converse-no-dependencies.js:10069
 msgid "Don't have a chat account?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10011
+#: dist/converse-no-dependencies.js:10071
 msgid "Create an account"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10027
+#: dist/converse-no-dependencies.js:10087
 msgid "Create your account"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10029
+#: dist/converse-no-dependencies.js:10089
 msgid "Please enter the XMPP provider to register with:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10047
-#: dist/converse-no-dependencies.js:10081
+#: dist/converse-no-dependencies.js:10107
+#: dist/converse-no-dependencies.js:10141
 msgid "Already have a chat account?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10049
-#: dist/converse-no-dependencies.js:10083
+#: dist/converse-no-dependencies.js:10109
+#: dist/converse-no-dependencies.js:10143
 msgid "Log in here"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10065
+#: dist/converse-no-dependencies.js:10125
 msgid "Account Registration:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10073
+#: dist/converse-no-dependencies.js:10133
 msgid "Register"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10077
+#: dist/converse-no-dependencies.js:10137
 msgid "Choose a different provider"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:10097
+#: dist/converse-no-dependencies.js:10157
 msgid "Hold tight, we're fetching the registration form…"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:27487
-msgid "Smileys and emotions"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27488
-msgid "People"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27489
-msgid "Activities"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27490
-msgid "Travel"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27491
-msgid "Objects"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27492
-msgid "Animals and nature"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27493
-msgid "Food and drink"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27494
-msgid "Symbols"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27495
-msgid "Flags"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:27496
-msgid "Stickers"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28145
-msgid "This groupchat is not anonymous"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28146
-msgid "This groupchat now shows unavailable members"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28147
-msgid "This groupchat does not show unavailable members"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28148
-msgid "The groupchat configuration has changed"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28149
-msgid "Groupchat logging is now enabled"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28150
-msgid "Groupchat logging is now disabled"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28151
-msgid "This groupchat is now no longer anonymous"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28152
-msgid "This groupchat is now semi-anonymous"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28153
-msgid "This groupchat is now fully-anonymous"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28154
-msgid "A new groupchat has been created"
-msgstr ""
-
-#. XXX: Note the triple underscore function and not double underscore.
-#: dist/converse-no-dependencies.js:28158
-#, javascript-format
-msgid "Your nickname has been automatically set to %1$s"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28159
-#, javascript-format
-msgid "Your nickname has been changed to %1$s"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28162
-msgid "You have been banned from this groupchat"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28163
-msgid "You have been kicked from this groupchat"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28164
-msgid ""
-"You have been removed from this groupchat because of an affiliation change"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28165
-msgid ""
-"You have been removed from this groupchat because the groupchat has changed "
-"to members-only and you're not a member"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28166
-msgid ""
-"You have been removed from this groupchat because the service hosting it is "
-"being shut down"
-msgstr ""
-
-#. XXX: Note the triple underscore function and not double underscore.
-#: dist/converse-no-dependencies.js:28170
-#, javascript-format
-msgid "%1$s has been banned"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28171
-#, javascript-format
-msgid "%1$s's nickname has changed"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28172
-#, javascript-format
-msgid "%1$s has been kicked out"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28173
-#, javascript-format
-msgid "%1$s has been removed because of an affiliation change"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:28174
-#, javascript-format
-msgid "%1$s has been removed for not being a member"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:29866
-msgid "You're not allowed to register yourself in this groupchat."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:29868
-msgid ""
-"You're not allowed to register in this groupchat because it's members-only."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:29914
-msgid ""
-"Can't register your nickname in this groupchat, it doesn't support "
-"registration."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:29916
-msgid ""
-"Can't register your nickname in this groupchat, invalid data form supplied."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30299
+#: dist/converse-no-dependencies.js:23362
 msgid ""
 "Your message was not delivered because you're not allowed to send messages "
 "in this groupchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:30301
+#: dist/converse-no-dependencies.js:23364
 msgid ""
 "Your message was not delivered because you're not present in the groupchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:30498
-#: dist/converse-no-dependencies.js:48591
-#, javascript-format
-msgid "This action was done by %1$s."
+#: dist/converse-no-dependencies.js:23369
+msgid "Sorry, an error occurred:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:30502
-#: dist/converse-no-dependencies.js:48597
-#, javascript-format
-msgid "The reason given is: \"%1$s\"."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30547
-msgid ""
-"The nickname you chose is reserved or currently in use, please choose a "
-"different one."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30571
-msgid "Password incorrect"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30577
-msgid "You are not on the member list of this groupchat."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30581
-msgid "You have been banned from this groupchat."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30587
-msgid "You are not allowed to create new groupchats."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30591
-msgid "Your nickname doesn't conform to this groupchat's policies."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30605
-msgid "This groupchat does not (yet) exist."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30609
-msgid "This groupchat has reached its maximum number of participants."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30613
-msgid "Remote server not found"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30615
-#, javascript-format
-msgid "The explanation given is: \"%1$s\"."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30979
-#, javascript-format
-msgid "%1$s has invited you to join a groupchat: %2$s"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:30981
-#, javascript-format
-msgid ""
-"%1$s has invited you to join a groupchat: %2$s, and left the following "
-"reason: \"%3$s\""
-msgstr ""
-
-#: dist/converse-no-dependencies.js:31668
-#: dist/converse-no-dependencies.js:42560
-#: dist/converse-no-dependencies.js:49931
-#: dist/converse-no-dependencies.js:50483
-#: dist/converse-no-dependencies.js:50932
-#: dist/converse-no-dependencies.js:50936
-#: dist/converse-no-dependencies.js:50983
-#: dist/converse-no-dependencies.js:54690
-msgid "Error"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:31668
-msgid "Sorry, something went wrong while trying to save your bookmark."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:31732
-msgid "Timeout Error"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:31732
-msgid ""
-"The server did not return your bookmarks within the allowed time. You can "
-"reload the page to request them again."
-msgstr ""
-
-#: dist/converse-no-dependencies.js:33481
+#: dist/converse-no-dependencies.js:26497
 msgid "Unencryptable OMEMO message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:33542
+#: dist/converse-no-dependencies.js:26556
 msgid "Sorry, could not determine upload URL."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:33564
+#: dist/converse-no-dependencies.js:26578
 msgid "Sorry, could not determine file upload URL."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:33613
+#: dist/converse-no-dependencies.js:26627
 #, javascript-format
 msgid ""
 "Sorry, could not succesfully upload your file. Your server’s response: \"%1$s"
 "\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:33615
+#: dist/converse-no-dependencies.js:26629
 msgid "Sorry, could not succesfully upload your file."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:34442
-#: dist/converse-no-dependencies.js:34462
+#: dist/converse-no-dependencies.js:27741
+#: dist/converse-no-dependencies.js:27761
 msgid "Sorry, looks like file upload is not supported by your server."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:34472
+#: dist/converse-no-dependencies.js:27771
 #, javascript-format
 msgid ""
 "The size of your file, %1$s, exceeds the maximum allowed by your server, "
 "which is %2$s."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:34563
-msgid "Sorry, an error occurred:"
+#: dist/converse-no-dependencies.js:30236
+msgid "Smileys and emotions"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:37087
-msgid "My contacts"
+#: dist/converse-no-dependencies.js:30237
+msgid "People"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:37088
-msgid "Pending contacts"
+#: dist/converse-no-dependencies.js:30238
+msgid "Activities"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:37089
-msgid "Contact requests"
+#: dist/converse-no-dependencies.js:30239
+msgid "Travel"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:37090
-msgid "Ungrouped"
+#: dist/converse-no-dependencies.js:30240
+msgid "Objects"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:37776
+#: dist/converse-no-dependencies.js:30241
+msgid "Animals and nature"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30242
+msgid "Food and drink"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30243
+msgid "Symbols"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30244
+msgid "Flags"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30245
+msgid "Stickers"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30912
+msgid "This groupchat is not anonymous"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30913
+msgid "This groupchat now shows unavailable members"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30914
+msgid "This groupchat does not show unavailable members"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30915
+msgid "The groupchat configuration has changed"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30916
+msgid "Groupchat logging is now enabled"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30917
+msgid "Groupchat logging is now disabled"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30918
+msgid "This groupchat is now no longer anonymous"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30919
+msgid "This groupchat is now semi-anonymous"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30920
+msgid "This groupchat is now fully-anonymous"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:30921
+msgid "A new groupchat has been created"
+msgstr ""
+
+#. XXX: Note the triple underscore function and not double underscore.
+#: dist/converse-no-dependencies.js:30925
 #, javascript-format
-msgid "Sorry, there was an error while trying to add %1$s as a contact."
+msgid "Your nickname has been automatically set to %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:38070
-msgid "This client does not allow presence subscriptions"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:38180
-msgid "Click to hide these contacts"
-msgstr ""
-
-#: dist/converse-no-dependencies.js:40265
+#: dist/converse-no-dependencies.js:30926
 #, javascript-format
-msgid "Are you sure you want to remove the bookmark \"%1$s\"?"
+msgid "Your nickname has been changed to %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40294
-#: dist/converse-no-dependencies.js:40434
-#: dist/converse-no-dependencies.js:53898
-msgid "Unbookmark this groupchat"
+#: dist/converse-no-dependencies.js:30929
+msgid "You have been banned from this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40294
-#: dist/converse-no-dependencies.js:40368
-#: dist/converse-no-dependencies.js:53896
-msgid "Bookmark this groupchat"
+#: dist/converse-no-dependencies.js:30930
+msgid "You have been kicked from this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40369
-msgid "Would you like this groupchat to be automatically joined upon startup?"
+#: dist/converse-no-dependencies.js:30931
+msgid ""
+"You have been removed from this groupchat because of an affiliation change"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40371
-msgid "The name for this bookmark:"
+#: dist/converse-no-dependencies.js:30932
+msgid ""
+"You have been removed from this groupchat because the groupchat has changed "
+"to members-only and you're not a member"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40372
-msgid "What should your nickname for this groupchat be?"
+#: dist/converse-no-dependencies.js:30933
+msgid ""
+"You have been removed from this groupchat because the service hosting it is "
+"being shut down"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40431
-msgid "Click to toggle the bookmarks list"
+#. XXX: Note the triple underscore function and not double underscore.
+#: dist/converse-no-dependencies.js:30937
+#, javascript-format
+msgid "%1$s has been banned"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40432
-#: dist/converse-no-dependencies.js:53897
-msgid "Leave this groupchat"
+#: dist/converse-no-dependencies.js:30938
+#, javascript-format
+msgid "%1$s's nickname has changed"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40433
-msgid "Remove this bookmark"
+#: dist/converse-no-dependencies.js:30939
+#, javascript-format
+msgid "%1$s has been kicked out"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40435
-#: dist/converse-no-dependencies.js:47475
-#: dist/converse-no-dependencies.js:53899
-msgid "Show more information on this groupchat"
+#: dist/converse-no-dependencies.js:30940
+#, javascript-format
+msgid "%1$s has been removed because of an affiliation change"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40436
-msgid "Bookmarks"
+#: dist/converse-no-dependencies.js:30941
+#, javascript-format
+msgid "%1$s has been removed for not being a member"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40437
-#: dist/converse-no-dependencies.js:47474
-#: dist/converse-no-dependencies.js:53900
-msgid "Click to open this groupchat"
+#: dist/converse-no-dependencies.js:32808
+msgid "You're not allowed to register yourself in this groupchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40927
+#: dist/converse-no-dependencies.js:32810
+msgid ""
+"You're not allowed to register in this groupchat because it's members-only."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:32855
+msgid ""
+"Can't register your nickname in this groupchat, it doesn't support "
+"registration."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:32857
+msgid ""
+"Can't register your nickname in this groupchat, invalid data form supplied."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33573
+#: dist/converse-no-dependencies.js:51253
+#, javascript-format
+msgid "This action was done by %1$s."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33577
+#: dist/converse-no-dependencies.js:51259
+#, javascript-format
+msgid "The reason given is: \"%1$s\"."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33632
+msgid ""
+"The nickname you chose is reserved or currently in use, please choose a "
+"different one."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33655
+msgid "Password incorrect"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33661
+msgid "You are not on the member list of this groupchat."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33665
+msgid "You have been banned from this groupchat."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33671
+msgid "You are not allowed to create new groupchats."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33675
+msgid "Your nickname doesn't conform to this groupchat's policies."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33688
+msgid "This groupchat does not (yet) exist."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33692
+msgid "This groupchat has reached its maximum number of participants."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33696
+msgid "Remote server not found"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:33698
+#, javascript-format
+msgid "The explanation given is: \"%1$s\"."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34072
+#, javascript-format
+msgid "%1$s has invited you to join a groupchat: %2$s"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34074
+#, javascript-format
+msgid ""
+"%1$s has invited you to join a groupchat: %2$s, and left the following "
+"reason: \"%3$s\""
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34806
+#: dist/converse-no-dependencies.js:40146
+#: dist/converse-no-dependencies.js:50428
+#: dist/converse-no-dependencies.js:50434
+#: dist/converse-no-dependencies.js:52698
+#: dist/converse-no-dependencies.js:53250
+#: dist/converse-no-dependencies.js:53699
+#: dist/converse-no-dependencies.js:53703
+#: dist/converse-no-dependencies.js:53750
+#: dist/converse-no-dependencies.js:57471
+msgid "Error"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34806
+msgid "Sorry, something went wrong while trying to save your bookmark."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34871
+msgid "Timeout Error"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:34871
+msgid ""
+"The server did not return your bookmarks within the allowed time. You can "
+"reload the page to request them again."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:38190
 #, javascript-format
 msgid "Download audio file \"%1$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40945
+#: dist/converse-no-dependencies.js:38208
 #, javascript-format
 msgid "Download file \"%1$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40960
+#: dist/converse-no-dependencies.js:38223
 #, javascript-format
 msgid "Download image \"%1$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:40992
+#: dist/converse-no-dependencies.js:38255
 msgid "Download"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:41010
+#: dist/converse-no-dependencies.js:38273
 #, javascript-format
 msgid "Download video file \"%1$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:41931
+#: dist/converse-no-dependencies.js:39242
 msgid "Show more"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42004
+#: dist/converse-no-dependencies.js:39325
+#: dist/converse-no-dependencies.js:39327
+#, javascript-format
+msgid "%1$s has retracted this message"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:39344
 msgid "Typing from another device"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42006
+#: dist/converse-no-dependencies.js:39346
 #, javascript-format
 msgid "%1$s is typing"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42010
+#: dist/converse-no-dependencies.js:39350
 msgid "Stopped typing on the other device"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42012
+#: dist/converse-no-dependencies.js:39352
 #, javascript-format
 msgid "%1$s has stopped typing"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42015
-#: dist/converse-no-dependencies.js:43702
+#: dist/converse-no-dependencies.js:39355
+#: dist/converse-no-dependencies.js:41397
 #, javascript-format
 msgid "%1$s has gone away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42418
+#: dist/converse-no-dependencies.js:40006
 msgid "Close this chat box"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42521
+#: dist/converse-no-dependencies.js:40107
 msgid "Sorry, something went wrong while trying to refresh"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42551
-#: dist/converse-no-dependencies.js:54660
+#: dist/converse-no-dependencies.js:40137
+#: dist/converse-no-dependencies.js:57442
 msgid "Are you sure you want to remove this contact?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42560
-#: dist/converse-no-dependencies.js:54690
+#: dist/converse-no-dependencies.js:40146
+#: dist/converse-no-dependencies.js:57471
 #, javascript-format
 msgid "Sorry, there was an error while trying to remove %1$s as a contact."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42651
-#: dist/converse-no-dependencies.js:42691
+#: dist/converse-no-dependencies.js:40238
+#: dist/converse-no-dependencies.js:40278
 msgid "You have unread messages"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42685
+#: dist/converse-no-dependencies.js:40272
 msgid "Hidden message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42685
+#: dist/converse-no-dependencies.js:40272
 msgid "Message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42686
+#: dist/converse-no-dependencies.js:40273
 msgid "Send"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42687
+#: dist/converse-no-dependencies.js:40274
 msgid "Optional hint"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42757
+#: dist/converse-no-dependencies.js:40344
 msgid "Choose a file to send"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42857
+#: dist/converse-no-dependencies.js:40439
 msgid "Click to write as a normal (non-spoiler) message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42859
+#: dist/converse-no-dependencies.js:40441
 msgid "Click to write your message as a spoiler"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42863
+#: dist/converse-no-dependencies.js:40445
 msgid "Clear all messages"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42864
+#: dist/converse-no-dependencies.js:40446
 msgid "Message characters remaining"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:42869
+#: dist/converse-no-dependencies.js:40451
 msgid "Start a call"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43297
+#: dist/converse-no-dependencies.js:40893
 msgid "Remove messages"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43297
+#: dist/converse-no-dependencies.js:40893
+msgid "Close this chat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:40893
 msgid "Write in the third person"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43297
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:40893
+#: dist/converse-no-dependencies.js:50987
 msgid "Show this menu"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43513
+#: dist/converse-no-dependencies.js:41139
+#: dist/converse-no-dependencies.js:50311
+msgid ""
+"Be aware that other XMPP/Jabber clients (and servers) may not yet support "
+"retractions and that this message may not be removed everywhere."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:41140
+#: dist/converse-no-dependencies.js:50318
+msgid "Are you sure you want to retract this message?"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:41147
+#: dist/converse-no-dependencies.js:50325
+msgid "Confirm"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:41181
 msgid ""
 "You have an unsent message which will be lost if you continue. Are you sure?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43595
+#: dist/converse-no-dependencies.js:41271
 msgid "Are you sure you want to clear the messages from this conversation?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43700
+#: dist/converse-no-dependencies.js:41395
 #, javascript-format
 msgid "%1$s has gone offline"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43704
+#: dist/converse-no-dependencies.js:41399
 #, javascript-format
 msgid "%1$s is busy"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:43706
+#: dist/converse-no-dependencies.js:41401
 #, javascript-format
 msgid "%1$s is online"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:44393
+#: dist/converse-no-dependencies.js:42864
+msgid "My contacts"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:42865
+msgid "Pending contacts"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:42866
+msgid "Contact requests"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:42867
+msgid "Ungrouped"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:43508
+#, javascript-format
+msgid "Sorry, there was an error while trying to add %1$s as a contact."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:43795
+msgid "This client does not allow presence subscriptions"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:43905
+msgid "Click to hide these contacts"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46188
+#, javascript-format
+msgid "Are you sure you want to remove the bookmark \"%1$s\"?"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46217
+#: dist/converse-no-dependencies.js:46357
+#: dist/converse-no-dependencies.js:56651
+msgid "Unbookmark this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46217
+#: dist/converse-no-dependencies.js:46291
+#: dist/converse-no-dependencies.js:56649
+msgid "Bookmark this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46292
+msgid "Would you like this groupchat to be automatically joined upon startup?"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46294
+msgid "The name for this bookmark:"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46295
+msgid "What should your nickname for this groupchat be?"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46354
+msgid "Click to toggle the bookmarks list"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46355
+#: dist/converse-no-dependencies.js:56650
+msgid "Leave this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46356
+msgid "Remove this bookmark"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46358
+#: dist/converse-no-dependencies.js:49907
+#: dist/converse-no-dependencies.js:56652
+msgid "Show more information on this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46359
+msgid "Bookmarks"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46360
+#: dist/converse-no-dependencies.js:49906
+#: dist/converse-no-dependencies.js:56653
+msgid "Click to open this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:46971
 msgid "Username"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:44393
+#: dist/converse-no-dependencies.js:46971
 msgid "user@domain"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:44413
-#: dist/converse-no-dependencies.js:49209
-#: dist/converse-no-dependencies.js:54204
+#: dist/converse-no-dependencies.js:46991
+#: dist/converse-no-dependencies.js:51871
+#: dist/converse-no-dependencies.js:56957
 msgid "Please enter a valid XMPP address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:44513
+#: dist/converse-no-dependencies.js:47091
 msgid "Chat Contacts"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:44513
+#: dist/converse-no-dependencies.js:47091
 msgid "Toggle chat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:45567
+#: dist/converse-no-dependencies.js:48217
 msgid "Insert emojis"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:46215
-#: dist/converse-no-dependencies.js:46253
+#: dist/converse-no-dependencies.js:48633
+#: dist/converse-no-dependencies.js:48671
 msgid "Minimize this chat box"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:46564
+#: dist/converse-no-dependencies.js:48990
 msgid "Click to restore this chat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:46733
+#: dist/converse-no-dependencies.js:49159
 msgid "Minimized"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47127
+#: dist/converse-no-dependencies.js:49559
 msgid "Description:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47128
+#: dist/converse-no-dependencies.js:49560
 msgid "Groupchat Address (JID):"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47129
+#: dist/converse-no-dependencies.js:49561
 msgid "Participants:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47130
+#: dist/converse-no-dependencies.js:49562
 msgid "Features:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47131
+#: dist/converse-no-dependencies.js:49563
 msgid "Requires authentication"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47133
+#: dist/converse-no-dependencies.js:49565
 msgid "Requires an invitation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47135
+#: dist/converse-no-dependencies.js:49567
 msgid "Non-anonymous"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47137
+#: dist/converse-no-dependencies.js:49569
 msgid "Permanent"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47141
+#: dist/converse-no-dependencies.js:49573
 msgid "Unmoderated"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47346
+#: dist/converse-no-dependencies.js:49778
 msgid "Affiliation changed"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47369
+#: dist/converse-no-dependencies.js:49801
 msgid "Sorry, something went wrong while trying to set the affiliation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47385
+#: dist/converse-no-dependencies.js:49817
 msgid "Role changed"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47398
+#: dist/converse-no-dependencies.js:49830
 msgid "You're not allowed to make that change"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47400
+#: dist/converse-no-dependencies.js:49832
 msgid "Sorry, something went wrong while trying to set the role"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47430
+#: dist/converse-no-dependencies.js:49862
 msgid "Query for Groupchats"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47431
+#: dist/converse-no-dependencies.js:49863
 msgid "Server address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47432
+#: dist/converse-no-dependencies.js:49864
 msgid "Show groupchats"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47434
+#: dist/converse-no-dependencies.js:49866
 msgid "conference.example.org"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47485
+#: dist/converse-no-dependencies.js:49917
 msgid "No groupchats found"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47500
+#: dist/converse-no-dependencies.js:49932
 msgid "Groupchats found:"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47566
+#: dist/converse-no-dependencies.js:49998
 msgid "name@conference.example.org"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47572
+#: dist/converse-no-dependencies.js:50004
 msgid "Groupchat name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47572
+#: dist/converse-no-dependencies.js:50004
 msgid "Groupchat address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47641
+#: dist/converse-no-dependencies.js:50073
 #, javascript-format
 msgid "Groupchat info for %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47872
+#: dist/converse-no-dependencies.js:50338
+msgid "You are about to retract this message."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50338
+msgid ""
+"You may optionally include a message, explaining the reason for the "
+"retraction."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50345
+msgid "Message Retraction"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50345
+msgid "Optional reason"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50384
+msgid "Sorry, something went wrong while trying to retract your message."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50426
+msgid "A timeout occurred while trying to retract the message"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50432
+msgid "Sorry, you're not allowed to retract this message."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50511
 #, javascript-format
 msgid "%1$s is no longer an admin of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47874
+#: dist/converse-no-dependencies.js:50513
 #, javascript-format
 msgid "%1$s is no longer an owner of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47876
+#: dist/converse-no-dependencies.js:50515
 #, javascript-format
 msgid "%1$s is no longer banned from this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47880
+#: dist/converse-no-dependencies.js:50519
 #, javascript-format
 msgid "%1$s is no longer a member of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47884
+#: dist/converse-no-dependencies.js:50523
 #, javascript-format
 msgid "%1$s is now a member of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47886
+#: dist/converse-no-dependencies.js:50525
 #, javascript-format
 msgid "%1$s has been banned from this groupchat"
 msgstr ""
 
 #. For example: AppleJack is now an (admin|owner) of this groupchat
-#: dist/converse-no-dependencies.js:47889
+#: dist/converse-no-dependencies.js:50528
 #, javascript-format
 msgid "%1$s is now an %2$s of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47908
+#: dist/converse-no-dependencies.js:50547
 #, javascript-format
 msgid "%1$s is no longer a moderator"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47912
+#: dist/converse-no-dependencies.js:50551
 #, javascript-format
 msgid "%1$s has been given a voice"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47916
+#: dist/converse-no-dependencies.js:50555
 #, javascript-format
 msgid "%1$s has been muted"
 msgstr ""
@@ -1218,277 +1287,281 @@ msgstr ""
 #. We only show this message if the user isn't already
 #. an admin or owner, otherwise this isn't new
 #. information.
-#: dist/converse-no-dependencies.js:47924
+#: dist/converse-no-dependencies.js:50563
 #, javascript-format
 msgid "%1$s is now a moderator"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47936
+#: dist/converse-no-dependencies.js:50575
 msgid "Close and leave this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47937
+#: dist/converse-no-dependencies.js:50576
 msgid "Configure this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47938
+#: dist/converse-no-dependencies.js:50577
 msgid "Show more details about this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:47980
+#: dist/converse-no-dependencies.js:50618
 msgid "Hide the list of participants"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48072
+#: dist/converse-no-dependencies.js:50735
 msgid "Forbidden: you do not have the necessary role in order to do that."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48101
+#: dist/converse-no-dependencies.js:50764
 msgid ""
 "Forbidden: you do not have the necessary affiliation in order to do that."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48108
+#: dist/converse-no-dependencies.js:50771
 #, javascript-format
 msgid ""
 "Error: the \"%1$s\" command takes two arguments, the user's nickname and "
 "optionally a reason."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48126
-#: dist/converse-no-dependencies.js:48139
+#: dist/converse-no-dependencies.js:50789
+#: dist/converse-no-dependencies.js:50802
 msgid "Error: couldn't find a groupchat participant based on your arguments"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48131
+#: dist/converse-no-dependencies.js:50794
 msgid "Error: found multiple groupchat participant based on your arguments"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48225
+#: dist/converse-no-dependencies.js:50887
 msgid ""
 "Sorry, an error happened while running the command. Check your browser's "
 "developer console for details."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48324
+#: dist/converse-no-dependencies.js:50986
 msgid "You can run the following commands"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Change user's affiliation to admin"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Ban user by changing their affiliation to outcast"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Clear the chat area"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
+msgid "Close this groupchat"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:50987
 msgid "Change user role to participant"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Remove this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Kick user from groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Write in 3rd person"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant membership to a user"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Opens up the moderator tools GUI"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Remove user's ability to post messages"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Change your nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant moderator role to user"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant ownership of this groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Register your nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Revoke the user's current affiliation"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Set groupchat subject"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Set groupchat subject (alias for /subject)"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Allow muted user to post messages"
 msgstr ""
 
 #. e.g. Your nickname is "coolguy69"
-#: dist/converse-no-dependencies.js:48361
+#: dist/converse-no-dependencies.js:51023
 #, javascript-format
 msgid "Your nickname is \"%1$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48388
+#: dist/converse-no-dependencies.js:51050
 msgid "Error: invalid number of arguments"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48708
+#: dist/converse-no-dependencies.js:51370
 #, javascript-format
 msgid "%1$s has left and re-entered the groupchat. \"%2$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48710
+#: dist/converse-no-dependencies.js:51372
 #, javascript-format
 msgid "%1$s has left and re-entered the groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48733
+#: dist/converse-no-dependencies.js:51395
 #, javascript-format
 msgid "%1$s has entered the groupchat. \"%2$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48735
+#: dist/converse-no-dependencies.js:51397
 #, javascript-format
 msgid "%1$s has entered the groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48771
+#: dist/converse-no-dependencies.js:51433
 #, javascript-format
 msgid "%1$s has entered and left the groupchat. \"%2$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48773
+#: dist/converse-no-dependencies.js:51435
 #, javascript-format
 msgid "%1$s has entered and left the groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48796
+#: dist/converse-no-dependencies.js:51458
 #, javascript-format
 msgid "%1$s has left the groupchat. \"%2$s\""
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48798
+#: dist/converse-no-dependencies.js:51460
 #, javascript-format
 msgid "%1$s has left the groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48861
+#: dist/converse-no-dependencies.js:51523
 #, javascript-format
 msgid "Topic set by %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48861
+#: dist/converse-no-dependencies.js:51523
 #, javascript-format
 msgid "Topic cleared by %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48895
+#: dist/converse-no-dependencies.js:51557
 msgid "Groupchats"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48896
+#: dist/converse-no-dependencies.js:51558
 msgid "Add a new groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48897
+#: dist/converse-no-dependencies.js:51559
 msgid "Query for groupchats"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48985
+#: dist/converse-no-dependencies.js:51647
 msgid "This groupchat requires a password"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48986
+#: dist/converse-no-dependencies.js:51648
 msgid "Password: "
 msgstr ""
 
-#: dist/converse-no-dependencies.js:48987
+#: dist/converse-no-dependencies.js:51649
 msgid "Submit"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49012
+#: dist/converse-no-dependencies.js:51674
 msgid "Please choose your nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49014
+#: dist/converse-no-dependencies.js:51676
 msgid "Enter groupchat"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49036
+#: dist/converse-no-dependencies.js:51698
 msgid "You need to provide a nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49053
+#: dist/converse-no-dependencies.js:51715
 #, javascript-format
 msgid "Click to mention %1$s in your message."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49054
+#: dist/converse-no-dependencies.js:51716
 msgid "This user is a moderator."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49055
+#: dist/converse-no-dependencies.js:51717
 msgid "This user can send messages in this groupchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49056
+#: dist/converse-no-dependencies.js:51718
 msgid "This user can NOT send messages in this groupchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49057
+#: dist/converse-no-dependencies.js:51719
 msgid "Moderator"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49058
+#: dist/converse-no-dependencies.js:51720
 msgid "Visitor"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49059
+#: dist/converse-no-dependencies.js:51721
 msgid "Owner"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49060
+#: dist/converse-no-dependencies.js:51722
 msgid "Member"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49061
+#: dist/converse-no-dependencies.js:51723
 msgid "Admin"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49117
+#: dist/converse-no-dependencies.js:51779
 msgid "Participants"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49150
-#: dist/converse-no-dependencies.js:49210
+#: dist/converse-no-dependencies.js:51812
+#: dist/converse-no-dependencies.js:51872
 msgid "Invite"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49185
+#: dist/converse-no-dependencies.js:51847
 #, javascript-format
 msgid ""
 "You are about to invite %1$s to the groupchat \"%2$s\". You may optionally "
@@ -1496,426 +1569,450 @@ msgid ""
 msgstr ""
 
 #. workaround for Prosody which doesn't give type "headline"
-#: dist/converse-no-dependencies.js:49602
-#: dist/converse-no-dependencies.js:49608
+#: dist/converse-no-dependencies.js:52370
+#: dist/converse-no-dependencies.js:52376
 #, javascript-format
 msgid "Notification from %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49610
-#: dist/converse-no-dependencies.js:49621
-#: dist/converse-no-dependencies.js:49624
+#: dist/converse-no-dependencies.js:52378
+#: dist/converse-no-dependencies.js:52388
+#: dist/converse-no-dependencies.js:52391
 #, javascript-format
 msgid "%1$s says"
 msgstr ""
 
 #. TODO: we should suppress notifications if we cannot decrypt
 #. the message...
-#: dist/converse-no-dependencies.js:49633
+#: dist/converse-no-dependencies.js:52400
 msgid "OMEMO Message received"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49664
+#: dist/converse-no-dependencies.js:52431
 msgid "has gone offline"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49666
+#: dist/converse-no-dependencies.js:52433
 msgid "has gone away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49668
+#: dist/converse-no-dependencies.js:52435
 msgid "is busy"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49670
+#: dist/converse-no-dependencies.js:52437
 msgid "has come online"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49687
+#: dist/converse-no-dependencies.js:52454
 msgid "wants to be your contact"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49888
+#: dist/converse-no-dependencies.js:52655
 msgid "Your avatar image"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49889
+#: dist/converse-no-dependencies.js:52656
 msgid "Your Profile"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49891
+#: dist/converse-no-dependencies.js:52658
 msgid "Email"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49892
+#: dist/converse-no-dependencies.js:52659
 msgid "Full Name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49893
+#: dist/converse-no-dependencies.js:52660
 msgid "XMPP Address (JID)"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49896
+#: dist/converse-no-dependencies.js:52663
 msgid ""
 "Use commas to separate multiple roles. Your roles are shown next to your "
 "name on your chat messages."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49897
+#: dist/converse-no-dependencies.js:52664
 msgid "URL"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49931
+#: dist/converse-no-dependencies.js:52698
 msgid "Sorry, an error happened while trying to save your profile data."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49931
+#: dist/converse-no-dependencies.js:52698
 msgid "You can check your browser's developer console for any error output."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49978
-#: dist/converse-no-dependencies.js:54384
+#: dist/converse-no-dependencies.js:52745
+#: dist/converse-no-dependencies.js:57137
 msgid "Away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49980
-#: dist/converse-no-dependencies.js:54383
+#: dist/converse-no-dependencies.js:52747
+#: dist/converse-no-dependencies.js:57136
 msgid "Busy"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49982
+#: dist/converse-no-dependencies.js:52749
 msgid "Custom status"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49983
-#: dist/converse-no-dependencies.js:54386
+#: dist/converse-no-dependencies.js:52750
+#: dist/converse-no-dependencies.js:57139
 msgid "Offline"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49984
-#: dist/converse-no-dependencies.js:54381
+#: dist/converse-no-dependencies.js:52751
+#: dist/converse-no-dependencies.js:57134
 msgid "Online"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49986
+#: dist/converse-no-dependencies.js:52753
 msgid "Away for long"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49987
+#: dist/converse-no-dependencies.js:52754
 msgid "Change chat status"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:49988
+#: dist/converse-no-dependencies.js:52755
 msgid "Personal status message"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50021
+#: dist/converse-no-dependencies.js:52788
 msgid "About"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50023
+#: dist/converse-no-dependencies.js:52790
 #, javascript-format
 msgid ""
 "%1$s Open Source %2$s XMPP chat client brought to you by %3$s Opkode %2$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50024
+#: dist/converse-no-dependencies.js:52791
 #, javascript-format
 msgid "%1$s Translate %2$s it into your own language"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50045
+#: dist/converse-no-dependencies.js:52812
 #, javascript-format
 msgid "I am %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50048
+#: dist/converse-no-dependencies.js:52815
 msgid "Change settings"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50049
+#: dist/converse-no-dependencies.js:52816
 msgid "Click to change your chat status"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50050
+#: dist/converse-no-dependencies.js:52817
 msgid "Log out"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50051
+#: dist/converse-no-dependencies.js:52818
 msgid "Show details about this chat client"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50052
+#: dist/converse-no-dependencies.js:52819
 msgid "Your profile"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50087
+#: dist/converse-no-dependencies.js:52854
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50095
-#: dist/converse-no-dependencies.js:50105
+#: dist/converse-no-dependencies.js:52862
+#: dist/converse-no-dependencies.js:52872
 msgid "online"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50097
+#: dist/converse-no-dependencies.js:52864
 msgid "busy"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50099
+#: dist/converse-no-dependencies.js:52866
 msgid "away for long"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50101
+#: dist/converse-no-dependencies.js:52868
 msgid "away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50103
+#: dist/converse-no-dependencies.js:52870
 msgid "offline"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50483
+#: dist/converse-no-dependencies.js:53250
 msgid "Sorry, an error occurred while trying to remove the devices."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50492
+#: dist/converse-no-dependencies.js:53259
 msgid ""
 "Are you sure you want to generate new OMEMO keys? This will remove your old "
 "keys and all previously encrypted messages will no longer be decryptable on "
 "this device."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50924
+#: dist/converse-no-dependencies.js:53691
 #, javascript-format
 msgid ""
 "Sorry, we're unable to send an encrypted message because %1$s requires you "
 "to be subscribed to their presence in order to see their OMEMO information"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50926
+#: dist/converse-no-dependencies.js:53693
 #, javascript-format
 msgid ""
 "Sorry, we're unable to send an encrypted message because the remote server "
 "for %1$s could not be found"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50928
+#: dist/converse-no-dependencies.js:53695
 msgid "Unable to send an encrypted message due to an unexpected error."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50978
+#: dist/converse-no-dependencies.js:53745
 msgid ""
 "Cannot use end-to-end encryption in this groupchat, either the groupchat has "
 "some anonymity or not all participants support OMEMO."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:50980
+#: dist/converse-no-dependencies.js:53747
 #, javascript-format
 msgid ""
 "Cannot use end-to-end encryption because %1$s uses a client that doesn't "
 "support OMEMO."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:51276
+#: dist/converse-no-dependencies.js:54040
 msgid ""
 "Sorry, no devices found to which we can send an OMEMO encrypted message."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:51406
+#: dist/converse-no-dependencies.js:54170
 msgid ""
 "This is an OMEMO encrypted message which your client doesn’t seem to "
 "support. Find more information on https://conversations.im/omemo"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:52400
+#: dist/converse-no-dependencies.js:55152
 #, javascript-format
 msgid ""
 "%1$s doesn't appear to have a client that supports OMEMO. Encrypted chat "
 "will no longer be possible in this grouchat."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53066
+#: dist/converse-no-dependencies.js:55819
 msgid " e.g. conversejs.org"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53182
+#: dist/converse-no-dependencies.js:55935
 msgid "Fetch registration form"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53183
+#: dist/converse-no-dependencies.js:55936
 msgid "Tip: A list of public XMPP providers is available"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53184
+#: dist/converse-no-dependencies.js:55937
 msgid "here"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53235
+#: dist/converse-no-dependencies.js:55988
 msgid "Sorry, we're unable to connect to your chosen provider."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53251
+#: dist/converse-no-dependencies.js:56004
 msgid ""
 "Sorry, the given provider does not support in band account registration. "
 "Please try with a different provider."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53277
+#: dist/converse-no-dependencies.js:56030
 #, javascript-format
 msgid ""
 "Something went wrong while establishing a connection with \"%1$s\". Are you "
 "sure it exists?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53468
+#: dist/converse-no-dependencies.js:56220
 msgid "Now logging you in"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53472
+#: dist/converse-no-dependencies.js:56224
 msgid "Registered successfully"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53584
+#: dist/converse-no-dependencies.js:56336
 msgid ""
 "The provider rejected your registration attempt. Please check the values you "
 "entered for correctness."
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53895
+#: dist/converse-no-dependencies.js:56648
 msgid "Click to toggle the list of open groupchats"
 msgstr ""
 
 #. Note to translators, "Open Groupchats" refers to groupchats that are open, NOT a command.
-#: dist/converse-no-dependencies.js:53906
+#: dist/converse-no-dependencies.js:56659
 msgid "Open Groupchats"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:53973
+#: dist/converse-no-dependencies.js:56726
 #, javascript-format
 msgid "Are you sure you want to leave the groupchat %1$s?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54179
+#: dist/converse-no-dependencies.js:56932
 msgid "This contact is busy"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54180
+#: dist/converse-no-dependencies.js:56933
 msgid "This contact is online"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54181
+#: dist/converse-no-dependencies.js:56934
 msgid "This contact is offline"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54182
+#: dist/converse-no-dependencies.js:56935
 msgid "This contact is unavailable"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54183
+#: dist/converse-no-dependencies.js:56936
 msgid "This contact is away for an extended period"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54184
+#: dist/converse-no-dependencies.js:56937
 msgid "This contact is away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54196
+#: dist/converse-no-dependencies.js:56949
 msgid "Contact name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54196
+#: dist/converse-no-dependencies.js:56949
 msgid "Optional nickname"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54199
+#: dist/converse-no-dependencies.js:56952
 msgid "Add a Contact"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54200
+#: dist/converse-no-dependencies.js:56953
 msgid "XMPP Address"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54202
+#: dist/converse-no-dependencies.js:56955
 msgid "name@example.org"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54203
+#: dist/converse-no-dependencies.js:56956
 msgid "Add"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54293
+#: dist/converse-no-dependencies.js:57046
 msgid "Sorry, could not find a contact with that name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54318
+#: dist/converse-no-dependencies.js:57071
 msgid "This contact has already been added"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54375
+#: dist/converse-no-dependencies.js:57128
 msgid "Filter"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54376
+#: dist/converse-no-dependencies.js:57129
 msgid "Filter by contact name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54377
+#: dist/converse-no-dependencies.js:57130
 msgid "Filter by group name"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54378
+#: dist/converse-no-dependencies.js:57131
 msgid "Filter by status"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54379
+#: dist/converse-no-dependencies.js:57132
 msgid "Any"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54380
+#: dist/converse-no-dependencies.js:57133
 msgid "Unread"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54382
+#: dist/converse-no-dependencies.js:57135
 msgid "Chatty"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54385
+#: dist/converse-no-dependencies.js:57138
 msgid "Extended Away"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54550
-#: dist/converse-no-dependencies.js:54605
+#: dist/converse-no-dependencies.js:57329
+#: dist/converse-no-dependencies.js:57384
 #, javascript-format
 msgid "Click to remove %1$s as a contact"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54559
+#: dist/converse-no-dependencies.js:57338
 #, javascript-format
 msgid "Click to accept the contact request from %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54560
+#: dist/converse-no-dependencies.js:57339
 #, javascript-format
 msgid "Click to decline the contact request from %1$s"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54604
+#: dist/converse-no-dependencies.js:57383
 #, javascript-format
 msgid "Click to chat with %1$s (JID: %2$s)"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:54743
+#: dist/converse-no-dependencies.js:57524
 msgid "Are you sure you want to decline this contact request?"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:55059
+#: dist/converse-no-dependencies.js:57851
 msgid "Contacts"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:55060
+#: dist/converse-no-dependencies.js:57852
 msgid "Add a contact"
 msgstr ""
 
-#: dist/converse-no-dependencies.js:55061
+#: dist/converse-no-dependencies.js:57853
 msgid "Re-sync your contacts"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58346
+msgid "send"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58399
+msgid "Choose the Service-admin Function"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58400
+msgid "Announcement"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58610
+msgid "The command was executed successfully."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58613
+msgid "The command was NOT executed successfully for the following reason: "
+msgstr ""
+
+#: dist/converse-no-dependencies.js:58621
+msgid "-- sent from "
 msgstr ""

--- a/locale/de/LC_MESSAGES/converse.po
+++ b/locale/de/LC_MESSAGES/converse.po
@@ -22,90 +22,107 @@ msgstr ""
 "lang: de\n"
 "plural_forms: nplurals=2; plural=(n != 1);\n"
 
-#: dist/converse-no-dependencies.js:7899
+#: dist/converse-no-dependencies.js:5738
+msgid "OK"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:5740 dist/converse-no-dependencies.js:9237
+#: dist/converse-no-dependencies.js:10161
+#: dist/converse-no-dependencies.js:46293
+#: dist/converse-no-dependencies.js:52748
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: dist/converse-no-dependencies.js:7807
 msgid "Uploading file:"
 msgstr "Lade Datei hoch:"
 
-#: dist/converse-no-dependencies.js:8008
+#: dist/converse-no-dependencies.js:7931
 msgid "This message has been edited"
 msgstr "Diese Nachricht wurde geändert"
 
-#: dist/converse-no-dependencies.js:8014
+#: dist/converse-no-dependencies.js:7937
 msgid "Edit this message"
 msgstr "Nachricht bearbeiten"
 
-#: dist/converse-no-dependencies.js:8030
+#: dist/converse-no-dependencies.js:7943
+#, fuzzy
+msgid "Retract this message"
+msgstr "Nachricht bearbeiten"
+
+#: dist/converse-no-dependencies.js:7959
 msgid "Message versions"
 msgstr "Nachrichtenarchivierung"
 
-#: dist/converse-no-dependencies.js:8044 dist/converse-no-dependencies.js:8321
-#: dist/converse-no-dependencies.js:8435 dist/converse-no-dependencies.js:9009
-#: dist/converse-no-dependencies.js:49890
-#: dist/converse-no-dependencies.js:49979
+#: dist/converse-no-dependencies.js:7973 dist/converse-no-dependencies.js:8250
+#: dist/converse-no-dependencies.js:8364 dist/converse-no-dependencies.js:9069
+#: dist/converse-no-dependencies.js:52657
+#: dist/converse-no-dependencies.js:52746
+#: dist/converse-no-dependencies.js:58460
 msgid "Close"
 msgstr "Schließen"
 
-#: dist/converse-no-dependencies.js:8325
+#: dist/converse-no-dependencies.js:8254
 msgid "The User's Profile Image"
 msgstr "Benutzerprofilbild"
 
-#: dist/converse-no-dependencies.js:8335
+#: dist/converse-no-dependencies.js:8264
 msgid "Full Name:"
 msgstr "Name:"
 
-#: dist/converse-no-dependencies.js:8341 dist/converse-no-dependencies.js:8517
+#: dist/converse-no-dependencies.js:8270 dist/converse-no-dependencies.js:8570
 msgid "XMPP Address:"
 msgstr "XMPP Adresse:"
 
-#: dist/converse-no-dependencies.js:8349
+#: dist/converse-no-dependencies.js:8278
 msgid "Nickname:"
 msgstr "Spitzname:"
 
-#: dist/converse-no-dependencies.js:8357
+#: dist/converse-no-dependencies.js:8286
 msgid "URL:"
 msgstr "URL:"
 
-#: dist/converse-no-dependencies.js:8367
+#: dist/converse-no-dependencies.js:8296
 msgid "Email:"
 msgstr "E-Mail:"
 
-#: dist/converse-no-dependencies.js:8377
+#: dist/converse-no-dependencies.js:8306
 msgid "Role:"
 msgstr "Rolle:"
 
-#: dist/converse-no-dependencies.js:8385
+#: dist/converse-no-dependencies.js:8314
 msgid "OMEMO Fingerprints"
 msgstr "OMEMO Fingerabdrücke"
 
-#: dist/converse-no-dependencies.js:8409
+#: dist/converse-no-dependencies.js:8338
 msgid "Trusted"
 msgstr "Vertrauenswürdig"
 
-#: dist/converse-no-dependencies.js:8423
+#: dist/converse-no-dependencies.js:8352
 msgid "Untrusted"
 msgstr "Nicht vertrauenswürdig"
 
-#: dist/converse-no-dependencies.js:8437
+#: dist/converse-no-dependencies.js:8366
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: dist/converse-no-dependencies.js:8441
+#: dist/converse-no-dependencies.js:8370
 msgid "Remove as contact"
 msgstr "Kontakt entfernen"
 
-#: dist/converse-no-dependencies.js:8523
+#: dist/converse-no-dependencies.js:8576
 msgid "Password:"
 msgstr "Passwort:"
 
-#: dist/converse-no-dependencies.js:8525
+#: dist/converse-no-dependencies.js:8578
 msgid "password"
 msgstr "passwort"
 
-#: dist/converse-no-dependencies.js:8535
+#: dist/converse-no-dependencies.js:8588
 msgid "This is a trusted device"
 msgstr "Diesem Gerät wird vertraut"
 
-#: dist/converse-no-dependencies.js:8537
+#: dist/converse-no-dependencies.js:8590
 msgid ""
 "To improve performance, we cache your data in this browser. Uncheck this box "
 "if this is a public computer or if you want your data to be deleted when you "
@@ -121,218 +138,212 @@ msgstr ""
 "gelöscht werden. Bitte beachten Sie, dass bei Verwendung eines nicht "
 "vertrauenswürdigen Geräts die OMEMO-Verschlüsselung NICHT verfügbar ist."
 
-#: dist/converse-no-dependencies.js:8541
+#: dist/converse-no-dependencies.js:8594
 msgid "Log in"
 msgstr "Anmelden"
 
-#: dist/converse-no-dependencies.js:8547
+#: dist/converse-no-dependencies.js:8600
 msgid "Click here to log in anonymously"
 msgstr "Hier klicken, um sich anonym anzumelden"
 
-#: dist/converse-no-dependencies.js:8593
+#: dist/converse-no-dependencies.js:8646
 msgid "Search"
 msgstr "Suchen"
 
-#: dist/converse-no-dependencies.js:8627
+#: dist/converse-no-dependencies.js:8680
 msgid "Search results"
 msgstr "Suchergebnisse"
 
-#: dist/converse-no-dependencies.js:8777
+#: dist/converse-no-dependencies.js:8830
 msgid "Enter a new Groupchat"
 msgstr "Einem neuen Gruppenchat beitreten"
 
-#: dist/converse-no-dependencies.js:8785 dist/converse-no-dependencies.js:49013
-#: dist/converse-no-dependencies.js:49894
+#: dist/converse-no-dependencies.js:8838 dist/converse-no-dependencies.js:51675
+#: dist/converse-no-dependencies.js:52661
 msgid "Nickname"
 msgstr "Spitzname"
 
-#: dist/converse-no-dependencies.js:8787
+#: dist/converse-no-dependencies.js:8840
 msgid "This field is required"
 msgstr "Dieses Feld ist ein Pflichtfeld"
 
-#: dist/converse-no-dependencies.js:8793
+#: dist/converse-no-dependencies.js:8846
 msgid "Join"
 msgstr "Betreten"
 
-#: dist/converse-no-dependencies.js:8833
+#: dist/converse-no-dependencies.js:8891
 msgid "You're not allowed to send messages in this room"
 msgstr "Sie dürfen in diesem Gruppenchat keine Nachrichten senden"
 
-#: dist/converse-no-dependencies.js:8847
+#: dist/converse-no-dependencies.js:8907
 msgid "This groupchat no longer exists"
 msgstr "Dieser Gruppenchat existiert nicht mehr"
 
-#: dist/converse-no-dependencies.js:8853
+#: dist/converse-no-dependencies.js:8913
 msgid "The conversation has moved. Click below to enter."
 msgstr "Das Gespräch wurde verschoben. Klicken Sie unten, um einzutreten."
 
-#: dist/converse-no-dependencies.js:8875
+#: dist/converse-no-dependencies.js:8935
 msgid "Name"
 msgstr "Name"
 
-#: dist/converse-no-dependencies.js:8879
+#: dist/converse-no-dependencies.js:8939
 msgid "Groupchat address (JID)"
 msgstr "Gruppenchat-Adresse (JID)"
 
-#: dist/converse-no-dependencies.js:8883
+#: dist/converse-no-dependencies.js:8943
 msgid "Description"
 msgstr "Beschreibung"
 
-#: dist/converse-no-dependencies.js:8889
+#: dist/converse-no-dependencies.js:8949
 msgid "Topic"
 msgstr "Thema"
 
-#: dist/converse-no-dependencies.js:8893
+#: dist/converse-no-dependencies.js:8953
 msgid "Topic author"
 msgstr "Autor des Themas"
 
-#: dist/converse-no-dependencies.js:8899
+#: dist/converse-no-dependencies.js:8959
 msgid "Online users"
 msgstr "Online"
 
-#: dist/converse-no-dependencies.js:8903 dist/converse-no-dependencies.js:9043
+#: dist/converse-no-dependencies.js:8963 dist/converse-no-dependencies.js:9103
 msgid "Features"
 msgstr "Funktionen"
 
-#: dist/converse-no-dependencies.js:8907 dist/converse-no-dependencies.js:9049
+#: dist/converse-no-dependencies.js:8967 dist/converse-no-dependencies.js:9109
 msgid "Password protected"
 msgstr "Passwortgeschützt"
 
-#: dist/converse-no-dependencies.js:8909 dist/converse-no-dependencies.js:9047
+#: dist/converse-no-dependencies.js:8969 dist/converse-no-dependencies.js:9107
 msgid "This groupchat requires a password before entry"
 msgstr "Dieser Gruppenchat erfordert ein Passwort"
 
-#: dist/converse-no-dependencies.js:8915
+#: dist/converse-no-dependencies.js:8975
 msgid "No password required"
 msgstr "Kein Passwort benötigt"
 
-#: dist/converse-no-dependencies.js:8917 dist/converse-no-dependencies.js:9055
+#: dist/converse-no-dependencies.js:8977 dist/converse-no-dependencies.js:9115
 msgid "This groupchat does not require a password upon entry"
 msgstr "Dieser Gruppenchat erfordert kein Passwort"
 
-#: dist/converse-no-dependencies.js:8923 dist/converse-no-dependencies.js:9065
-#: dist/converse-no-dependencies.js:47132
+#: dist/converse-no-dependencies.js:8983 dist/converse-no-dependencies.js:9125
+#: dist/converse-no-dependencies.js:49564
 msgid "Hidden"
 msgstr "Ausblenden"
 
-#: dist/converse-no-dependencies.js:8925 dist/converse-no-dependencies.js:9063
+#: dist/converse-no-dependencies.js:8985 dist/converse-no-dependencies.js:9123
 msgid "This groupchat is not publicly searchable"
 msgstr "Dieser Gruppenchat ist nicht öffentlich auffindbar"
 
-#: dist/converse-no-dependencies.js:8931 dist/converse-no-dependencies.js:9073
-#: dist/converse-no-dependencies.js:47138
+#: dist/converse-no-dependencies.js:8991 dist/converse-no-dependencies.js:9133
+#: dist/converse-no-dependencies.js:49570
 msgid "Public"
 msgstr "Öffentlich"
 
-#: dist/converse-no-dependencies.js:8933 dist/converse-no-dependencies.js:9071
+#: dist/converse-no-dependencies.js:8993 dist/converse-no-dependencies.js:9131
 msgid "This groupchat is publicly searchable"
 msgstr "Dieser Gruppenchat ist öffentlich auffindbar"
 
-#: dist/converse-no-dependencies.js:8939 dist/converse-no-dependencies.js:9081
+#: dist/converse-no-dependencies.js:8999 dist/converse-no-dependencies.js:9141
 msgid "Members only"
 msgstr "Nur Mitglieder"
 
-#: dist/converse-no-dependencies.js:8941
+#: dist/converse-no-dependencies.js:9001
 msgid "This groupchat is restricted to members only"
 msgstr "Dieser Gruppenchat ist nur für Mitglieder zugänglich"
 
-#: dist/converse-no-dependencies.js:8947 dist/converse-no-dependencies.js:9089
-#: dist/converse-no-dependencies.js:47136
+#: dist/converse-no-dependencies.js:9007 dist/converse-no-dependencies.js:9149
+#: dist/converse-no-dependencies.js:49568
 msgid "Open"
 msgstr "Offen"
 
-#: dist/converse-no-dependencies.js:8949 dist/converse-no-dependencies.js:9087
+#: dist/converse-no-dependencies.js:9009 dist/converse-no-dependencies.js:9147
 msgid "Anyone can join this groupchat"
 msgstr "Jeder kann diesem Gruppenchat beitreten"
 
-#: dist/converse-no-dependencies.js:8955 dist/converse-no-dependencies.js:9097
+#: dist/converse-no-dependencies.js:9015 dist/converse-no-dependencies.js:9157
 msgid "Persistent"
 msgstr "Dauerhaft"
 
-#: dist/converse-no-dependencies.js:8957 dist/converse-no-dependencies.js:9095
+#: dist/converse-no-dependencies.js:9017 dist/converse-no-dependencies.js:9155
 msgid "This groupchat persists even if it's unoccupied"
 msgstr "Dieser Gruppenchat bleibt bestehen, auch wenn er nicht besetzt ist"
 
-#: dist/converse-no-dependencies.js:8963 dist/converse-no-dependencies.js:9105
-#: dist/converse-no-dependencies.js:47140
+#: dist/converse-no-dependencies.js:9023 dist/converse-no-dependencies.js:9165
+#: dist/converse-no-dependencies.js:49572
 msgid "Temporary"
 msgstr "Vorübergehend"
 
-#: dist/converse-no-dependencies.js:8965 dist/converse-no-dependencies.js:9103
+#: dist/converse-no-dependencies.js:9025 dist/converse-no-dependencies.js:9163
 msgid "This groupchat will disappear once the last person leaves"
 msgstr ""
 "Dieser Gruppenchat verschwindet, sobald die letzte Person den Gruppenchat "
 "verlässt"
 
-#: dist/converse-no-dependencies.js:8971 dist/converse-no-dependencies.js:9113
+#: dist/converse-no-dependencies.js:9031 dist/converse-no-dependencies.js:9173
 msgid "Not anonymous"
 msgstr "Nicht anonym"
 
-#: dist/converse-no-dependencies.js:8973 dist/converse-no-dependencies.js:9111
+#: dist/converse-no-dependencies.js:9033 dist/converse-no-dependencies.js:9171
 msgid "All other groupchat participants can see your XMPP address"
 msgstr "Jeder in dem Gruppenchat kann ihre XMPP-Adresse sehen"
 
-#: dist/converse-no-dependencies.js:8979 dist/converse-no-dependencies.js:9121
-#: dist/converse-no-dependencies.js:47139
+#: dist/converse-no-dependencies.js:9039 dist/converse-no-dependencies.js:9181
+#: dist/converse-no-dependencies.js:49571
 msgid "Semi-anonymous"
 msgstr "Teilweise anonym"
 
-#: dist/converse-no-dependencies.js:8981 dist/converse-no-dependencies.js:9119
+#: dist/converse-no-dependencies.js:9041 dist/converse-no-dependencies.js:9179
 msgid "Only moderators can see your XMPP address"
 msgstr "Nur Moderatoren können deine XMPP-Adresse sehen"
 
-#: dist/converse-no-dependencies.js:8987 dist/converse-no-dependencies.js:9129
-#: dist/converse-no-dependencies.js:47134
+#: dist/converse-no-dependencies.js:9047 dist/converse-no-dependencies.js:9189
+#: dist/converse-no-dependencies.js:49566
 msgid "Moderated"
 msgstr "Moderiert"
 
-#: dist/converse-no-dependencies.js:8989 dist/converse-no-dependencies.js:9127
+#: dist/converse-no-dependencies.js:9049 dist/converse-no-dependencies.js:9187
 msgid ""
 "Participants entering this groupchat need to request permission to write"
 msgstr ""
 "Teilnehmer, die diesem Gruppenchat beitreten, müssen die Erlaubnis zum "
 "Schreiben anfordern"
 
-#: dist/converse-no-dependencies.js:8995 dist/converse-no-dependencies.js:9137
+#: dist/converse-no-dependencies.js:9055 dist/converse-no-dependencies.js:9197
 msgid "Not moderated"
 msgstr "Nicht moderiert"
 
-#: dist/converse-no-dependencies.js:8997 dist/converse-no-dependencies.js:9135
+#: dist/converse-no-dependencies.js:9057 dist/converse-no-dependencies.js:9195
 msgid "Participants entering this groupchat can write right away"
 msgstr "Teilnehmer, die diesem Gruppenchat beitreten, können sofort schreiben"
 
-#: dist/converse-no-dependencies.js:9003 dist/converse-no-dependencies.js:9145
+#: dist/converse-no-dependencies.js:9063 dist/converse-no-dependencies.js:9205
 msgid "Message archiving"
 msgstr "Nachrichtenarchivierung"
 
-#: dist/converse-no-dependencies.js:9005 dist/converse-no-dependencies.js:9143
+#: dist/converse-no-dependencies.js:9065 dist/converse-no-dependencies.js:9203
 msgid "Messages are archived on the server"
 msgstr "Nachrichten werden auf dem Server archiviert"
 
-#: dist/converse-no-dependencies.js:9057
+#: dist/converse-no-dependencies.js:9117
 msgid "No password"
 msgstr "Kein Passwort"
 
-#: dist/converse-no-dependencies.js:9079
+#: dist/converse-no-dependencies.js:9139
 msgid "this groupchat is restricted to members only"
 msgstr "Dieser Gruppenchat ist nur für Mitglieder zugänglich"
 
-#: dist/converse-no-dependencies.js:9175 dist/converse-no-dependencies.js:40373
-#: dist/converse-no-dependencies.js:49985
+#: dist/converse-no-dependencies.js:9235 dist/converse-no-dependencies.js:46296
+#: dist/converse-no-dependencies.js:52752
 msgid "Save"
 msgstr "Speichern"
 
-#: dist/converse-no-dependencies.js:9177 dist/converse-no-dependencies.js:10101
-#: dist/converse-no-dependencies.js:40370
-#: dist/converse-no-dependencies.js:49981
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: dist/converse-no-dependencies.js:9312
+#: dist/converse-no-dependencies.js:9372
 msgid "Moderator Tools"
 msgstr "Moderatoren-Tools"
 
-#: dist/converse-no-dependencies.js:9314
+#: dist/converse-no-dependencies.js:9374
 msgid ""
 "Roles are assigned to users to grant or deny them certain abilities in a "
 "multi-user chat. They're assigned either explicitly or implicitly as part of "
@@ -345,11 +356,11 @@ msgstr ""
 "die nicht auf eine Zugehörigkeit zurückzuführen ist, ist nur für die Dauer "
 "der Sitzung des Benutzers gültig."
 
-#: dist/converse-no-dependencies.js:9316 dist/converse-no-dependencies.js:49895
+#: dist/converse-no-dependencies.js:9376 dist/converse-no-dependencies.js:52662
 msgid "Role"
 msgstr "Rolle"
 
-#: dist/converse-no-dependencies.js:9328 dist/converse-no-dependencies.js:9352
+#: dist/converse-no-dependencies.js:9388 dist/converse-no-dependencies.js:9412
 msgid ""
 "Moderators are privileged users who can change the roles of other users "
 "(except those with admin or owner affiliations."
@@ -357,39 +368,39 @@ msgstr ""
 "Moderatoren sind privilegierte Benutzer, die die Rollen anderer Benutzer "
 "ändern können (außer denen mit Administrator- oder Eigentümerzugehörigkeit)."
 
-#: dist/converse-no-dependencies.js:9334 dist/converse-no-dependencies.js:9358
+#: dist/converse-no-dependencies.js:9394 dist/converse-no-dependencies.js:9418
 msgid "The default role, implies that you can read and write messages."
 msgstr ""
 "Die Standardrolle bedeutet, dass Sie Nachrichten lesen und schreiben können."
 
-#: dist/converse-no-dependencies.js:9340 dist/converse-no-dependencies.js:9364
+#: dist/converse-no-dependencies.js:9400 dist/converse-no-dependencies.js:9424
 msgid ""
 "Visitors aren't allowed to write messages in a moderated multi-user chat."
 msgstr ""
 "Besucher dürfen keine Nachrichten in einem moderierten Mehrbenutzer-Chat "
 "schreiben."
 
-#: dist/converse-no-dependencies.js:9348 dist/converse-no-dependencies.js:9444
+#: dist/converse-no-dependencies.js:9408 dist/converse-no-dependencies.js:9504
 msgid "Show users"
 msgstr "Nutzer anzeigen"
 
-#: dist/converse-no-dependencies.js:9374
+#: dist/converse-no-dependencies.js:9434
 msgid "No users with that role found."
 msgstr "Keine Nutzer mit dieser Rolle gefunden."
 
-#: dist/converse-no-dependencies.js:9390
+#: dist/converse-no-dependencies.js:9450
 msgid "New Role"
 msgstr "Neue Rolle"
 
-#: dist/converse-no-dependencies.js:9404 dist/converse-no-dependencies.js:9504
+#: dist/converse-no-dependencies.js:9464 dist/converse-no-dependencies.js:9564
 msgid "Reason"
 msgstr "Grund"
 
-#: dist/converse-no-dependencies.js:9406
+#: dist/converse-no-dependencies.js:9466
 msgid "Change role"
 msgstr "Rolle ändern"
 
-#: dist/converse-no-dependencies.js:9410
+#: dist/converse-no-dependencies.js:9470
 msgid ""
 "An affiliation is a long-lived entitlement which typically implies a certain "
 "role and which grants privileges and responsibilities. For example admins "
@@ -400,11 +411,11 @@ msgstr ""
 "Beispielsweise haben Administratoren und Eigentümer automatisch die "
 "Moderatorenrolle."
 
-#: dist/converse-no-dependencies.js:9412
+#: dist/converse-no-dependencies.js:9472
 msgid "Affiliation"
 msgstr "Zugehörigkeit"
 
-#: dist/converse-no-dependencies.js:9424 dist/converse-no-dependencies.js:9448
+#: dist/converse-no-dependencies.js:9484 dist/converse-no-dependencies.js:9508
 msgid ""
 "Owner is the highest affiliation. Owners can modify roles and affiliations "
 "of all other users."
@@ -412,7 +423,7 @@ msgstr ""
 "Besitzer ist die höchste Zugehörigkeit. Besitzer können Rollen und "
 "Zugehörigkeiten aller anderen Benutzer ändern."
 
-#: dist/converse-no-dependencies.js:9430 dist/converse-no-dependencies.js:9454
+#: dist/converse-no-dependencies.js:9490 dist/converse-no-dependencies.js:9514
 msgid ""
 "Admin is the 2nd highest affiliation. Admins can modify roles and "
 "affiliations of all other users except owners."
@@ -421,282 +432,109 @@ msgstr ""
 "Rollen und Zugehörigkeiten aller anderen Benutzer mit Ausnahme der "
 "Eigentümer ändern."
 
-#: dist/converse-no-dependencies.js:9436 dist/converse-no-dependencies.js:9460
+#: dist/converse-no-dependencies.js:9496 dist/converse-no-dependencies.js:9520
 msgid "To ban a user, you give them the affiliation of \"outcast\"."
 msgstr ""
 "Sperren Sie Benutzer, indem Sie ihre Zugehörigkeit zu ausgeschlossenen "
 "Personen ändern."
 
-#: dist/converse-no-dependencies.js:9470
+#: dist/converse-no-dependencies.js:9530
 msgid "No users with that affiliation found."
 msgstr "Keine Benutzer mit dieser Zugehörigkeit gefunden."
 
-#: dist/converse-no-dependencies.js:9490
+#: dist/converse-no-dependencies.js:9550
 msgid "New affiliation"
 msgstr "Neue Zugehörigkeit"
 
-#: dist/converse-no-dependencies.js:9506
+#: dist/converse-no-dependencies.js:9566
 msgid "Change affiliation"
 msgstr "Zugehörigkeit ändern"
 
-#: dist/converse-no-dependencies.js:9865
+#: dist/converse-no-dependencies.js:9925
 msgid "Save and close"
 msgstr "Speichern und schließen"
 
-#: dist/converse-no-dependencies.js:9869
+#: dist/converse-no-dependencies.js:9929
 msgid "This device's OMEMO fingerprint"
 msgstr "OMEMO-Fingerabdruck dieses Geräts"
 
-#: dist/converse-no-dependencies.js:9879
+#: dist/converse-no-dependencies.js:9939
 msgid "Generate new keys and fingerprint"
 msgstr "Neuer Schlüssel und Fingerabdrücke generieren"
 
-#: dist/converse-no-dependencies.js:9883
+#: dist/converse-no-dependencies.js:9943
 msgid "Select all"
 msgstr "Alle auswählen"
 
-#: dist/converse-no-dependencies.js:9885
+#: dist/converse-no-dependencies.js:9945
 msgid "Checkbox to select fingerprints of all other OMEMO devices"
 msgstr ""
 "Kontrollkästchen zur Auswahl der Fingerabdrücke aller anderen OMEMO-Geräte"
 
-#: dist/converse-no-dependencies.js:9887
+#: dist/converse-no-dependencies.js:9947
 msgid "Other OMEMO-enabled devices"
 msgstr "Andere OMEMO-fähige Geräte"
 
-#: dist/converse-no-dependencies.js:9895 dist/converse-no-dependencies.js:9903
+#: dist/converse-no-dependencies.js:9955 dist/converse-no-dependencies.js:9963
 msgid "Checkbox for selecting the following fingerprint"
 msgstr "Kontrollkästchen zur Auswahl des folgenden Fingerabdrucks"
 
-#: dist/converse-no-dependencies.js:9905
+#: dist/converse-no-dependencies.js:9965
 msgid "Device without a fingerprint"
 msgstr "Gerät ohne Fingerabdruck"
 
-#: dist/converse-no-dependencies.js:9911
+#: dist/converse-no-dependencies.js:9971
 msgid "Remove checked devices and close"
 msgstr "Überprüfte Geräte entfernen und schließen"
 
-#: dist/converse-no-dependencies.js:9993
+#: dist/converse-no-dependencies.js:10053
 msgid "Messages are being sent in plaintext"
 msgstr "Nachrichten werden im Klartext gesendet"
 
-#: dist/converse-no-dependencies.js:10009
+#: dist/converse-no-dependencies.js:10069
 msgid "Don't have a chat account?"
 msgstr "Sie haben noch kein Chat-Konto?"
 
-#: dist/converse-no-dependencies.js:10011
+#: dist/converse-no-dependencies.js:10071
 msgid "Create an account"
 msgstr "Konto erstellen"
 
-#: dist/converse-no-dependencies.js:10027
+#: dist/converse-no-dependencies.js:10087
 msgid "Create your account"
 msgstr "Erstellen Sie Ihr Konto"
 
-#: dist/converse-no-dependencies.js:10029
+#: dist/converse-no-dependencies.js:10089
 msgid "Please enter the XMPP provider to register with:"
 msgstr ""
 "Bitte geben Sie den XMPP-Provider ein, bei dem Sie sich anmelden möchten:"
 
-#: dist/converse-no-dependencies.js:10047
-#: dist/converse-no-dependencies.js:10081
+#: dist/converse-no-dependencies.js:10107
+#: dist/converse-no-dependencies.js:10141
 msgid "Already have a chat account?"
 msgstr "Sie haben bereits ein Chat-Konto?"
 
-#: dist/converse-no-dependencies.js:10049
-#: dist/converse-no-dependencies.js:10083
+#: dist/converse-no-dependencies.js:10109
+#: dist/converse-no-dependencies.js:10143
 msgid "Log in here"
 msgstr "Hier anmelden"
 
-#: dist/converse-no-dependencies.js:10065
+#: dist/converse-no-dependencies.js:10125
 msgid "Account Registration:"
 msgstr "Konto-Registrierung:"
 
-#: dist/converse-no-dependencies.js:10073
+#: dist/converse-no-dependencies.js:10133
 msgid "Register"
 msgstr "Registrierung"
 
-#: dist/converse-no-dependencies.js:10077
+#: dist/converse-no-dependencies.js:10137
 msgid "Choose a different provider"
 msgstr "Wählen Sie einen anderen Anbieter"
 
-#: dist/converse-no-dependencies.js:10097
+#: dist/converse-no-dependencies.js:10157
 msgid "Hold tight, we're fetching the registration form…"
 msgstr "Bitte warten, das Anmeldeformular wird geladen …"
 
-#: dist/converse-no-dependencies.js:27487
-msgid "Smileys and emotions"
-msgstr "Smileys und Emotionen"
-
-#: dist/converse-no-dependencies.js:27488
-msgid "People"
-msgstr "Menschen"
-
-#: dist/converse-no-dependencies.js:27489
-msgid "Activities"
-msgstr "Aktivitäten"
-
-#: dist/converse-no-dependencies.js:27490
-msgid "Travel"
-msgstr "Reisen"
-
-#: dist/converse-no-dependencies.js:27491
-msgid "Objects"
-msgstr "Objekte"
-
-#: dist/converse-no-dependencies.js:27492
-msgid "Animals and nature"
-msgstr "Tiere und Natur"
-
-#: dist/converse-no-dependencies.js:27493
-msgid "Food and drink"
-msgstr "Essen und Trinken"
-
-#: dist/converse-no-dependencies.js:27494
-msgid "Symbols"
-msgstr "Symbole"
-
-#: dist/converse-no-dependencies.js:27495
-msgid "Flags"
-msgstr "Flaggen"
-
-#: dist/converse-no-dependencies.js:27496
-msgid "Stickers"
-msgstr "Aufkleber"
-
-#: dist/converse-no-dependencies.js:28145
-msgid "This groupchat is not anonymous"
-msgstr "Dieser Gruppenchat ist nicht anonym"
-
-#: dist/converse-no-dependencies.js:28146
-msgid "This groupchat now shows unavailable members"
-msgstr "Dieser Gruppenchat zeigt nicht verfügbare Mitglieder an"
-
-#: dist/converse-no-dependencies.js:28147
-msgid "This groupchat does not show unavailable members"
-msgstr "Dieser Gruppenchat zeigt keine nicht verfügbaren Mitglieder an"
-
-#: dist/converse-no-dependencies.js:28148
-msgid "The groupchat configuration has changed"
-msgstr "Die Gruppenchatkonfiguration hat sich geändert"
-
-#: dist/converse-no-dependencies.js:28149
-msgid "Groupchat logging is now enabled"
-msgstr "Gruppenchat wird ab jetzt protokolliert"
-
-#: dist/converse-no-dependencies.js:28150
-msgid "Groupchat logging is now disabled"
-msgstr "Gruppenchat wird nicht mehr protokolliert"
-
-#: dist/converse-no-dependencies.js:28151
-msgid "This groupchat is now no longer anonymous"
-msgstr "Dieser Gruppenchat ist jetzt nicht mehr anonym"
-
-#: dist/converse-no-dependencies.js:28152
-msgid "This groupchat is now semi-anonymous"
-msgstr "Dieser Gruppenchat ist jetzt nur teilweise anonym"
-
-#: dist/converse-no-dependencies.js:28153
-msgid "This groupchat is now fully-anonymous"
-msgstr "Dieser Gruppenchat ist jetzt vollständig anonym"
-
-#: dist/converse-no-dependencies.js:28154
-msgid "A new groupchat has been created"
-msgstr "Ein neuer Gruppenchat wurde erstellt"
-
-#. XXX: Note the triple underscore function and not double underscore.
-#: dist/converse-no-dependencies.js:28158
-#, javascript-format
-msgid "Your nickname has been automatically set to %1$s"
-msgstr "Ihr Spitzname wurde automatisch geändert zu: %1$s"
-
-#: dist/converse-no-dependencies.js:28159
-#, javascript-format
-msgid "Your nickname has been changed to %1$s"
-msgstr "Ihr Spitzname wurde geändert zu: %1$s"
-
-#: dist/converse-no-dependencies.js:28162
-msgid "You have been banned from this groupchat"
-msgstr "Sie wurden aus diesem Gruppenchat entfernt"
-
-#: dist/converse-no-dependencies.js:28163
-msgid "You have been kicked from this groupchat"
-msgstr "Sie wurden aus diesem Gruppenchat hinausgeworfen"
-
-#: dist/converse-no-dependencies.js:28164
-msgid ""
-"You have been removed from this groupchat because of an affiliation change"
-msgstr ""
-"Sie wurden aus diesem Gruppenchat wegen einer Zugehörigkeitsänderung entfernt"
-
-#: dist/converse-no-dependencies.js:28165
-msgid ""
-"You have been removed from this groupchat because the groupchat has changed "
-"to members-only and you're not a member"
-msgstr ""
-"Sie wurden aus diesem Gruppenchat ausgeschlossen, da der Gruppenchat jetzt "
-"nur noch Mitglieder erlaubt und Sie kein Mitglied sind"
-
-#: dist/converse-no-dependencies.js:28166
-msgid ""
-"You have been removed from this groupchat because the service hosting it is "
-"being shut down"
-msgstr ""
-"Sie wurden aus dem Gruppenchat entfernt, weil der Hostingservice "
-"heruntergefahren wurde"
-
-#. XXX: Note the triple underscore function and not double underscore.
-#: dist/converse-no-dependencies.js:28170
-#, javascript-format
-msgid "%1$s has been banned"
-msgstr "%1$s wurde verbannt"
-
-#: dist/converse-no-dependencies.js:28171
-#, javascript-format
-msgid "%1$s's nickname has changed"
-msgstr "Der Spitzname von %1$s hat sich geändert"
-
-#: dist/converse-no-dependencies.js:28172
-#, javascript-format
-msgid "%1$s has been kicked out"
-msgstr "%1$s wurde hinausgeworfen"
-
-#: dist/converse-no-dependencies.js:28173
-#, javascript-format
-msgid "%1$s has been removed because of an affiliation change"
-msgstr "%1$s wurde wegen einer Zugehörigkeitsänderung entfernt"
-
-#: dist/converse-no-dependencies.js:28174
-#, javascript-format
-msgid "%1$s has been removed for not being a member"
-msgstr "%1$s ist kein Mitglied und wurde daher entfernt"
-
-#: dist/converse-no-dependencies.js:29866
-msgid "You're not allowed to register yourself in this groupchat."
-msgstr "Sie dürfen sich nicht an diesem Gruppenchat anmelden."
-
-#: dist/converse-no-dependencies.js:29868
-msgid ""
-"You're not allowed to register in this groupchat because it's members-only."
-msgstr ""
-"Sie dürfen sich nicht in diesem Gruppenchat anmelden, da er nur für "
-"Mitglieder ist."
-
-#: dist/converse-no-dependencies.js:29914
-msgid ""
-"Can't register your nickname in this groupchat, it doesn't support "
-"registration."
-msgstr ""
-"Sie können Ihren Spitznamen in diesem Gruppenchat nicht registrieren, er "
-"unterstützt keine Registrierung."
-
-#: dist/converse-no-dependencies.js:29916
-msgid ""
-"Can't register your nickname in this groupchat, invalid data form supplied."
-msgstr ""
-"Sie können Ihren Spitznamen nicht in diesem Gruppenchat registrieren, "
-"ungültige Formulardaten wurde übermittelt."
-
-#: dist/converse-no-dependencies.js:30299
+#: dist/converse-no-dependencies.js:23362
 msgid ""
 "Your message was not delivered because you're not allowed to send messages "
 "in this groupchat."
@@ -704,122 +542,30 @@ msgstr ""
 "Ihre Nachricht wurde nicht zugestellt, weil Sie in diesem Gruppenchat keine "
 "Nachrichten senden dürfen."
 
-#: dist/converse-no-dependencies.js:30301
+#: dist/converse-no-dependencies.js:23364
 msgid ""
 "Your message was not delivered because you're not present in the groupchat."
 msgstr ""
 "Ihre Nachricht wurde nicht zugestellt, weil Sie im Gruppenchat nicht "
 "vertreten sind."
 
-#: dist/converse-no-dependencies.js:30498
-#: dist/converse-no-dependencies.js:48591
-#, javascript-format
-msgid "This action was done by %1$s."
-msgstr "Diese Aktion wurde durch %1$s ausgeführt."
+#: dist/converse-no-dependencies.js:23369
+msgid "Sorry, an error occurred:"
+msgstr "Leider ist ein Fehler aufgetreten:"
 
-#: dist/converse-no-dependencies.js:30502
-#: dist/converse-no-dependencies.js:48597
-#, javascript-format
-msgid "The reason given is: \"%1$s\"."
-msgstr "Angegebene Grund: „%1$s”"
-
-#: dist/converse-no-dependencies.js:30547
-msgid ""
-"The nickname you chose is reserved or currently in use, please choose a "
-"different one."
-msgstr ""
-"Der gewählte Spitzname ist reserviert oder derzeit in Gebrauch. Bitte wählen "
-"Sie einen Anderen."
-
-#: dist/converse-no-dependencies.js:30571
-msgid "Password incorrect"
-msgstr "Passwort falsch"
-
-#: dist/converse-no-dependencies.js:30577
-msgid "You are not on the member list of this groupchat."
-msgstr "Sie sind nicht auf der Mitgliederliste dieses Gruppenchats."
-
-#: dist/converse-no-dependencies.js:30581
-msgid "You have been banned from this groupchat."
-msgstr "Sie wurden aus diesem Gruppenchat entfernt."
-
-#: dist/converse-no-dependencies.js:30587
-msgid "You are not allowed to create new groupchats."
-msgstr "Es ist Ihnen nicht erlaubt neue Räume anzulegen."
-
-#: dist/converse-no-dependencies.js:30591
-msgid "Your nickname doesn't conform to this groupchat's policies."
-msgstr "Ihr Spitzname entspricht nicht den Richtlinien dieses Gruppenchats."
-
-#: dist/converse-no-dependencies.js:30605
-msgid "This groupchat does not (yet) exist."
-msgstr "Dieser Gruppenchat existiert (noch) nicht."
-
-#: dist/converse-no-dependencies.js:30609
-msgid "This groupchat has reached its maximum number of participants."
-msgstr "Maximale Anzahl an Teilnehmern für diesen Gruppenchat erreicht."
-
-#: dist/converse-no-dependencies.js:30613
-msgid "Remote server not found"
-msgstr "Server wurde nicht gefunden"
-
-#: dist/converse-no-dependencies.js:30615
-#, javascript-format
-msgid "The explanation given is: \"%1$s\"."
-msgstr "Angegebene Grund: „%1$s”."
-
-#: dist/converse-no-dependencies.js:30979
-#, javascript-format
-msgid "%1$s has invited you to join a groupchat: %2$s"
-msgstr "%1$s hat Sie in den Gruppenchat „%2$s” eingeladen"
-
-#: dist/converse-no-dependencies.js:30981
-#, javascript-format
-msgid ""
-"%1$s has invited you to join a groupchat: %2$s, and left the following "
-"reason: \"%3$s\""
-msgstr "%1$s hat Sie in den Gruppenchat „%2$s” eingeladen. Begründung: „%3$s”"
-
-#: dist/converse-no-dependencies.js:31668
-#: dist/converse-no-dependencies.js:42560
-#: dist/converse-no-dependencies.js:49931
-#: dist/converse-no-dependencies.js:50483
-#: dist/converse-no-dependencies.js:50932
-#: dist/converse-no-dependencies.js:50936
-#: dist/converse-no-dependencies.js:50983
-#: dist/converse-no-dependencies.js:54690
-msgid "Error"
-msgstr "Fehler"
-
-#: dist/converse-no-dependencies.js:31668
-msgid "Sorry, something went wrong while trying to save your bookmark."
-msgstr "Leider konnte das Lesezeichen nicht gespeichert werden."
-
-#: dist/converse-no-dependencies.js:31732
-msgid "Timeout Error"
-msgstr "Timeout-Fehler"
-
-#: dist/converse-no-dependencies.js:31732
-msgid ""
-"The server did not return your bookmarks within the allowed time. You can "
-"reload the page to request them again."
-msgstr ""
-"Der Server hat Ihre Lesezeichen nicht innerhalb der zulässigen Zeit "
-"zurückgegeben. Sie können die Seite neu laden, um sie erneut anzufordern."
-
-#: dist/converse-no-dependencies.js:33481
+#: dist/converse-no-dependencies.js:26497
 msgid "Unencryptable OMEMO message"
 msgstr "Unentschlüsselbare OMEMO Nachricht"
 
-#: dist/converse-no-dependencies.js:33542
+#: dist/converse-no-dependencies.js:26556
 msgid "Sorry, could not determine upload URL."
 msgstr "Leider konnte die Upload-URL nicht ermittelt werden."
 
-#: dist/converse-no-dependencies.js:33564
+#: dist/converse-no-dependencies.js:26578
 msgid "Sorry, could not determine file upload URL."
 msgstr "Leider konnte die Upload-URL für die Datei nicht ermittelt werden."
 
-#: dist/converse-no-dependencies.js:33613
+#: dist/converse-no-dependencies.js:26627
 #, javascript-format
 msgid ""
 "Sorry, could not succesfully upload your file. Your server’s response: \"%1$s"
@@ -828,18 +574,18 @@ msgstr ""
 "Leider konnte die Datei nicht hochgeladen werden. Der Server antwortete: "
 "\"%1$s\""
 
-#: dist/converse-no-dependencies.js:33615
+#: dist/converse-no-dependencies.js:26629
 msgid "Sorry, could not succesfully upload your file."
 msgstr "Leider konnte die Datei nicht erfolgreich hochgeladen werden."
 
-#: dist/converse-no-dependencies.js:34442
-#: dist/converse-no-dependencies.js:34462
+#: dist/converse-no-dependencies.js:27741
+#: dist/converse-no-dependencies.js:27761
 msgid "Sorry, looks like file upload is not supported by your server."
 msgstr ""
 "Leider sieht es so aus, als ob der Datei-Upload von deinem Server nicht "
 "unterstützt wird."
 
-#: dist/converse-no-dependencies.js:34472
+#: dist/converse-no-dependencies.js:27771
 #, javascript-format
 msgid ""
 "The size of your file, %1$s, exceeds the maximum allowed by your server, "
@@ -848,438 +594,774 @@ msgstr ""
 "Die Größe deiner Datei, %1$s, überschreitet das erlaubte Maximum vom Server, "
 "welches bei %2$s liegt."
 
-#: dist/converse-no-dependencies.js:34563
-msgid "Sorry, an error occurred:"
-msgstr "Leider ist ein Fehler aufgetreten:"
+#: dist/converse-no-dependencies.js:30236
+msgid "Smileys and emotions"
+msgstr "Smileys und Emotionen"
 
-#: dist/converse-no-dependencies.js:37087
-msgid "My contacts"
-msgstr "Meine Kontakte"
+#: dist/converse-no-dependencies.js:30237
+msgid "People"
+msgstr "Menschen"
 
-#: dist/converse-no-dependencies.js:37088
-msgid "Pending contacts"
-msgstr "Unbestätigte Kontakte"
+#: dist/converse-no-dependencies.js:30238
+msgid "Activities"
+msgstr "Aktivitäten"
 
-#: dist/converse-no-dependencies.js:37089
-msgid "Contact requests"
-msgstr "Kontaktanfragen"
+#: dist/converse-no-dependencies.js:30239
+msgid "Travel"
+msgstr "Reisen"
 
-#: dist/converse-no-dependencies.js:37090
-msgid "Ungrouped"
-msgstr "Ungruppiert"
+#: dist/converse-no-dependencies.js:30240
+msgid "Objects"
+msgstr "Objekte"
 
-#: dist/converse-no-dependencies.js:37776
+#: dist/converse-no-dependencies.js:30241
+msgid "Animals and nature"
+msgstr "Tiere und Natur"
+
+#: dist/converse-no-dependencies.js:30242
+msgid "Food and drink"
+msgstr "Essen und Trinken"
+
+#: dist/converse-no-dependencies.js:30243
+msgid "Symbols"
+msgstr "Symbole"
+
+#: dist/converse-no-dependencies.js:30244
+msgid "Flags"
+msgstr "Flaggen"
+
+#: dist/converse-no-dependencies.js:30245
+msgid "Stickers"
+msgstr "Aufkleber"
+
+#: dist/converse-no-dependencies.js:30912
+msgid "This groupchat is not anonymous"
+msgstr "Dieser Gruppenchat ist nicht anonym"
+
+#: dist/converse-no-dependencies.js:30913
+msgid "This groupchat now shows unavailable members"
+msgstr "Dieser Gruppenchat zeigt nicht verfügbare Mitglieder an"
+
+#: dist/converse-no-dependencies.js:30914
+msgid "This groupchat does not show unavailable members"
+msgstr "Dieser Gruppenchat zeigt keine nicht verfügbaren Mitglieder an"
+
+#: dist/converse-no-dependencies.js:30915
+msgid "The groupchat configuration has changed"
+msgstr "Die Gruppenchatkonfiguration hat sich geändert"
+
+#: dist/converse-no-dependencies.js:30916
+msgid "Groupchat logging is now enabled"
+msgstr "Gruppenchat wird ab jetzt protokolliert"
+
+#: dist/converse-no-dependencies.js:30917
+msgid "Groupchat logging is now disabled"
+msgstr "Gruppenchat wird nicht mehr protokolliert"
+
+#: dist/converse-no-dependencies.js:30918
+msgid "This groupchat is now no longer anonymous"
+msgstr "Dieser Gruppenchat ist jetzt nicht mehr anonym"
+
+#: dist/converse-no-dependencies.js:30919
+msgid "This groupchat is now semi-anonymous"
+msgstr "Dieser Gruppenchat ist jetzt nur teilweise anonym"
+
+#: dist/converse-no-dependencies.js:30920
+msgid "This groupchat is now fully-anonymous"
+msgstr "Dieser Gruppenchat ist jetzt vollständig anonym"
+
+#: dist/converse-no-dependencies.js:30921
+msgid "A new groupchat has been created"
+msgstr "Ein neuer Gruppenchat wurde erstellt"
+
+#. XXX: Note the triple underscore function and not double underscore.
+#: dist/converse-no-dependencies.js:30925
 #, javascript-format
-msgid "Sorry, there was an error while trying to add %1$s as a contact."
+msgid "Your nickname has been automatically set to %1$s"
+msgstr "Ihr Spitzname wurde automatisch geändert zu: %1$s"
+
+#: dist/converse-no-dependencies.js:30926
+#, javascript-format
+msgid "Your nickname has been changed to %1$s"
+msgstr "Ihr Spitzname wurde geändert zu: %1$s"
+
+#: dist/converse-no-dependencies.js:30929
+msgid "You have been banned from this groupchat"
+msgstr "Sie wurden aus diesem Gruppenchat entfernt"
+
+#: dist/converse-no-dependencies.js:30930
+msgid "You have been kicked from this groupchat"
+msgstr "Sie wurden aus diesem Gruppenchat hinausgeworfen"
+
+#: dist/converse-no-dependencies.js:30931
+msgid ""
+"You have been removed from this groupchat because of an affiliation change"
 msgstr ""
-"Leider gab es einen Fehler beim Versuch, %1$s als Kontakt hinzuzufügen."
+"Sie wurden aus diesem Gruppenchat wegen einer Zugehörigkeitsänderung entfernt"
 
-#: dist/converse-no-dependencies.js:38070
-msgid "This client does not allow presence subscriptions"
-msgstr "Dieser Client erlaubt keine Anwesenheitsabonnements"
+#: dist/converse-no-dependencies.js:30932
+msgid ""
+"You have been removed from this groupchat because the groupchat has changed "
+"to members-only and you're not a member"
+msgstr ""
+"Sie wurden aus diesem Gruppenchat ausgeschlossen, da der Gruppenchat jetzt "
+"nur noch Mitglieder erlaubt und Sie kein Mitglied sind"
 
-#: dist/converse-no-dependencies.js:38180
-msgid "Click to hide these contacts"
-msgstr "Hier klicken, um diese Kontakte auszublenden"
+#: dist/converse-no-dependencies.js:30933
+msgid ""
+"You have been removed from this groupchat because the service hosting it is "
+"being shut down"
+msgstr ""
+"Sie wurden aus dem Gruppenchat entfernt, weil der Hostingservice "
+"heruntergefahren wurde"
 
-#: dist/converse-no-dependencies.js:40265
+#. XXX: Note the triple underscore function and not double underscore.
+#: dist/converse-no-dependencies.js:30937
 #, javascript-format
-msgid "Are you sure you want to remove the bookmark \"%1$s\"?"
-msgstr "Möchten Sie das Lesezeichen „%1$s” wirklich löschen?"
+msgid "%1$s has been banned"
+msgstr "%1$s wurde verbannt"
 
-#: dist/converse-no-dependencies.js:40294
-#: dist/converse-no-dependencies.js:40434
-#: dist/converse-no-dependencies.js:53898
-msgid "Unbookmark this groupchat"
-msgstr "Lesezeichen für diesen Gruppenchat entfernen"
+#: dist/converse-no-dependencies.js:30938
+#, javascript-format
+msgid "%1$s's nickname has changed"
+msgstr "Der Spitzname von %1$s hat sich geändert"
 
-#: dist/converse-no-dependencies.js:40294
-#: dist/converse-no-dependencies.js:40368
-#: dist/converse-no-dependencies.js:53896
-msgid "Bookmark this groupchat"
-msgstr "Lesezeichen für diesen Gruppenchat speichern"
+#: dist/converse-no-dependencies.js:30939
+#, javascript-format
+msgid "%1$s has been kicked out"
+msgstr "%1$s wurde hinausgeworfen"
 
-#: dist/converse-no-dependencies.js:40369
-msgid "Would you like this groupchat to be automatically joined upon startup?"
-msgstr "Beim Anmelden diesem Gruppenchat automatisch beitreten?"
+#: dist/converse-no-dependencies.js:30940
+#, javascript-format
+msgid "%1$s has been removed because of an affiliation change"
+msgstr "%1$s wurde wegen einer Zugehörigkeitsänderung entfernt"
 
-#: dist/converse-no-dependencies.js:40371
-msgid "The name for this bookmark:"
-msgstr "Name des Lesezeichens:"
+#: dist/converse-no-dependencies.js:30941
+#, javascript-format
+msgid "%1$s has been removed for not being a member"
+msgstr "%1$s ist kein Mitglied und wurde daher entfernt"
 
-#: dist/converse-no-dependencies.js:40372
-msgid "What should your nickname for this groupchat be?"
-msgstr "Welcher Spitzname soll für diesen Gruppenchat verwendet werden?"
+#: dist/converse-no-dependencies.js:32808
+msgid "You're not allowed to register yourself in this groupchat."
+msgstr "Sie dürfen sich nicht an diesem Gruppenchat anmelden."
 
-#: dist/converse-no-dependencies.js:40431
-msgid "Click to toggle the bookmarks list"
-msgstr "Liste der Lesezeichen umschalten"
+#: dist/converse-no-dependencies.js:32810
+msgid ""
+"You're not allowed to register in this groupchat because it's members-only."
+msgstr ""
+"Sie dürfen sich nicht in diesem Gruppenchat anmelden, da er nur für "
+"Mitglieder ist."
 
-#: dist/converse-no-dependencies.js:40432
-#: dist/converse-no-dependencies.js:53897
-msgid "Leave this groupchat"
-msgstr "Diesen Gruppenchat verlassen"
+#: dist/converse-no-dependencies.js:32855
+msgid ""
+"Can't register your nickname in this groupchat, it doesn't support "
+"registration."
+msgstr ""
+"Sie können Ihren Spitznamen in diesem Gruppenchat nicht registrieren, er "
+"unterstützt keine Registrierung."
 
-#: dist/converse-no-dependencies.js:40433
-msgid "Remove this bookmark"
-msgstr "Dieses Lesezeichen entfernen"
+#: dist/converse-no-dependencies.js:32857
+msgid ""
+"Can't register your nickname in this groupchat, invalid data form supplied."
+msgstr ""
+"Sie können Ihren Spitznamen nicht in diesem Gruppenchat registrieren, "
+"ungültige Formulardaten wurde übermittelt."
 
-#: dist/converse-no-dependencies.js:40435
-#: dist/converse-no-dependencies.js:47475
-#: dist/converse-no-dependencies.js:53899
-msgid "Show more information on this groupchat"
-msgstr "Zeige mehr Informationen über diesen Gruppenchat"
+#: dist/converse-no-dependencies.js:33573
+#: dist/converse-no-dependencies.js:51253
+#, javascript-format
+msgid "This action was done by %1$s."
+msgstr "Diese Aktion wurde durch %1$s ausgeführt."
 
-#: dist/converse-no-dependencies.js:40436
-msgid "Bookmarks"
-msgstr "Lesezeichen"
+#: dist/converse-no-dependencies.js:33577
+#: dist/converse-no-dependencies.js:51259
+#, javascript-format
+msgid "The reason given is: \"%1$s\"."
+msgstr "Angegebene Grund: „%1$s”"
 
-#: dist/converse-no-dependencies.js:40437
-#: dist/converse-no-dependencies.js:47474
-#: dist/converse-no-dependencies.js:53900
-msgid "Click to open this groupchat"
-msgstr "Hier klicken, um diesen Gruppenchat zu öffnen"
+#: dist/converse-no-dependencies.js:33632
+msgid ""
+"The nickname you chose is reserved or currently in use, please choose a "
+"different one."
+msgstr ""
+"Der gewählte Spitzname ist reserviert oder derzeit in Gebrauch. Bitte wählen "
+"Sie einen Anderen."
 
-#: dist/converse-no-dependencies.js:40927
+#: dist/converse-no-dependencies.js:33655
+msgid "Password incorrect"
+msgstr "Passwort falsch"
+
+#: dist/converse-no-dependencies.js:33661
+msgid "You are not on the member list of this groupchat."
+msgstr "Sie sind nicht auf der Mitgliederliste dieses Gruppenchats."
+
+#: dist/converse-no-dependencies.js:33665
+msgid "You have been banned from this groupchat."
+msgstr "Sie wurden aus diesem Gruppenchat entfernt."
+
+#: dist/converse-no-dependencies.js:33671
+msgid "You are not allowed to create new groupchats."
+msgstr "Es ist Ihnen nicht erlaubt neue Räume anzulegen."
+
+#: dist/converse-no-dependencies.js:33675
+msgid "Your nickname doesn't conform to this groupchat's policies."
+msgstr "Ihr Spitzname entspricht nicht den Richtlinien dieses Gruppenchats."
+
+#: dist/converse-no-dependencies.js:33688
+msgid "This groupchat does not (yet) exist."
+msgstr "Dieser Gruppenchat existiert (noch) nicht."
+
+#: dist/converse-no-dependencies.js:33692
+msgid "This groupchat has reached its maximum number of participants."
+msgstr "Maximale Anzahl an Teilnehmern für diesen Gruppenchat erreicht."
+
+#: dist/converse-no-dependencies.js:33696
+msgid "Remote server not found"
+msgstr "Server wurde nicht gefunden"
+
+#: dist/converse-no-dependencies.js:33698
+#, javascript-format
+msgid "The explanation given is: \"%1$s\"."
+msgstr "Angegebene Grund: „%1$s”."
+
+#: dist/converse-no-dependencies.js:34072
+#, javascript-format
+msgid "%1$s has invited you to join a groupchat: %2$s"
+msgstr "%1$s hat Sie in den Gruppenchat „%2$s” eingeladen"
+
+#: dist/converse-no-dependencies.js:34074
+#, javascript-format
+msgid ""
+"%1$s has invited you to join a groupchat: %2$s, and left the following "
+"reason: \"%3$s\""
+msgstr "%1$s hat Sie in den Gruppenchat „%2$s” eingeladen. Begründung: „%3$s”"
+
+#: dist/converse-no-dependencies.js:34806
+#: dist/converse-no-dependencies.js:40146
+#: dist/converse-no-dependencies.js:50428
+#: dist/converse-no-dependencies.js:50434
+#: dist/converse-no-dependencies.js:52698
+#: dist/converse-no-dependencies.js:53250
+#: dist/converse-no-dependencies.js:53699
+#: dist/converse-no-dependencies.js:53703
+#: dist/converse-no-dependencies.js:53750
+#: dist/converse-no-dependencies.js:57471
+msgid "Error"
+msgstr "Fehler"
+
+#: dist/converse-no-dependencies.js:34806
+msgid "Sorry, something went wrong while trying to save your bookmark."
+msgstr "Leider konnte das Lesezeichen nicht gespeichert werden."
+
+#: dist/converse-no-dependencies.js:34871
+msgid "Timeout Error"
+msgstr "Timeout-Fehler"
+
+#: dist/converse-no-dependencies.js:34871
+msgid ""
+"The server did not return your bookmarks within the allowed time. You can "
+"reload the page to request them again."
+msgstr ""
+"Der Server hat Ihre Lesezeichen nicht innerhalb der zulässigen Zeit "
+"zurückgegeben. Sie können die Seite neu laden, um sie erneut anzufordern."
+
+#: dist/converse-no-dependencies.js:38190
 #, javascript-format
 msgid "Download audio file \"%1$s\""
 msgstr "Audiodatei \"%1$s\" herunterladen"
 
-#: dist/converse-no-dependencies.js:40945
+#: dist/converse-no-dependencies.js:38208
 #, javascript-format
 msgid "Download file \"%1$s\""
 msgstr "Datei \"%1$s\" herunterladen"
 
-#: dist/converse-no-dependencies.js:40960
+#: dist/converse-no-dependencies.js:38223
 #, javascript-format
 msgid "Download image \"%1$s\""
 msgstr "Bild \"%1$s\" herunterladen"
 
-#: dist/converse-no-dependencies.js:40992
+#: dist/converse-no-dependencies.js:38255
 msgid "Download"
 msgstr "Herunterladen"
 
-#: dist/converse-no-dependencies.js:41010
+#: dist/converse-no-dependencies.js:38273
 #, javascript-format
 msgid "Download video file \"%1$s\""
 msgstr "Videodatei \"%1$s\" herunterladen"
 
-#: dist/converse-no-dependencies.js:41931
+#: dist/converse-no-dependencies.js:39242
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: dist/converse-no-dependencies.js:42004
+#: dist/converse-no-dependencies.js:39325
+#: dist/converse-no-dependencies.js:39327
+#, fuzzy, javascript-format
+msgid "%1$s has retracted this message"
+msgstr "%1$s ist dem Gruppenchat beigetreten"
+
+#: dist/converse-no-dependencies.js:39344
 msgid "Typing from another device"
 msgstr "Schreibt von einem anderen Gerät"
 
-#: dist/converse-no-dependencies.js:42006
+#: dist/converse-no-dependencies.js:39346
 #, javascript-format
 msgid "%1$s is typing"
 msgstr "%1$s schreibt"
 
-#: dist/converse-no-dependencies.js:42010
+#: dist/converse-no-dependencies.js:39350
 msgid "Stopped typing on the other device"
 msgstr "Schreibt nicht mehr auf dem anderen Gerät"
 
-#: dist/converse-no-dependencies.js:42012
+#: dist/converse-no-dependencies.js:39352
 #, javascript-format
 msgid "%1$s has stopped typing"
 msgstr "%1$s tippt nicht mehr"
 
-#: dist/converse-no-dependencies.js:42015
-#: dist/converse-no-dependencies.js:43702
+#: dist/converse-no-dependencies.js:39355
+#: dist/converse-no-dependencies.js:41397
 #, javascript-format
 msgid "%1$s has gone away"
 msgstr "%1$s ist jetzt abwesend"
 
-#: dist/converse-no-dependencies.js:42418
+#: dist/converse-no-dependencies.js:40006
 msgid "Close this chat box"
 msgstr "Dieses Chat-Fenster schließen"
 
-#: dist/converse-no-dependencies.js:42521
+#: dist/converse-no-dependencies.js:40107
 msgid "Sorry, something went wrong while trying to refresh"
 msgstr "Leider ist bei der Aktualisierung etwas schief gelaufen"
 
-#: dist/converse-no-dependencies.js:42551
-#: dist/converse-no-dependencies.js:54660
+#: dist/converse-no-dependencies.js:40137
+#: dist/converse-no-dependencies.js:57442
 msgid "Are you sure you want to remove this contact?"
 msgstr "Möchten Sie diesen Kontakt wirklich entfernen?"
 
-#: dist/converse-no-dependencies.js:42560
-#: dist/converse-no-dependencies.js:54690
+#: dist/converse-no-dependencies.js:40146
+#: dist/converse-no-dependencies.js:57471
 #, javascript-format
 msgid "Sorry, there was an error while trying to remove %1$s as a contact."
 msgstr ""
 "Leider gab es einen Fehler beim Versuch, %1$s als Kontakt zu entfernen."
 
-#: dist/converse-no-dependencies.js:42651
-#: dist/converse-no-dependencies.js:42691
+#: dist/converse-no-dependencies.js:40238
+#: dist/converse-no-dependencies.js:40278
 msgid "You have unread messages"
 msgstr "Sie haben ungelesene Nachrichten"
 
-#: dist/converse-no-dependencies.js:42685
+#: dist/converse-no-dependencies.js:40272
 msgid "Hidden message"
 msgstr "Versteckte Nachricht"
 
-#: dist/converse-no-dependencies.js:42685
+#: dist/converse-no-dependencies.js:40272
 msgid "Message"
 msgstr "Nachricht"
 
-#: dist/converse-no-dependencies.js:42686
+#: dist/converse-no-dependencies.js:40273
 msgid "Send"
 msgstr "Senden"
 
-#: dist/converse-no-dependencies.js:42687
+#: dist/converse-no-dependencies.js:40274
 msgid "Optional hint"
 msgstr "Optionaler Hinweis"
 
-#: dist/converse-no-dependencies.js:42757
+#: dist/converse-no-dependencies.js:40344
 msgid "Choose a file to send"
 msgstr "Datei versenden"
 
-#: dist/converse-no-dependencies.js:42857
+#: dist/converse-no-dependencies.js:40439
 msgid "Click to write as a normal (non-spoiler) message"
 msgstr "Hier klicken, um Statusnachricht zu ändern (ohne Spoiler)"
 
-#: dist/converse-no-dependencies.js:42859
+#: dist/converse-no-dependencies.js:40441
 msgid "Click to write your message as a spoiler"
 msgstr "Hier klicken, um die Nachricht als Spoiler zu kennzeichnen"
 
-#: dist/converse-no-dependencies.js:42863
+#: dist/converse-no-dependencies.js:40445
 msgid "Clear all messages"
 msgstr "Alle Nachrichten löschen"
 
-#: dist/converse-no-dependencies.js:42864
+#: dist/converse-no-dependencies.js:40446
 msgid "Message characters remaining"
 msgstr "Verbleibende Zeichen"
 
-#: dist/converse-no-dependencies.js:42869
+#: dist/converse-no-dependencies.js:40451
 msgid "Start a call"
 msgstr "Beginne eine Unterhaltung"
 
-#: dist/converse-no-dependencies.js:43297
+#: dist/converse-no-dependencies.js:40893
 msgid "Remove messages"
 msgstr "Nachrichten entfernen"
 
-#: dist/converse-no-dependencies.js:43297
+#: dist/converse-no-dependencies.js:40893
+#, fuzzy
+msgid "Close this chat"
+msgstr "Dieses Chat-Fenster schließen"
+
+#: dist/converse-no-dependencies.js:40893
 msgid "Write in the third person"
 msgstr "In der dritten Person schreiben"
 
-#: dist/converse-no-dependencies.js:43297
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:40893
+#: dist/converse-no-dependencies.js:50987
 msgid "Show this menu"
 msgstr "Dieses Menü anzeigen"
 
-#: dist/converse-no-dependencies.js:43513
+#: dist/converse-no-dependencies.js:41139
+#: dist/converse-no-dependencies.js:50311
+msgid ""
+"Be aware that other XMPP/Jabber clients (and servers) may not yet support "
+"retractions and that this message may not be removed everywhere."
+msgstr ""
+
+#: dist/converse-no-dependencies.js:41140
+#: dist/converse-no-dependencies.js:50318
+#, fuzzy
+msgid "Are you sure you want to retract this message?"
+msgstr "Möchten Sie diesen Kontakt wirklich entfernen?"
+
+#: dist/converse-no-dependencies.js:41147
+#: dist/converse-no-dependencies.js:50325
+msgid "Confirm"
+msgstr ""
+
+#: dist/converse-no-dependencies.js:41181
 msgid ""
 "You have an unsent message which will be lost if you continue. Are you sure?"
 msgstr ""
 "Sie haben eine nicht gesendete Nachricht, die verloren geht, wenn Sie "
 "fortfahren. Sind Sie sicher?"
 
-#: dist/converse-no-dependencies.js:43595
+#: dist/converse-no-dependencies.js:41271
 msgid "Are you sure you want to clear the messages from this conversation?"
 msgstr ""
 "Sind Sie sicher, dass Sie alle Nachrichten dieses Chats löschen möchten?"
 
-#: dist/converse-no-dependencies.js:43700
+#: dist/converse-no-dependencies.js:41395
 #, javascript-format
 msgid "%1$s has gone offline"
 msgstr "%1$s hat sich abgemeldet"
 
-#: dist/converse-no-dependencies.js:43704
+#: dist/converse-no-dependencies.js:41399
 #, javascript-format
 msgid "%1$s is busy"
 msgstr "%1$s ist beschäftigt"
 
-#: dist/converse-no-dependencies.js:43706
+#: dist/converse-no-dependencies.js:41401
 #, javascript-format
 msgid "%1$s is online"
 msgstr "%1$s ist jetzt online"
 
-#: dist/converse-no-dependencies.js:44393
+#: dist/converse-no-dependencies.js:42864
+msgid "My contacts"
+msgstr "Meine Kontakte"
+
+#: dist/converse-no-dependencies.js:42865
+msgid "Pending contacts"
+msgstr "Unbestätigte Kontakte"
+
+#: dist/converse-no-dependencies.js:42866
+msgid "Contact requests"
+msgstr "Kontaktanfragen"
+
+#: dist/converse-no-dependencies.js:42867
+msgid "Ungrouped"
+msgstr "Ungruppiert"
+
+#: dist/converse-no-dependencies.js:43508
+#, javascript-format
+msgid "Sorry, there was an error while trying to add %1$s as a contact."
+msgstr ""
+"Leider gab es einen Fehler beim Versuch, %1$s als Kontakt hinzuzufügen."
+
+#: dist/converse-no-dependencies.js:43795
+msgid "This client does not allow presence subscriptions"
+msgstr "Dieser Client erlaubt keine Anwesenheitsabonnements"
+
+#: dist/converse-no-dependencies.js:43905
+msgid "Click to hide these contacts"
+msgstr "Hier klicken, um diese Kontakte auszublenden"
+
+#: dist/converse-no-dependencies.js:46188
+#, javascript-format
+msgid "Are you sure you want to remove the bookmark \"%1$s\"?"
+msgstr "Möchten Sie das Lesezeichen „%1$s” wirklich löschen?"
+
+#: dist/converse-no-dependencies.js:46217
+#: dist/converse-no-dependencies.js:46357
+#: dist/converse-no-dependencies.js:56651
+msgid "Unbookmark this groupchat"
+msgstr "Lesezeichen für diesen Gruppenchat entfernen"
+
+#: dist/converse-no-dependencies.js:46217
+#: dist/converse-no-dependencies.js:46291
+#: dist/converse-no-dependencies.js:56649
+msgid "Bookmark this groupchat"
+msgstr "Lesezeichen für diesen Gruppenchat speichern"
+
+#: dist/converse-no-dependencies.js:46292
+msgid "Would you like this groupchat to be automatically joined upon startup?"
+msgstr "Beim Anmelden diesem Gruppenchat automatisch beitreten?"
+
+#: dist/converse-no-dependencies.js:46294
+msgid "The name for this bookmark:"
+msgstr "Name des Lesezeichens:"
+
+#: dist/converse-no-dependencies.js:46295
+msgid "What should your nickname for this groupchat be?"
+msgstr "Welcher Spitzname soll für diesen Gruppenchat verwendet werden?"
+
+#: dist/converse-no-dependencies.js:46354
+msgid "Click to toggle the bookmarks list"
+msgstr "Liste der Lesezeichen umschalten"
+
+#: dist/converse-no-dependencies.js:46355
+#: dist/converse-no-dependencies.js:56650
+msgid "Leave this groupchat"
+msgstr "Diesen Gruppenchat verlassen"
+
+#: dist/converse-no-dependencies.js:46356
+msgid "Remove this bookmark"
+msgstr "Dieses Lesezeichen entfernen"
+
+#: dist/converse-no-dependencies.js:46358
+#: dist/converse-no-dependencies.js:49907
+#: dist/converse-no-dependencies.js:56652
+msgid "Show more information on this groupchat"
+msgstr "Zeige mehr Informationen über diesen Gruppenchat"
+
+#: dist/converse-no-dependencies.js:46359
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+#: dist/converse-no-dependencies.js:46360
+#: dist/converse-no-dependencies.js:49906
+#: dist/converse-no-dependencies.js:56653
+msgid "Click to open this groupchat"
+msgstr "Hier klicken, um diesen Gruppenchat zu öffnen"
+
+#: dist/converse-no-dependencies.js:46971
 msgid "Username"
 msgstr "Benutzername"
 
-#: dist/converse-no-dependencies.js:44393
+#: dist/converse-no-dependencies.js:46971
 msgid "user@domain"
 msgstr "user@domain"
 
-#: dist/converse-no-dependencies.js:44413
-#: dist/converse-no-dependencies.js:49209
-#: dist/converse-no-dependencies.js:54204
+#: dist/converse-no-dependencies.js:46991
+#: dist/converse-no-dependencies.js:51871
+#: dist/converse-no-dependencies.js:56957
 msgid "Please enter a valid XMPP address"
 msgstr "Bitte eine gültige XMPP-Adresse eingeben"
 
-#: dist/converse-no-dependencies.js:44513
+#: dist/converse-no-dependencies.js:47091
 msgid "Chat Contacts"
 msgstr "Kontakte"
 
-#: dist/converse-no-dependencies.js:44513
+#: dist/converse-no-dependencies.js:47091
 msgid "Toggle chat"
 msgstr "Chat ein-/ausblenden"
 
-#: dist/converse-no-dependencies.js:45567
+#: dist/converse-no-dependencies.js:48217
 msgid "Insert emojis"
 msgstr "Emojis einfügen"
 
-#: dist/converse-no-dependencies.js:46215
-#: dist/converse-no-dependencies.js:46253
+#: dist/converse-no-dependencies.js:48633
+#: dist/converse-no-dependencies.js:48671
 msgid "Minimize this chat box"
 msgstr "Dieses Chatfenster minimieren"
 
-#: dist/converse-no-dependencies.js:46564
+#: dist/converse-no-dependencies.js:48990
 msgid "Click to restore this chat"
 msgstr "Hier klicken, um diesen Chat wiederherzustellen"
 
-#: dist/converse-no-dependencies.js:46733
+#: dist/converse-no-dependencies.js:49159
 msgid "Minimized"
 msgstr "Minimiert"
 
-#: dist/converse-no-dependencies.js:47127
+#: dist/converse-no-dependencies.js:49559
 msgid "Description:"
 msgstr "Beschreibung:"
 
-#: dist/converse-no-dependencies.js:47128
+#: dist/converse-no-dependencies.js:49560
 msgid "Groupchat Address (JID):"
 msgstr "Gruppenchat-Adresse (JID):"
 
-#: dist/converse-no-dependencies.js:47129
+#: dist/converse-no-dependencies.js:49561
 msgid "Participants:"
 msgstr "Teilnehmer:"
 
-#: dist/converse-no-dependencies.js:47130
+#: dist/converse-no-dependencies.js:49562
 msgid "Features:"
 msgstr "Funktionen:"
 
-#: dist/converse-no-dependencies.js:47131
+#: dist/converse-no-dependencies.js:49563
 msgid "Requires authentication"
 msgstr "Authentifizierung erforderlich"
 
-#: dist/converse-no-dependencies.js:47133
+#: dist/converse-no-dependencies.js:49565
 msgid "Requires an invitation"
 msgstr "Einladung erforderlich"
 
-#: dist/converse-no-dependencies.js:47135
+#: dist/converse-no-dependencies.js:49567
 msgid "Non-anonymous"
 msgstr "Nicht anonym"
 
-#: dist/converse-no-dependencies.js:47137
+#: dist/converse-no-dependencies.js:49569
 msgid "Permanent"
 msgstr "Dauerhafter Raum"
 
-#: dist/converse-no-dependencies.js:47141
+#: dist/converse-no-dependencies.js:49573
 msgid "Unmoderated"
 msgstr "Nicht moderiert"
 
-#: dist/converse-no-dependencies.js:47346
+#: dist/converse-no-dependencies.js:49778
 msgid "Affiliation changed"
 msgstr "Zugehörigkeit geändert"
 
-#: dist/converse-no-dependencies.js:47369
+#: dist/converse-no-dependencies.js:49801
 msgid "Sorry, something went wrong while trying to set the affiliation"
 msgstr "Leider ist bei der Änderung der Zugehörigkeiten etwas schief gelaufen"
 
-#: dist/converse-no-dependencies.js:47385
+#: dist/converse-no-dependencies.js:49817
 msgid "Role changed"
 msgstr "Rolle geändert"
 
-#: dist/converse-no-dependencies.js:47398
+#: dist/converse-no-dependencies.js:49830
 msgid "You're not allowed to make that change"
 msgstr "Du darfst diese Änderung nicht vornehmen"
 
-#: dist/converse-no-dependencies.js:47400
+#: dist/converse-no-dependencies.js:49832
 msgid "Sorry, something went wrong while trying to set the role"
 msgstr "Leider ist bei der Festlegung der Rolle etwas schief gelaufen"
 
-#: dist/converse-no-dependencies.js:47430
+#: dist/converse-no-dependencies.js:49862
 msgid "Query for Groupchats"
 msgstr "Gruppenchats abfragen"
 
-#: dist/converse-no-dependencies.js:47431
+#: dist/converse-no-dependencies.js:49863
 msgid "Server address"
 msgstr "Server"
 
-#: dist/converse-no-dependencies.js:47432
+#: dist/converse-no-dependencies.js:49864
 msgid "Show groupchats"
 msgstr "Gruppen"
 
-#: dist/converse-no-dependencies.js:47434
+#: dist/converse-no-dependencies.js:49866
 msgid "conference.example.org"
 msgstr "konferenz.beispiel.org"
 
-#: dist/converse-no-dependencies.js:47485
+#: dist/converse-no-dependencies.js:49917
 msgid "No groupchats found"
 msgstr "Keine Räume gefunden"
 
-#: dist/converse-no-dependencies.js:47500
+#: dist/converse-no-dependencies.js:49932
 msgid "Groupchats found:"
 msgstr "Gruppenchat gefunden:"
 
-#: dist/converse-no-dependencies.js:47566
+#: dist/converse-no-dependencies.js:49998
 msgid "name@conference.example.org"
 msgstr "name@conference.beispiel.org"
 
-#: dist/converse-no-dependencies.js:47572
+#: dist/converse-no-dependencies.js:50004
 msgid "Groupchat name"
 msgstr "Gruppenchatname"
 
-#: dist/converse-no-dependencies.js:47572
+#: dist/converse-no-dependencies.js:50004
 msgid "Groupchat address"
 msgstr "Gruppenchat-Adresse"
 
-#: dist/converse-no-dependencies.js:47641
+#: dist/converse-no-dependencies.js:50073
 #, javascript-format
 msgid "Groupchat info for %1$s"
 msgstr "Gruppenchat-Benachrichtigung für %1$s"
 
-#: dist/converse-no-dependencies.js:47872
+#: dist/converse-no-dependencies.js:50338
+#, fuzzy
+msgid "You are about to retract this message."
+msgstr "Sie haben ungelesene Nachrichten"
+
+#: dist/converse-no-dependencies.js:50338
+#, fuzzy
+msgid ""
+"You may optionally include a message, explaining the reason for the "
+"retraction."
+msgstr ""
+"Sie sind dabei, %1$s in den Gruppenchat „%2$s” einzuladen. Optional können "
+"Sie eine Nachricht anfügen, in der Sie den Grund für die Einladung erläutern."
+
+#: dist/converse-no-dependencies.js:50345
+#, fuzzy
+msgid "Message Retraction"
+msgstr "Nachrichtenarchivierung"
+
+#: dist/converse-no-dependencies.js:50345
+#, fuzzy
+msgid "Optional reason"
+msgstr "Optionaler Hinweis"
+
+#: dist/converse-no-dependencies.js:50384
+#, fuzzy
+msgid "Sorry, something went wrong while trying to retract your message."
+msgstr "Leider ist bei der Aktualisierung etwas schief gelaufen"
+
+#: dist/converse-no-dependencies.js:50426
+#, fuzzy
+msgid "A timeout occurred while trying to retract the message"
+msgstr ""
+"Leider ist beim Versuch, die Geräte zu entfernen, ein Fehler aufgetreten."
+
+#: dist/converse-no-dependencies.js:50432
+#, fuzzy
+msgid "Sorry, you're not allowed to retract this message."
+msgstr "Du darfst diese Änderung nicht vornehmen"
+
+#: dist/converse-no-dependencies.js:50511
 #, javascript-format
 msgid "%1$s is no longer an admin of this groupchat"
 msgstr "%1$s ist nicht mehr ein Admin dieses Gruppenchats"
 
-#: dist/converse-no-dependencies.js:47874
+#: dist/converse-no-dependencies.js:50513
 #, javascript-format
 msgid "%1$s is no longer an owner of this groupchat"
 msgstr "%1$s ist nicht mehr Eigentümer dieses Gruppenchats"
 
-#: dist/converse-no-dependencies.js:47876
+#: dist/converse-no-dependencies.js:50515
 #, javascript-format
 msgid "%1$s is no longer banned from this groupchat"
 msgstr "%1$s ist in diesem Gruppenchat nicht mehr gesperrt"
 
-#: dist/converse-no-dependencies.js:47880
+#: dist/converse-no-dependencies.js:50519
 #, javascript-format
 msgid "%1$s is no longer a member of this groupchat"
 msgstr "%1$s ist nicht mehr ein Mitglied dieses Gruppenchats"
 
-#: dist/converse-no-dependencies.js:47884
+#: dist/converse-no-dependencies.js:50523
 #, javascript-format
 msgid "%1$s is now a member of this groupchat"
 msgstr "%1$s ist nun Mitglied dieses Gruppenchats"
 
-#: dist/converse-no-dependencies.js:47886
+#: dist/converse-no-dependencies.js:50525
 #, javascript-format
 msgid "%1$s has been banned from this groupchat"
 msgstr "%1$s wurde aus diesem Gruppenchat entfernt"
 
 #. For example: AppleJack is now an (admin|owner) of this groupchat
-#: dist/converse-no-dependencies.js:47889
+#: dist/converse-no-dependencies.js:50528
 #, javascript-format
 msgid "%1$s is now an %2$s of this groupchat"
 msgstr "%1$s ist nun ein %2$s dieses Gruppenchats"
 
-#: dist/converse-no-dependencies.js:47908
+#: dist/converse-no-dependencies.js:50547
 #, javascript-format
 msgid "%1$s is no longer a moderator"
 msgstr "%1$s ist kein Moderator mehr"
 
-#: dist/converse-no-dependencies.js:47912
+#: dist/converse-no-dependencies.js:50551
 #, javascript-format
 msgid "%1$s has been given a voice"
 msgstr "%1$s darf nun wieder schreiben"
 
-#: dist/converse-no-dependencies.js:47916
+#: dist/converse-no-dependencies.js:50555
 #, javascript-format
 msgid "%1$s has been muted"
 msgstr "%1$s wurde das Schreibrecht entzogen"
@@ -1287,37 +1369,37 @@ msgstr "%1$s wurde das Schreibrecht entzogen"
 #. We only show this message if the user isn't already
 #. an admin or owner, otherwise this isn't new
 #. information.
-#: dist/converse-no-dependencies.js:47924
+#: dist/converse-no-dependencies.js:50563
 #, javascript-format
 msgid "%1$s is now a moderator"
 msgstr "%1$s ist jetzt ein Moderator"
 
-#: dist/converse-no-dependencies.js:47936
+#: dist/converse-no-dependencies.js:50575
 msgid "Close and leave this groupchat"
 msgstr "Schließen und diesen Gruppenchat verlassen"
 
-#: dist/converse-no-dependencies.js:47937
+#: dist/converse-no-dependencies.js:50576
 msgid "Configure this groupchat"
 msgstr "Diesen Gruppenchat konfigurieren"
 
-#: dist/converse-no-dependencies.js:47938
+#: dist/converse-no-dependencies.js:50577
 msgid "Show more details about this groupchat"
 msgstr "Mehr Information über diesen Gruppenchat anzeigen"
 
-#: dist/converse-no-dependencies.js:47980
+#: dist/converse-no-dependencies.js:50618
 msgid "Hide the list of participants"
 msgstr "Teilnehmerliste ausblenden"
 
-#: dist/converse-no-dependencies.js:48072
+#: dist/converse-no-dependencies.js:50735
 msgid "Forbidden: you do not have the necessary role in order to do that."
 msgstr "Verboten: Sie haben nicht die nötigen Rechte, um das zu tun."
 
-#: dist/converse-no-dependencies.js:48101
+#: dist/converse-no-dependencies.js:50764
 msgid ""
 "Forbidden: you do not have the necessary affiliation in order to do that."
 msgstr "Verboten: Sie haben nicht die nötige Zugehörigkeit, um das zu tun."
 
-#: dist/converse-no-dependencies.js:48108
+#: dist/converse-no-dependencies.js:50771
 #, javascript-format
 msgid ""
 "Error: the \"%1$s\" command takes two arguments, the user's nickname and "
@@ -1326,18 +1408,18 @@ msgstr ""
 "Fehler: Das „%1$s”-Kommando benötigt zwei Argumente: Den Spitznamen und "
 "einen Grund."
 
-#: dist/converse-no-dependencies.js:48126
-#: dist/converse-no-dependencies.js:48139
+#: dist/converse-no-dependencies.js:50789
+#: dist/converse-no-dependencies.js:50802
 msgid "Error: couldn't find a groupchat participant based on your arguments"
 msgstr ""
 "Fehler: Konnte keinen Groupchat-Teilnehmer anhand ihrer Kriterien finden"
 
-#: dist/converse-no-dependencies.js:48131
+#: dist/converse-no-dependencies.js:50794
 msgid "Error: found multiple groupchat participant based on your arguments"
 msgstr ""
 "Fehler: Mehrere Gruppenchat-Teilnehmer basierend auf ihren Kriterien gefunden"
 
-#: dist/converse-no-dependencies.js:48225
+#: dist/converse-no-dependencies.js:50887
 msgid ""
 "Sorry, an error happened while running the command. Check your browser's "
 "developer console for details."
@@ -1345,229 +1427,234 @@ msgstr ""
 "Leider ist ein Fehler während dem Ausführen des Kommandos aufgetreten. "
 "Überprüfe die Entwicklerkonsole des Browsers."
 
-#: dist/converse-no-dependencies.js:48324
+#: dist/converse-no-dependencies.js:50986
 msgid "You can run the following commands"
 msgstr "Sie können die folgenden Befehle ausführen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Change user's affiliation to admin"
 msgstr "Zugehörigkeit des Benutzers zu Administrator ändern"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Ban user by changing their affiliation to outcast"
 msgstr ""
 "Sperren Sie Benutzer, indem Sie ihre Zugehörigkeit zu ausgeschlossenen "
 "Personen ändern"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Clear the chat area"
 msgstr "Löschen des Chatbereichs"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
+#, fuzzy
+msgid "Close this groupchat"
+msgstr "Diesen Gruppenchat entfernen"
+
+#: dist/converse-no-dependencies.js:50987
 msgid "Change user role to participant"
 msgstr "Rolle zu Teilnehmer ändern"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Remove this groupchat"
 msgstr "Diesen Gruppenchat entfernen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Kick user from groupchat"
 msgstr "Mitglied aus diesem Gruppenchat entfernen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Write in 3rd person"
 msgstr "In der dritten Person schreiben"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant membership to a user"
 msgstr "Einem Benutzer die Mitgliedschaft gewähren"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Opens up the moderator tools GUI"
 msgstr "Öffnet die Benutzeroberfläche der Moderatorentools"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Remove user's ability to post messages"
 msgstr "Die Möglichkeit des Benutzers, Nachrichten zu senden, entfernen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Change your nickname"
 msgstr "Eigenen Spitznamen ändern"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant moderator role to user"
 msgstr "Benutzer Moderatorenrechte gewähren"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Grant ownership of this groupchat"
 msgstr "Besitzrechte an diesem Gruppenchat vergeben"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Register your nickname"
 msgstr "Registrieren Sie Ihren Spitznamen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Revoke the user's current affiliation"
 msgstr "Widerrufen der aktuellen Zugehörigkeit des Benutzers"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Set groupchat subject"
 msgstr "Thema des Gruppenchats festlegen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Set groupchat subject (alias for /subject)"
 msgstr "Gruppenchatthema (alias für /subject) festlegen"
 
-#: dist/converse-no-dependencies.js:48325
+#: dist/converse-no-dependencies.js:50987
 msgid "Allow muted user to post messages"
 msgstr "Stummgeschaltetem Benutzer erlauben Nachrichten zu senden"
 
 #. e.g. Your nickname is "coolguy69"
-#: dist/converse-no-dependencies.js:48361
+#: dist/converse-no-dependencies.js:51023
 #, javascript-format
 msgid "Your nickname is \"%1$s\""
 msgstr "Ihr Spitzname ist \"%1$s\""
 
-#: dist/converse-no-dependencies.js:48388
+#: dist/converse-no-dependencies.js:51050
 msgid "Error: invalid number of arguments"
 msgstr "Fehler: ungültige Anzahl von Argumenten"
 
-#: dist/converse-no-dependencies.js:48708
+#: dist/converse-no-dependencies.js:51370
 #, javascript-format
 msgid "%1$s has left and re-entered the groupchat. \"%2$s\""
 msgstr ""
 "%1$s hat den Gruppenchat verlassen und ist wieder beigetreten. \"%2$s\""
 
-#: dist/converse-no-dependencies.js:48710
+#: dist/converse-no-dependencies.js:51372
 #, javascript-format
 msgid "%1$s has left and re-entered the groupchat"
 msgstr "%1$s ist den Gruppenchat verlassen und ist wieder beigetreten"
 
-#: dist/converse-no-dependencies.js:48733
+#: dist/converse-no-dependencies.js:51395
 #, javascript-format
 msgid "%1$s has entered the groupchat. \"%2$s\""
 msgstr "%1$s ist dem Gruppenchat beigetreten. „%2$s”"
 
-#: dist/converse-no-dependencies.js:48735
+#: dist/converse-no-dependencies.js:51397
 #, javascript-format
 msgid "%1$s has entered the groupchat"
 msgstr "%1$s ist dem Gruppenchat beigetreten"
 
-#: dist/converse-no-dependencies.js:48771
+#: dist/converse-no-dependencies.js:51433
 #, javascript-format
 msgid "%1$s has entered and left the groupchat. \"%2$s\""
 msgstr "%1$s ist dem Gruppenchat beigetreten und ihn wieder verlassen. „%2$s”"
 
-#: dist/converse-no-dependencies.js:48773
+#: dist/converse-no-dependencies.js:51435
 #, javascript-format
 msgid "%1$s has entered and left the groupchat"
 msgstr "%1$s ist dem Gruppenchat beigetreten und ihn wieder verlassen"
 
-#: dist/converse-no-dependencies.js:48796
+#: dist/converse-no-dependencies.js:51458
 #, javascript-format
 msgid "%1$s has left the groupchat. \"%2$s\""
 msgstr "%1$s hat den Gruppenchat verlassen. „%2$s”"
 
-#: dist/converse-no-dependencies.js:48798
+#: dist/converse-no-dependencies.js:51460
 #, javascript-format
 msgid "%1$s has left the groupchat"
 msgstr "%1$s hat den Gruppenchat verlassen"
 
-#: dist/converse-no-dependencies.js:48861
+#: dist/converse-no-dependencies.js:51523
 #, javascript-format
 msgid "Topic set by %1$s"
 msgstr "Thema von %1$s festgelegt"
 
-#: dist/converse-no-dependencies.js:48861
+#: dist/converse-no-dependencies.js:51523
 #, javascript-format
 msgid "Topic cleared by %1$s"
 msgstr "Thema wurde durch %1$s bereinigt"
 
-#: dist/converse-no-dependencies.js:48895
+#: dist/converse-no-dependencies.js:51557
 msgid "Groupchats"
 msgstr "Gruppenchat"
 
-#: dist/converse-no-dependencies.js:48896
+#: dist/converse-no-dependencies.js:51558
 msgid "Add a new groupchat"
 msgstr "Neuen Gruppenchat hinzufügen"
 
-#: dist/converse-no-dependencies.js:48897
+#: dist/converse-no-dependencies.js:51559
 msgid "Query for groupchats"
 msgstr "Gruppenchats abfragen"
 
-#: dist/converse-no-dependencies.js:48985
+#: dist/converse-no-dependencies.js:51647
 msgid "This groupchat requires a password"
 msgstr "Dieser Gruppenchat erfordert ein Passwort"
 
-#: dist/converse-no-dependencies.js:48986
+#: dist/converse-no-dependencies.js:51648
 msgid "Password: "
 msgstr "Passwort: "
 
-#: dist/converse-no-dependencies.js:48987
+#: dist/converse-no-dependencies.js:51649
 msgid "Submit"
 msgstr "Senden"
 
-#: dist/converse-no-dependencies.js:49012
+#: dist/converse-no-dependencies.js:51674
 msgid "Please choose your nickname"
 msgstr "Wählen Sie Ihren Spitznamen"
 
-#: dist/converse-no-dependencies.js:49014
+#: dist/converse-no-dependencies.js:51676
 msgid "Enter groupchat"
 msgstr "Gruppenchat beitreten"
 
-#: dist/converse-no-dependencies.js:49036
+#: dist/converse-no-dependencies.js:51698
 msgid "You need to provide a nickname"
 msgstr "Sie müssen einen Spitznamen angeben"
 
-#: dist/converse-no-dependencies.js:49053
+#: dist/converse-no-dependencies.js:51715
 #, javascript-format
 msgid "Click to mention %1$s in your message."
 msgstr "Klicken Sie hier, um %1$s in Ihrer Nachricht zu erwähnen."
 
-#: dist/converse-no-dependencies.js:49054
+#: dist/converse-no-dependencies.js:51716
 msgid "This user is a moderator."
 msgstr "Dieser Benutzer ist ein Moderator."
 
-#: dist/converse-no-dependencies.js:49055
+#: dist/converse-no-dependencies.js:51717
 msgid "This user can send messages in this groupchat."
 msgstr "Dieser Teilnehmer kann Nachrichten in diesem Gruppenchat versenden."
 
-#: dist/converse-no-dependencies.js:49056
+#: dist/converse-no-dependencies.js:51718
 msgid "This user can NOT send messages in this groupchat."
 msgstr ""
 "Dieser Teilnehmer kann keine Nachrichten in diesem Gruppenchat versenden."
 
-#: dist/converse-no-dependencies.js:49057
+#: dist/converse-no-dependencies.js:51719
 msgid "Moderator"
 msgstr "Moderator"
 
-#: dist/converse-no-dependencies.js:49058
+#: dist/converse-no-dependencies.js:51720
 msgid "Visitor"
 msgstr "Besucher"
 
-#: dist/converse-no-dependencies.js:49059
+#: dist/converse-no-dependencies.js:51721
 msgid "Owner"
 msgstr "Eigentümer"
 
-#: dist/converse-no-dependencies.js:49060
+#: dist/converse-no-dependencies.js:51722
 msgid "Member"
 msgstr "Mitglieder"
 
-#: dist/converse-no-dependencies.js:49061
+#: dist/converse-no-dependencies.js:51723
 msgid "Admin"
 msgstr "Administrator"
 
-#: dist/converse-no-dependencies.js:49117
+#: dist/converse-no-dependencies.js:51779
 msgid "Participants"
 msgstr "Teilnehmer"
 
-#: dist/converse-no-dependencies.js:49150
-#: dist/converse-no-dependencies.js:49210
+#: dist/converse-no-dependencies.js:51812
+#: dist/converse-no-dependencies.js:51872
 msgid "Invite"
 msgstr "Einladen"
 
-#: dist/converse-no-dependencies.js:49185
+#: dist/converse-no-dependencies.js:51847
 #, javascript-format
 msgid ""
 "You are about to invite %1$s to the groupchat \"%2$s\". You may optionally "
@@ -1577,66 +1664,66 @@ msgstr ""
 "Sie eine Nachricht anfügen, in der Sie den Grund für die Einladung erläutern."
 
 #. workaround for Prosody which doesn't give type "headline"
-#: dist/converse-no-dependencies.js:49602
-#: dist/converse-no-dependencies.js:49608
+#: dist/converse-no-dependencies.js:52370
+#: dist/converse-no-dependencies.js:52376
 #, javascript-format
 msgid "Notification from %1$s"
 msgstr "Benachrichtigung von %1$s"
 
-#: dist/converse-no-dependencies.js:49610
-#: dist/converse-no-dependencies.js:49621
-#: dist/converse-no-dependencies.js:49624
+#: dist/converse-no-dependencies.js:52378
+#: dist/converse-no-dependencies.js:52388
+#: dist/converse-no-dependencies.js:52391
 #, javascript-format
 msgid "%1$s says"
 msgstr "%1$s sagt"
 
 #. TODO: we should suppress notifications if we cannot decrypt
 #. the message...
-#: dist/converse-no-dependencies.js:49633
+#: dist/converse-no-dependencies.js:52400
 msgid "OMEMO Message received"
 msgstr "OMEMO-Nachricht empfangen"
 
-#: dist/converse-no-dependencies.js:49664
+#: dist/converse-no-dependencies.js:52431
 msgid "has gone offline"
 msgstr "hat sich abgemeldet"
 
-#: dist/converse-no-dependencies.js:49666
+#: dist/converse-no-dependencies.js:52433
 msgid "has gone away"
 msgstr "ist jetzt abwesend"
 
-#: dist/converse-no-dependencies.js:49668
+#: dist/converse-no-dependencies.js:52435
 msgid "is busy"
 msgstr "ist beschäftigt"
 
-#: dist/converse-no-dependencies.js:49670
+#: dist/converse-no-dependencies.js:52437
 msgid "has come online"
 msgstr "kam online"
 
-#: dist/converse-no-dependencies.js:49687
+#: dist/converse-no-dependencies.js:52454
 msgid "wants to be your contact"
 msgstr "möchte Ihr Kontakt sein"
 
-#: dist/converse-no-dependencies.js:49888
+#: dist/converse-no-dependencies.js:52655
 msgid "Your avatar image"
 msgstr "Dein Avatarbild"
 
-#: dist/converse-no-dependencies.js:49889
+#: dist/converse-no-dependencies.js:52656
 msgid "Your Profile"
 msgstr "Dein Profil"
 
-#: dist/converse-no-dependencies.js:49891
+#: dist/converse-no-dependencies.js:52658
 msgid "Email"
 msgstr "E-Mail"
 
-#: dist/converse-no-dependencies.js:49892
+#: dist/converse-no-dependencies.js:52659
 msgid "Full Name"
 msgstr "Name"
 
-#: dist/converse-no-dependencies.js:49893
+#: dist/converse-no-dependencies.js:52660
 msgid "XMPP Address (JID)"
 msgstr "XMPP/Jabber-ID (JID)"
 
-#: dist/converse-no-dependencies.js:49896
+#: dist/converse-no-dependencies.js:52663
 msgid ""
 "Use commas to separate multiple roles. Your roles are shown next to your "
 "name on your chat messages."
@@ -1644,61 +1731,61 @@ msgstr ""
 "Benutze Kommas um die Rollen zu separieren. Die Rollen erscheinen neben "
 "deinem Namen."
 
-#: dist/converse-no-dependencies.js:49897
+#: dist/converse-no-dependencies.js:52664
 msgid "URL"
 msgstr "URL"
 
-#: dist/converse-no-dependencies.js:49931
+#: dist/converse-no-dependencies.js:52698
 msgid "Sorry, an error happened while trying to save your profile data."
 msgstr "Leider ist beim Speichern deiner Profildaten ein Fehler aufgetreten."
 
-#: dist/converse-no-dependencies.js:49931
+#: dist/converse-no-dependencies.js:52698
 msgid "You can check your browser's developer console for any error output."
 msgstr ""
 "Schau in die Entwicklerkonsole des Browsers um mögliche Fehlerausgaben zu "
 "sehen."
 
-#: dist/converse-no-dependencies.js:49978
-#: dist/converse-no-dependencies.js:54384
+#: dist/converse-no-dependencies.js:52745
+#: dist/converse-no-dependencies.js:57137
 msgid "Away"
 msgstr "Abwesend"
 
-#: dist/converse-no-dependencies.js:49980
-#: dist/converse-no-dependencies.js:54383
+#: dist/converse-no-dependencies.js:52747
+#: dist/converse-no-dependencies.js:57136
 msgid "Busy"
 msgstr "Beschäftigt"
 
-#: dist/converse-no-dependencies.js:49982
+#: dist/converse-no-dependencies.js:52749
 msgid "Custom status"
 msgstr "Statusnachricht"
 
-#: dist/converse-no-dependencies.js:49983
-#: dist/converse-no-dependencies.js:54386
+#: dist/converse-no-dependencies.js:52750
+#: dist/converse-no-dependencies.js:57139
 msgid "Offline"
 msgstr "Abgemeldet"
 
-#: dist/converse-no-dependencies.js:49984
-#: dist/converse-no-dependencies.js:54381
+#: dist/converse-no-dependencies.js:52751
+#: dist/converse-no-dependencies.js:57134
 msgid "Online"
 msgstr "Online"
 
-#: dist/converse-no-dependencies.js:49986
+#: dist/converse-no-dependencies.js:52753
 msgid "Away for long"
 msgstr "Lange abwesend"
 
-#: dist/converse-no-dependencies.js:49987
+#: dist/converse-no-dependencies.js:52754
 msgid "Change chat status"
 msgstr "Hier klicken, um Ihren Status zu ändern"
 
-#: dist/converse-no-dependencies.js:49988
+#: dist/converse-no-dependencies.js:52755
 msgid "Personal status message"
 msgstr "Persönliche Statusnachricht"
 
-#: dist/converse-no-dependencies.js:50021
+#: dist/converse-no-dependencies.js:52788
 msgid "About"
 msgstr "Über"
 
-#: dist/converse-no-dependencies.js:50023
+#: dist/converse-no-dependencies.js:52790
 #, javascript-format
 msgid ""
 "%1$s Open Source %2$s XMPP chat client brought to you by %3$s Opkode %2$s"
@@ -1706,67 +1793,67 @@ msgstr ""
 "%1$s Open Source %2$s XMPP Chat Client, der Ihnen von %3$s Opkode %2$s zur "
 "Verfügung gestellt wird"
 
-#: dist/converse-no-dependencies.js:50024
+#: dist/converse-no-dependencies.js:52791
 #, javascript-format
 msgid "%1$s Translate %2$s it into your own language"
 msgstr "%1$s Übersetzen Sie %2$s es in Ihre eigene Sprache"
 
-#: dist/converse-no-dependencies.js:50045
+#: dist/converse-no-dependencies.js:52812
 #, javascript-format
 msgid "I am %1$s"
 msgstr "Ich bin %1$s"
 
-#: dist/converse-no-dependencies.js:50048
+#: dist/converse-no-dependencies.js:52815
 msgid "Change settings"
 msgstr "Einstellungen ändern"
 
-#: dist/converse-no-dependencies.js:50049
+#: dist/converse-no-dependencies.js:52816
 msgid "Click to change your chat status"
 msgstr "Hier klicken, um Ihren Status zu ändern"
 
-#: dist/converse-no-dependencies.js:50050
+#: dist/converse-no-dependencies.js:52817
 msgid "Log out"
 msgstr "Abmelden"
 
-#: dist/converse-no-dependencies.js:50051
+#: dist/converse-no-dependencies.js:52818
 msgid "Show details about this chat client"
 msgstr "Details zu diesem Chat-Client anzeigen"
 
-#: dist/converse-no-dependencies.js:50052
+#: dist/converse-no-dependencies.js:52819
 msgid "Your profile"
 msgstr "Dein Profil"
 
-#: dist/converse-no-dependencies.js:50087
+#: dist/converse-no-dependencies.js:52854
 msgid "Are you sure you want to log out?"
 msgstr "Möchten Sie sich wirklich abmelden?"
 
-#: dist/converse-no-dependencies.js:50095
-#: dist/converse-no-dependencies.js:50105
+#: dist/converse-no-dependencies.js:52862
+#: dist/converse-no-dependencies.js:52872
 msgid "online"
 msgstr "online"
 
-#: dist/converse-no-dependencies.js:50097
+#: dist/converse-no-dependencies.js:52864
 msgid "busy"
 msgstr "beschäftigt"
 
-#: dist/converse-no-dependencies.js:50099
+#: dist/converse-no-dependencies.js:52866
 msgid "away for long"
 msgstr "länger abwesend"
 
-#: dist/converse-no-dependencies.js:50101
+#: dist/converse-no-dependencies.js:52868
 msgid "away"
 msgstr "abwesend"
 
-#: dist/converse-no-dependencies.js:50103
+#: dist/converse-no-dependencies.js:52870
 msgid "offline"
 msgstr "abgemeldet"
 
-#: dist/converse-no-dependencies.js:50483
+#: dist/converse-no-dependencies.js:53250
 msgid "Sorry, an error occurred while trying to remove the devices."
 msgstr ""
 "Leider ist beim Versuch, die Geräte zu entfernen, ein Fehler aufgetreten."
 
-#: dist/converse-no-dependencies.js:50492
+#: dist/converse-no-dependencies.js:53259
 msgid ""
 "Are you sure you want to generate new OMEMO keys? This will remove your old "
 "keys and all previously encrypted messages will no longer be decryptable on "
@@ -1776,7 +1863,7 @@ msgstr ""
 "Ihre alten Schlüssel entfernt und alle zuvor verschlüsselten Nachrichten "
 "sind auf diesem Gerät nicht mehr entschlüsselbar."
 
-#: dist/converse-no-dependencies.js:50924
+#: dist/converse-no-dependencies.js:53691
 #, javascript-format
 msgid ""
 "Sorry, we're unable to send an encrypted message because %1$s requires you "
@@ -1786,7 +1873,7 @@ msgstr ""
 "dass Sie für ihre Teilnahme angemeldet sind, um ihre OMEMO-Informationen zu "
 "sehen"
 
-#: dist/converse-no-dependencies.js:50926
+#: dist/converse-no-dependencies.js:53693
 #, javascript-format
 msgid ""
 "Sorry, we're unable to send an encrypted message because the remote server "
@@ -1795,13 +1882,13 @@ msgstr ""
 "Leider können wir keine verschlüsselte Nachricht senden, da der Remote-"
 "Server für %1$s nicht gefunden werden konnte"
 
-#: dist/converse-no-dependencies.js:50928
+#: dist/converse-no-dependencies.js:53695
 msgid "Unable to send an encrypted message due to an unexpected error."
 msgstr ""
 "Die verschlüsselte Nachricht konnte aufgrund eines unerwarteten Fehlers "
 "nicht versendet werden."
 
-#: dist/converse-no-dependencies.js:50978
+#: dist/converse-no-dependencies.js:53745
 msgid ""
 "Cannot use end-to-end encryption in this groupchat, either the groupchat has "
 "some anonymity or not all participants support OMEMO."
@@ -1810,7 +1897,7 @@ msgstr ""
 "werden, entweder hat der Gruppenchat eine gewisse Anonymität oder nicht alle "
 "Teilnehmer unterstützen OMEMO."
 
-#: dist/converse-no-dependencies.js:50980
+#: dist/converse-no-dependencies.js:53747
 #, javascript-format
 msgid ""
 "Cannot use end-to-end encryption because %1$s uses a client that doesn't "
@@ -1819,14 +1906,14 @@ msgstr ""
 "Ende-zu-Ende Verschlüsselung konnte nicht verwendet werden, da %1$s einen "
 "Client verwendet, der OMEMO nicht unterstützt."
 
-#: dist/converse-no-dependencies.js:51276
+#: dist/converse-no-dependencies.js:54040
 msgid ""
 "Sorry, no devices found to which we can send an OMEMO encrypted message."
 msgstr ""
 "Leider können wir keine Geräte finden, an die wir eine OMEMO-verschlüsselte "
 "Nachricht senden können."
 
-#: dist/converse-no-dependencies.js:51406
+#: dist/converse-no-dependencies.js:54170
 msgid ""
 "This is an OMEMO encrypted message which your client doesn’t seem to "
 "support. Find more information on https://conversations.im/omemo"
@@ -1835,7 +1922,7 @@ msgstr ""
 "unterstützen scheint. Weitere Informationen finden Sie unter https://"
 "conversations.im/omemo"
 
-#: dist/converse-no-dependencies.js:52400
+#: dist/converse-no-dependencies.js:55152
 #, javascript-format
 msgid ""
 "%1$s doesn't appear to have a client that supports OMEMO. Encrypted chat "
@@ -1844,29 +1931,29 @@ msgstr ""
 "%1$s scheint keinen Client zu haben, der OMEMO unterstützt. Ein "
 "verschlüsselter Chat wird in diesem Gruppenchat nicht mehr möglich sein."
 
-#: dist/converse-no-dependencies.js:53066
+#: dist/converse-no-dependencies.js:55819
 msgid " e.g. conversejs.org"
 msgstr " z. B. conversejs.org"
 
-#: dist/converse-no-dependencies.js:53182
+#: dist/converse-no-dependencies.js:55935
 msgid "Fetch registration form"
 msgstr "Anmeldeformular wird abgerufen"
 
-#: dist/converse-no-dependencies.js:53183
+#: dist/converse-no-dependencies.js:55936
 msgid "Tip: A list of public XMPP providers is available"
 msgstr "Tipp: Eine Liste öffentlicher Provider ist verfügbar"
 
-#: dist/converse-no-dependencies.js:53184
+#: dist/converse-no-dependencies.js:55937
 msgid "here"
 msgstr "hier"
 
-#: dist/converse-no-dependencies.js:53235
+#: dist/converse-no-dependencies.js:55988
 msgid "Sorry, we're unable to connect to your chosen provider."
 msgstr ""
 "Leider können wir keine Verbindung zu dem von Ihnen gewählten Provider "
 "herstellen."
 
-#: dist/converse-no-dependencies.js:53251
+#: dist/converse-no-dependencies.js:56004
 msgid ""
 "Sorry, the given provider does not support in band account registration. "
 "Please try with a different provider."
@@ -1874,7 +1961,7 @@ msgstr ""
 "Leider unterstützt der angegebene Anbieter die keine Benutzerregistrierung. "
 "Bitte versuche es bei einem anderen Anbieter."
 
-#: dist/converse-no-dependencies.js:53277
+#: dist/converse-no-dependencies.js:56030
 #, javascript-format
 msgid ""
 "Something went wrong while establishing a connection with \"%1$s\". Are you "
@@ -1883,15 +1970,15 @@ msgstr ""
 "Die Verbindung zu „%1$s” konnte nicht hergestellt werden. Sind Sie sicher, "
 "dass „%1$s” existiert?"
 
-#: dist/converse-no-dependencies.js:53468
+#: dist/converse-no-dependencies.js:56220
 msgid "Now logging you in"
 msgstr "Sie werden angemeldet"
 
-#: dist/converse-no-dependencies.js:53472
+#: dist/converse-no-dependencies.js:56224
 msgid "Registered successfully"
 msgstr "Registrierung erfolgreich"
 
-#: dist/converse-no-dependencies.js:53584
+#: dist/converse-no-dependencies.js:56336
 msgid ""
 "The provider rejected your registration attempt. Please check the values you "
 "entered for correctness."
@@ -1899,144 +1986,168 @@ msgstr ""
 "Der Provider hat die Registrierung abgelehnt. Bitte überprüfen Sie Ihre "
 "Angaben auf Richtigkeit."
 
-#: dist/converse-no-dependencies.js:53895
+#: dist/converse-no-dependencies.js:56648
 msgid "Click to toggle the list of open groupchats"
 msgstr "Gruppenteilnehmer anzeigen"
 
 #. Note to translators, "Open Groupchats" refers to groupchats that are open, NOT a command.
-#: dist/converse-no-dependencies.js:53906
+#: dist/converse-no-dependencies.js:56659
 msgid "Open Groupchats"
 msgstr "Offene Gruppenchats"
 
-#: dist/converse-no-dependencies.js:53973
+#: dist/converse-no-dependencies.js:56726
 #, javascript-format
 msgid "Are you sure you want to leave the groupchat %1$s?"
 msgstr "Möchten Sie den Gruppenchat „%1$s” wirklich verlassen?"
 
-#: dist/converse-no-dependencies.js:54179
+#: dist/converse-no-dependencies.js:56932
 msgid "This contact is busy"
 msgstr "Dieser Kontakt ist beschäftigt"
 
-#: dist/converse-no-dependencies.js:54180
+#: dist/converse-no-dependencies.js:56933
 msgid "This contact is online"
 msgstr "Dieser Kontakt ist online"
 
-#: dist/converse-no-dependencies.js:54181
+#: dist/converse-no-dependencies.js:56934
 msgid "This contact is offline"
 msgstr "Dieser Kontakt ist offline"
 
-#: dist/converse-no-dependencies.js:54182
+#: dist/converse-no-dependencies.js:56935
 msgid "This contact is unavailable"
 msgstr "Dieser Kontakt ist nicht verfügbar"
 
-#: dist/converse-no-dependencies.js:54183
+#: dist/converse-no-dependencies.js:56936
 msgid "This contact is away for an extended period"
 msgstr "Dieser Kontakt ist für längere Zeit abwesend"
 
-#: dist/converse-no-dependencies.js:54184
+#: dist/converse-no-dependencies.js:56937
 msgid "This contact is away"
 msgstr "Dieser Kontakt ist abwesend"
 
-#: dist/converse-no-dependencies.js:54196
+#: dist/converse-no-dependencies.js:56949
 msgid "Contact name"
 msgstr "Name des Kontakts"
 
-#: dist/converse-no-dependencies.js:54196
+#: dist/converse-no-dependencies.js:56949
 msgid "Optional nickname"
 msgstr "Optionaler Spitzname"
 
-#: dist/converse-no-dependencies.js:54199
+#: dist/converse-no-dependencies.js:56952
 msgid "Add a Contact"
 msgstr "Kontakt hinzufügen"
 
-#: dist/converse-no-dependencies.js:54200
+#: dist/converse-no-dependencies.js:56953
 msgid "XMPP Address"
 msgstr "XMPP-Adresse"
 
-#: dist/converse-no-dependencies.js:54202
+#: dist/converse-no-dependencies.js:56955
 msgid "name@example.org"
 msgstr "z.B. benutzer@beispiel.org"
 
-#: dist/converse-no-dependencies.js:54203
+#: dist/converse-no-dependencies.js:56956
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: dist/converse-no-dependencies.js:54293
+#: dist/converse-no-dependencies.js:57046
 msgid "Sorry, could not find a contact with that name"
 msgstr "Leider konnte kein Kontakt mit diesem Namen gefunden werden"
 
-#: dist/converse-no-dependencies.js:54318
+#: dist/converse-no-dependencies.js:57071
 msgid "This contact has already been added"
 msgstr "Dieser Kontakt wurde bereits hinzugefügt"
 
-#: dist/converse-no-dependencies.js:54375
+#: dist/converse-no-dependencies.js:57128
 msgid "Filter"
 msgstr "Filter"
 
-#: dist/converse-no-dependencies.js:54376
+#: dist/converse-no-dependencies.js:57129
 msgid "Filter by contact name"
 msgstr "Nach Name des Kontakts filtern"
 
-#: dist/converse-no-dependencies.js:54377
+#: dist/converse-no-dependencies.js:57130
 msgid "Filter by group name"
 msgstr "Nach Gruppennamen filtern"
 
-#: dist/converse-no-dependencies.js:54378
+#: dist/converse-no-dependencies.js:57131
 msgid "Filter by status"
 msgstr "Suche via Status"
 
-#: dist/converse-no-dependencies.js:54379
+#: dist/converse-no-dependencies.js:57132
 msgid "Any"
 msgstr "Jeder"
 
-#: dist/converse-no-dependencies.js:54380
+#: dist/converse-no-dependencies.js:57133
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: dist/converse-no-dependencies.js:54382
+#: dist/converse-no-dependencies.js:57135
 msgid "Chatty"
 msgstr "Gesprächsbereit"
 
-#: dist/converse-no-dependencies.js:54385
+#: dist/converse-no-dependencies.js:57138
 msgid "Extended Away"
 msgstr "Länger nicht anwesend"
 
-#: dist/converse-no-dependencies.js:54550
-#: dist/converse-no-dependencies.js:54605
+#: dist/converse-no-dependencies.js:57329
+#: dist/converse-no-dependencies.js:57384
 #, javascript-format
 msgid "Click to remove %1$s as a contact"
 msgstr "Hier klicken, um %1$s als Kontakt zu entfernen"
 
-#: dist/converse-no-dependencies.js:54559
+#: dist/converse-no-dependencies.js:57338
 #, javascript-format
 msgid "Click to accept the contact request from %1$s"
 msgstr "Hier klicken, um die Kontaktanfrage von %1$s zu akzeptieren"
 
-#: dist/converse-no-dependencies.js:54560
+#: dist/converse-no-dependencies.js:57339
 #, javascript-format
 msgid "Click to decline the contact request from %1$s"
 msgstr "Hier klicken, um die Kontaktanfrage von %1$s abzulehnen"
 
-#: dist/converse-no-dependencies.js:54604
+#: dist/converse-no-dependencies.js:57383
 #, javascript-format
 msgid "Click to chat with %1$s (JID: %2$s)"
 msgstr "Hier klicken, um mit %1$s (JID: %2$s) eine Unterhaltung zu beginnen"
 
-#: dist/converse-no-dependencies.js:54743
+#: dist/converse-no-dependencies.js:57524
 msgid "Are you sure you want to decline this contact request?"
 msgstr "Möchten Sie diese Kontaktanfrage wirklich ablehnen?"
 
-#: dist/converse-no-dependencies.js:55059
+#: dist/converse-no-dependencies.js:57851
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: dist/converse-no-dependencies.js:55060
+#: dist/converse-no-dependencies.js:57852
 msgid "Add a contact"
 msgstr "Kontakt hinzufügen"
 
-#: dist/converse-no-dependencies.js:55061
+#: dist/converse-no-dependencies.js:57853
 msgid "Re-sync your contacts"
 msgstr "Resynchronisieren Sie Ihre Kontakte"
+
+#: dist/converse-no-dependencies.js:58346
+msgid "send"
+msgstr "Senden"
+
+#: dist/converse-no-dependencies.js:58399
+msgid "Choose the Service-admin Function"
+msgstr "Wählen Sie die auszuführende Service-Administration-funktion."
+
+#: dist/converse-no-dependencies.js:58400
+msgid "Announcement"
+msgstr "Ankündigung"
+
+#: dist/converse-no-dependencies.js:58610
+msgid "The command was executed successfully."
+msgstr "Der Befehl wurde erfolgreich ausgeführt"
+
+#: dist/converse-no-dependencies.js:58613
+msgid "The command was NOT executed successfully for the following reason: "
+msgstr "Der Befehl konnte aus folgendem Grund NICHT ausgeführt werden: "
+
+#: dist/converse-no-dependencies.js:58621
+msgid "-- sent from "
+msgstr "-- gesendet von "
 
 #~ msgid "Groups"
 #~ msgstr "Gruppen"
@@ -2074,7 +2185,6 @@ msgstr "Resynchronisieren Sie Ihre Kontakte"
 #~ "Ihre Jabber-ID und/oder Ihr Passwort ist falsch. Bitte versuchen Sie es "
 #~ "erneut."
 
-#, javascript-format
 #~ msgid "Sorry, we could not connect to the XMPP host with domain: %1$s"
 #~ msgstr ""
 #~ "Leider konnten wir keine Verbindung zum XMPP-Host mit der Domain %1$s "
@@ -2105,6 +2215,24 @@ msgstr "Resynchronisieren Sie Ihre Kontakte"
 
 #~ msgid "Error: the groupchat %1$s does not exist."
 #~ msgstr "Fehler: Der Gruppenchat %1$s existiert nicht."
+
+#~ msgid "Announce All"
+#~ msgstr "Ankündigung an alle"
+
+#~ msgid "Announce Online"
+#~ msgstr "Ankündigung an Online-Nutzer"
+
+#~ msgid "Create MOTD"
+#~ msgstr "Nachricht des Tages erfassen"
+
+#~ msgid "Edit MOTD"
+#~ msgstr "Nachricht des Tages bearbeiten"
+
+#~ msgid "Delete MOTD"
+#~ msgstr "Nachricht des Tages löschen"
+
+#~ msgid "Please enter a Message."
+#~ msgstr "Bitten geben Sie eine Nachricht ein."
 
 #~ msgid "Destroy groupchat"
 #~ msgstr "Gruppenchat löschen"

--- a/sass/_chatbox.scss
+++ b/sass/_chatbox.scss
@@ -548,6 +548,27 @@
 
 }
 
+#conversejs {
+    #service-administration {
+        .flyout {
+            border-color: var(--service-administration-color);
+        }
+        .chat-head-chatbox {
+            background-color: var(--service-administration-color);
+        }
+        .chat-body {
+            background-color: var(--chat-textarea-background-color);
+            display: block;
+            padding: 1em;
+            overflow: auto;
+        }
+        .send-button {
+            margin-top: 1em;
+            width: 100%;
+        }
+    }
+}
+
 #conversejs.converse-embedded {
     .converse-chatboxes {
         z-index: 1031; // One more than bootstrap navbar

--- a/sass/_controlbox.scss
+++ b/sass/_controlbox.scss
@@ -358,6 +358,21 @@
     }
 }
 
+#conversejs {
+    #controlbox {
+        #service-admin-panel {
+            .controlbox-heading--service-administration {
+                color: var(--service-administration-color);
+            }
+            .service-admin-selector {
+                color: var(--service-administration-color);
+            }
+            .service-admin-selector-caret {
+                color: var(--service-administration-color);
+            }
+        }
+    }
+}
 
 #conversejs.converse-overlayed {
     .toggle-controlbox {

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -8,6 +8,7 @@ $mobile_portrait_length: 480px !default;
     --redder-orange: #E77051;
     --orange: #E7A151;
     --light-blue: #578EA9;
+    --darker-blue: #3c8be0;
 
     --chat-status-online: var(--green);
     --chat-status-busy: var(--redder-orange);
@@ -125,6 +126,9 @@ $mobile_portrait_length: 480px !default;
 
     --headline-head-color: var(--orange);
     --headline-message-color: #D2842B;
+
+    --service-administration-color: var(--darker-blue);
+    --service-administration-chat-background-color: white;
 
     --chatbox-button-size: 14px;
     --fullpage-chatbox-button-size: 16px;

--- a/src/converse-service-administration.js
+++ b/src/converse-service-administration.js
@@ -1,0 +1,433 @@
+// Converse.js (A browser based XMPP chat client)
+// https://conversejs.org
+//
+// Copyright (c) 2012-2017, Jan-Carel Brand <jc@opkode.com>
+// Licensed under the Mozilla Public License (MPLv2)
+//
+
+import "converse-chatview";
+import "converse-profile";
+import "converse-rosterview";
+import converse from "@converse/headless/converse-core";
+import sizzle from "sizzle";
+import tpl_form_checkbox from "templates/form_checkbox.html";
+import tpl_form_input from "templates/form_input.html";
+import tpl_form_textarea from "templates/form_textarea.html";
+import tpl_service_admin_chat from "templates/service_administration_chat.html";
+import tpl_service_admin_option from "templates/service_administration_option.html";
+import tpl_service_admin_selector from "templates/service_administration_selector.html";
+
+const { $iq, Backbone, Strophe } = converse.env;
+const u = converse.env.utils;
+
+converse.plugins.add('converse-service-administration', {
+
+    /* Plugin dependencies are other plugins which might be
+     * overridden or relied upon, and therefore need to be loaded before
+     * this plugin.
+     *
+     * If the setting "strict_plugin_dependencies" is set to true,
+     * an error will be raised if the plugin is not found. By default it's
+     * false, which means these plugins are only loaded opportunistically.
+     *
+     * NB: These plugins need to have already been loaded via require.js.
+     */
+    dependencies: ["converse-chatboxes", "converse-rosterview", "converse-chatview"],
+
+    initialize () {
+        const { _converse } = this,
+            { __ } = _converse;
+
+        _converse.SERVICE_ADMIN_TYPE = 'service-administration';
+
+        _converse.ServiceAdministration = Backbone.Model.extend({
+            async discoverSupport () {
+                const supported = await _converse.api.disco.supports(Strophe.NS.COMMANDS, _converse.bare_jid);
+                if (supported) {
+                    const stanza = $iq({
+                        'from': _converse.connection.jid,
+                        'id': 'test-supported-commands',
+                        'to': _converse.domain,
+                        'type': 'get'
+                    }).c('query', {
+                        xmlns: Strophe.NS.DISCO_ITEMS,
+                        node: 'announce'
+                    }).up();
+
+                    _converse.connection.sendIQ(stanza, result => {
+                        const commands = sizzle('item[node^="http://jabber.org/protocol/admin"]', result);
+                        _converse.serviceAdminCommands = new _converse.ServiceAdminCommandCollection();
+                        commands.forEach(command => {
+                            const command_description = command.getAttribute('name');
+                            const command_node = command.getAttribute('node');
+                            const command_name = command_node.split('#').pop();
+                            _converse.serviceAdminCommands.add(new _converse.ServiceAdminCommandItem({
+                                command_node: command_node,
+                                description: command_description,
+                                command_name: command_name
+                            }));
+                        });
+                        this.renderControlboxElement();
+                    });
+                }
+            },
+
+            renderControlboxElement () {
+                _converse.serviceAdministrationCommandView = new _converse.ServiceAdminCommandView({collection: _converse.serviceAdminCommands});
+                const groupchat_element = _converse.chatboxviews.get('controlbox').el.querySelector('#chatrooms');
+                if (groupchat_element !== null) {
+                    groupchat_element.insertAdjacentElement('beforebegin', _converse.serviceAdministrationCommandView.render());
+                }
+            }
+        });
+
+        _converse.ServiceAdminCommandItem = Backbone.Model.extend({});
+
+        _converse.ServiceAdminCommandItemView = Backbone.NativeView.extend({
+            tagName: 'div',
+            className: 'list-item controlbox-padded d-flex flex-row',
+            events: {
+                'click': 'openServiceAdminChat'
+            },
+            stanza: 'server_response',
+
+            render () {
+                this.el.innerHTML = tpl_service_admin_option({
+                    'name': this.model.get('command_name'),
+                    'service_admin_name': this.model.get('command_name')
+                });
+                return this.el;
+            },
+
+            openServiceAdminChat () {
+                const stanza = $iq({
+                    'from': _converse.connection.jid,
+                    'id': this.model.attributes.command_name + '-1',
+                    'to': _converse.domain,
+                    'type': 'set',
+                    'xml:lang': _converse.locale
+                }).c('command', {
+                    xmlns: Strophe.NS.COMMANDS,
+                    action: 'execute',
+                    node: this.model.attributes.command_node
+                }).up();
+
+                _converse.connection.sendIQ(stanza, result => {
+                    this.server_response = result;
+                    const session_id = sizzle('command', this.server_response).pop().getAttribute('sessionid');
+                    const title = sizzle('title', this.server_response).pop();
+                    const fields = sizzle('field', this.server_response);
+                    const form_type_value = sizzle('field[var="FORM_TYPE"] > value', this.server_response).pop().innerHTML;
+
+                    const field_array = [];
+                    fields.forEach(field => {
+                        const field_attrs = this.getAttributesFromField(field);
+                        field_array.push(field_attrs);
+                    });
+
+                    const attributes = {
+                        'id': this.model.get('command_name'),
+                        'jid': _converse.domain,
+                        'type': _converse.SERVICE_ADMIN_TYPE,
+                        'from': _converse.domain,
+                        'fields': field_array,
+                        'form_type_value': form_type_value,
+                        'name': this.model.get('name'),
+                        'node': this.model.get('command_node'),
+                        'stanza_id': this.model.get('name'),
+                        'header_text': title.innerHTML,
+                        'send_button_text': __('send'),
+                        'placeholder_text': title.innerHTML,
+                        'session_id': session_id
+                    };
+
+                    const existing_chatbox = _converse.chatboxes.get(this.model.get('command_name'));
+                    if (existing_chatbox) {
+                        existing_chatbox.set(attributes);
+                        existing_chatbox.maybeShow(true);
+                    } else {
+                        const chatbox = new _converse.ServiceAdminBox(attributes);
+
+                        _converse.chatboxes.add(chatbox);
+                        chatbox.maybeShow(true);
+                    }
+                }, error => {
+                    _converse.log(error, Strophe.LogLevel.ERROR);
+                });
+            },
+
+            getAttributesFromField (field) {
+                const attribute_names = field.getAttributeNames();
+                const obj = {};
+                attribute_names.forEach(name => {
+                    obj[name] = field.getAttribute(name);
+                });
+                obj["value"] = this.getValueOfFieldElement(field);
+                obj["required"] = field.getElementsByTagName('required').length !== 0;
+                return obj;
+            },
+
+            getValueOfFieldElement (field) {
+                const values = sizzle('value', field);
+                let string_value = '';
+                values.forEach(value => {
+                    string_value = string_value + value.innerHTML + '\n';
+                });
+                return string_value.substring(0, string_value.length - 1); // return string without last line-break
+            },
+        });
+
+        _converse.ServiceAdminCommandCollection = Backbone.Collection.extend ({
+            model: _converse.ServiceAdminCommandItem,
+        });
+
+        _converse.ServiceAdminCommandView = Backbone.NativeView.extend({
+            tagName: 'div',
+            className: 'controlbox-section',
+            id: 'service-admin-panel',
+            collection: _converse.ServiceAdminCommandCollection,
+            events: {
+                'click a.service-admin-selector': 'toggleAdminOptions'
+            },
+
+            render () {
+                this.el.innerHTML = tpl_service_admin_selector({
+                    'title': __('Choose the Service-admin Function'),
+                    'label': __('Announcement')
+                });
+
+                const service_admin_menu = this.el.querySelector('.service-admin-menu');
+                this.collection.forEach(command => {
+                    const itemView = new _converse.ServiceAdminCommandItemView({ model: command });
+                    service_admin_menu.insertAdjacentElement('beforeend', itemView.render());
+                });
+                return this.el;
+            },
+
+            toggleAdminOptions (ev) {
+                ev.preventDefault();
+                u.slideToggleElement(this.el.querySelector(".service-admin-menu"));
+
+                // toggle caret on List-Item
+                const admin_list_caret = this.el.querySelector('.service-admin-selector-caret');
+                if (admin_list_caret.classList.contains('fa-caret-right')) {
+                    admin_list_caret.classList.remove('fa-caret-right');
+                    admin_list_caret.classList.add('fa-caret-down');
+                } else {
+                    admin_list_caret.classList.remove('fa-caret-down');
+                    admin_list_caret.classList.add('fa-caret-right');
+                }
+            }
+        });
+
+        _converse.ServiceAdminBox = _converse.ChatBox.extend({
+            defaults () {
+                return {
+                    'bookmarked': false,
+                    'box_id': 'service-administration',
+                    'hidden': ['mobile', 'fullscreen'].includes(_converse.view_mode),
+                    'message_type': 'service-administration',
+                    'num_unread': 0,
+                    'time_opened': this.get('time_opened') || (new Date()).getTime(),
+                    'type': _converse.SERVICE_ADMIN_TYPE,
+                    'url': '/test/' // ERROR: the url property is still missing, when save is called ...
+                };
+            }
+        });
+
+        _converse.ServiceAdminBoxView = _converse.ChatBoxView.extend({
+            className: 'chatbox',
+            id: 'service-administration',
+            events: {
+                'click .send-button': 'sendMessageToServer',
+                'click .chatbox-btn': 'close'
+            },
+
+            initialize () {
+                _converse.api.trigger('chatBoxInitialized', this);
+                this.listenTo(this.model, 'destroy', this.hide);
+                this.listenTo(this.model, 'hide', this.hide);
+                this.listenTo(this.model, 'show', this.show);
+                this.listenTo(this.model, 'change:closed', this.ensureClosedState);
+
+                this.render();
+            },
+
+            render () {
+                this.el.innerHTML = tpl_service_admin_chat({
+                    'service_admin_header': this.model.attributes.header_text,
+                    'info_close': __('Close'),
+                    'send_button_text': this.model.attributes.send_button_text,
+                    'placeholder_text': this.model.attributes.placeholder_text,
+                });
+
+                this.createGuiElementsByFieldType();
+                this.insertSendButton();
+
+                const converse_html = _converse.chatboxviews.el.querySelector('#controlbox');
+                converse_html.insertAdjacentElement('afterend', this.el);
+
+                return this.el;
+            },
+
+            createGuiElementsByFieldType () {
+                this.model.attributes.fields.forEach(field => {
+                    const type = field['type'];
+                    switch (type) {
+                        case 'hidden': break;
+                        case 'text-single': this.renderTextSingleField(field); break;
+                        case 'text-multi': this.renderTextMultiField(field); break;
+                        case 'boolean': this.renderBooleanField(field); break;
+                        default: break;
+                    }
+                });
+            },
+
+            renderTextSingleField (field) {
+                const element = tpl_form_input({
+                    'type': field['type'],
+                    'label': field['label'],
+                    'id': field['label'],
+                    'name': field['var'],
+                    'value': field['value'],
+                    'autocomplete': false,
+                    'placeholder': ''
+                });
+                const chat_body = this.el.querySelector('.chat-body');
+                chat_body.insertAdjacentHTML('beforeend', element);
+            },
+
+            renderTextMultiField (field) {
+                const element = tpl_form_textarea({
+                    'label': field['label'],
+                    'name': field['var'],
+                    'value': field['value']
+                });
+
+                const chat_body = this.el.querySelector('.chat-body');
+                chat_body.insertAdjacentHTML('beforeend', element);
+
+                const text_area = sizzle('textarea[name="' + field['var'] + '"]', chat_body).pop();
+                text_area.classList.add('form-control');
+            },
+
+            renderBooleanField (field) {
+                const element = tpl_form_checkbox({
+                    'id': field['var'],
+                    'name': field['var'],
+                    'label': field['label'],
+                    'checked': field['value'],
+                    'required': field["required"]
+                });
+
+                const chat_body = this.el.querySelector('.chat-body');
+                chat_body.insertAdjacentHTML('beforeend', element);
+            },
+
+            insertSendButton () {
+                const button = '<input type="button" class="send-button" value="send"/>';
+                const chat_body = this.el.querySelector('.chat-body');
+                chat_body.insertAdjacentHTML('beforeend', button);
+            },
+
+            show () {
+                this.render();
+                _converse.api.trigger('beforeShowingChatView', this);
+                this.el.classList.remove('hidden');
+            },
+
+            hide () {
+                this.el.classList.add('hidden');
+                _converse.api.trigger('chatBoxClosed', this);
+                return this;
+            },
+
+            close (ev) {
+                if (ev && ev.preventDefault) { ev.preventDefault(); }
+                // ERROR there is still a problem here, that the following line causes an infinite loop.
+                // Since this function wasn't called in the tests lately I'm not sure how to fix this.
+                this.model.close();
+                this.remove();
+
+                _converse.api.trigger('chatBoxClosed', this);
+                return this;
+            },
+
+            sendMessageToServer (ev) {
+                ev.preventDefault();
+
+                const stanza = $iq({
+                    'from': _converse.connection.jid,
+                    'to': _converse.domain,
+                    'id': this.model.attributes.stanza_id,
+                    'type': 'set',
+                    'xml:lang': _converse.locale
+                }).c('command', {
+                    xmlns: Strophe.NS.COMMANDS,
+                    node: this.model.attributes.node,
+                    sessionid: this.model.attributes.session_id
+                }).c('x', {
+                    xmlns: 'jabber:x:data',
+                    type: 'submit'
+                }).c('field', {
+                    type: 'hidden',
+                    var: 'FORM_TYPE'
+                }).c('value').t(this.model.attributes.form_type_value).up().up();
+
+                this.model.attributes.fields.forEach(field => {
+                    const element = this.el.querySelector('[name="' + field['var'] + '"]');
+                    if (element && element.value !== '') {
+                        let value;
+                        if (element.type === 'checkbox') {
+                            value = element.checked;
+                        } else {
+                            value = this.addSenderJidToMessage(element.value, field);
+                        }
+
+                        stanza.c('field', {
+                            var: field['var']
+                        }).c('value').t(value).up().up();
+                    }
+                });
+
+                _converse.connection.sendIQ(stanza, () => {
+                    alert(__("The command was executed successfully."));
+                }, error => {
+                    const error_text = sizzle('error > text', error).pop().innerHTML;
+                    alert(__("The command was NOT executed successfully for the following reason: " + error_text));
+                });
+            },
+
+            addSenderJidToMessage (message, field) {
+                if (field['var'] === 'subject' ||
+                    (!this.model.attributes.node.includes('motd') &&
+                    !this.model.attributes.node.includes('announce')))
+                {
+                    return message;
+                }
+                const SEND_FROM_SUBSTRING = __("-- sent from ");
+                if (message.includes(SEND_FROM_SUBSTRING)) {
+                    message = message.substring(0, message.indexOf(SEND_FROM_SUBSTRING));
+                }
+                message = message.trim();
+
+                const attachment = SEND_FROM_SUBSTRING + _converse.jid.split('/')[0];
+                return message + " " + attachment;
+            }
+        });
+
+        _converse.api.listen.on('rosterViewInitialized', () => {
+            _converse.serviceAdmin = new _converse.ServiceAdministration();
+            _converse.serviceAdmin.discoverSupport();
+        });
+
+        _converse.api.listen.on('chatBoxViewsInitialized', () => {
+            const views = _converse.chatboxviews;
+            _converse.chatboxes.on('add', item => {
+                if (!views.get(item.get('id')) && item.get('type') === _converse.SERVICE_ADMIN_TYPE) {
+                    views.add(item.get('id'), new _converse.ServiceAdminBoxView({model: item}));
+                }
+            });
+        });
+    }
+});

--- a/src/converse.js
+++ b/src/converse.js
@@ -28,6 +28,7 @@ import "converse-push";            // XEP-0357 Push Notifications
 import "converse-register";        // XEP-0077 In-band registration
 import "converse-roomslist";       // Show currently open chat rooms
 import "converse-rosterview";
+import "converse-service-administration"; // adds Service-administration functionality (XEP-0133)
 import "converse-singleton";
 import "converse-uniview";
 /* END: Removable components */
@@ -58,6 +59,7 @@ const WHITELISTED_PLUGINS = [
     'converse-register',
     'converse-roomslist',
     'converse-rosterview',
+    'converse-service-administration',
     'converse-singleton',
     'converse-uniview'
 ];

--- a/src/headless/converse-core.js
+++ b/src/headless/converse-core.js
@@ -36,6 +36,7 @@ dayjs.extend(advancedFormat);
 Strophe.addNamespace('CARBONS', 'urn:xmpp:carbons:2');
 Strophe.addNamespace('CHATSTATES', 'http://jabber.org/protocol/chatstates');
 Strophe.addNamespace('CSI', 'urn:xmpp:csi:0');
+Strophe.addNamespace('COMMANDS', 'http://jabber.org/protocol/commands');
 Strophe.addNamespace('DELAY', 'urn:xmpp:delay');
 Strophe.addNamespace('FASTEN', 'urn:xmpp:fasten:0');
 Strophe.addNamespace('FORWARD', 'urn:xmpp:forward:0');

--- a/src/templates/service_administration_chat.html
+++ b/src/templates/service_administration_chat.html
@@ -1,0 +1,20 @@
+<div class="flyout box-flyout">
+    <div>
+        <div class="chat-head chat-head-chatbox row no-gutters">
+            <div class="chatbox-navback"><i class="fa fa-arrow-left"></i></div>
+            <div class="chatbox-title">
+                <div class="row no-gutter">
+                    <div class="col chat-title" title="Service Administration (XEP-0133)">Service Administration (XEP-0133)
+                        <p class="user-custom-message"> {{{o.service_admin_header}}}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="chatbox-buttons row no-gutters">
+                <a class="chatbox-btn close-chatbox-button fa fa-times" title="{{{o.info_close}}}"></a>
+            </div>
+        </div>
+    </div>
+    <div class="chat-body">
+        <!-- form-elements will be inserted here -->
+    </div> 
+</div>

--- a/src/templates/service_administration_option.html
+++ b/src/templates/service_administration_option.html
@@ -1,0 +1,1 @@
+<a class="list-item-link w-100" title="{{{o.name}}}" href="#">{{{o.service_admin_name}}}</a>

--- a/src/templates/service_administration_selector.html
+++ b/src/templates/service_administration_selector.html
@@ -1,0 +1,12 @@
+<div class="d-flex controlbox-padded">
+    <span class="w-100 controlbox-heading controlbox-heading--service-administration">{{{o.label}}}</span>
+</div>
+<div class="list-container" style="margin-top: 8px; margin-bottom: 2px;">
+    <a href="#" class="list-toggle controlbox-padded service-admin-selector" title="{{{o.title}}}">
+        <span class="service-admin-selector service-admin-selector-caret fa fa-caret-right"></span>
+         Broadcast-Messages
+    </a>
+    <div class="items-list service-admin-menu collapsed">
+        <!-- the diffrent Broadcast-Message-Options will be inserted here (service_admin_option.html)-->
+    </div>
+</div>


### PR DESCRIPTION
Adds the ability to send Announcements and to set the Message of the
Day. After Login a stanza is send to the xmpp-server to check if the
user is allowed to send these messages. If the user has permission a
submenu will be added to the controlbox.

This implementation does not fully implement the service-administration
XEP-0133. This is because eJabberd handles the standard differently. So
it is not certain it will work with other xmpp-servers. Mainly eJabberd
expects a message-stanza instead of an iq-Stanza.

Furthermore adds a "-- send from <jid>" at the end of the announcement.
This helps users to contact the sender.


Even if this does send a different stanza to the server, I believe the code is still valuable. For other servers the msg-stanza need to be changed to a iq-stanza (I cannot do this because I'm not able to test it with another server).

I also tried to add the views as a "chat" so that converse can handle the visibility automatically. But this attempt failed :( So now I added code to clean the view manually.

An example-Screenshot:
![01_examplePic](https://user-images.githubusercontent.com/38032700/60977190-4e106b00-a32f-11e9-8932-fcdc6cea31c3.png)


