### PR TITLE
Remove useless rm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,6 @@ stamp-npm: $(LERNA) package.json package-lock.json src/headless/package.json
 .PHONY: clean
 clean:
 	npm run clean
-	rm -r lib bin include parts
 
 .PHONY: dev
 dev: stamp-npm


### PR DESCRIPTION
...else `make clean` will error out:
```
npm run clean

> converse.js@4.2.0 clean /home/user/converse.js
> rm -rf node_modules stamp-npm dist *.zip

rm -r lib bin include parts
rm: cannot remove 'lib': No such file or directory
rm: cannot remove 'bin': No such file or directory
rm: cannot remove 'include': No such file or directory
rm: cannot remove 'parts': No such file or directory
make: *** [Makefile:123: clean] Error 1
```
