### PR TITLE
Fix fonts path back

### DIFF
--- a/sass/font-awesome.scss
+++ b/sass/font-awesome.scss
@@ -2,38 +2,38 @@
   font-family: 'Baumans';
   font-style: normal;
   font-weight: 400;
-  src: local('Baumans Regular'), local('Baumans-Regular'), url('../dist/webfonts/baumans.ttf') format('truetype');
+  src: local('Baumans Regular'), local('Baumans-Regular'), url('../webfonts/baumans.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Muli';
   font-style: normal;
   font-weight: 400;
-  src: local('Muli Regular'), local('Muli-Regular'), url('../dist/webfonts/muli.ttf') format('truetype');
+  src: local('Muli Regular'), local('Muli-Regular'), url('../webfonts/muli.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'ConverseFontAwesomeBrands';
   font-style: normal;
   font-weight: normal;
-  src: url('../dist/webfonts/fa-brands-400.eot');
-  src: url('../dist/webfonts/fa-brands-400.eot?#iefix') format('embedded-opentype'),
-  url('../dist/webfonts/fa-brands-400.woff2') format('woff2'),
-  url('../dist/webfonts/fa-brands-400.woff') format('woff'),
-  url('../dist/webfonts/fa-brands-400.ttf') format('truetype'),
-  url('../dist/webfonts/fa-brands-400.svg#fontawesome') format('svg');
+  src: url('../webfonts/fa-brands-400.eot');
+  src: url('../webfonts/fa-brands-400.eot?#iefix') format('embedded-opentype'),
+  url('../webfonts/fa-brands-400.woff2') format('woff2'),
+  url('../webfonts/fa-brands-400.woff') format('woff'),
+  url('../webfonts/fa-brands-400.ttf') format('truetype'),
+  url('../webfonts/fa-brands-400.svg#fontawesome') format('svg');
 }
 
 @font-face {
   font-family: 'ConverseFontAwesomeRegular';
   font-style: normal;
   font-weight: 400;
-  src: url('../dist/webfonts/fa-regular-400.eot');
-  src: url('../dist/webfonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
-    url('../dist/webfonts/fa-regular-400.woff2') format('woff2'),
-    url('../dist/webfonts/fa-regular-400.woff') format('woff'),
-    url('../dist/webfonts/fa-regular-400.ttf') format('truetype'),
-    url('../dist/webfonts/fa-regular-400.svg#fontawesome') format('svg');
+  src: url('../webfonts/fa-regular-400.eot');
+  src: url('../webfonts/fa-regular-400.eot?#iefix') format('embedded-opentype'),
+    url('../webfonts/fa-regular-400.woff2') format('woff2'),
+    url('../webfonts/fa-regular-400.woff') format('woff'),
+    url('../webfonts/fa-regular-400.ttf') format('truetype'),
+    url('../webfonts/fa-regular-400.svg#fontawesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -42,12 +42,12 @@
   font-family: 'ConverseFontAwesomeSolid';
   font-style: normal;
   font-weight: 900;
-  src: url('../dist/webfonts/fa-solid-900.eot');
-  src: url('../dist/webfonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
-  url('../dist/webfonts/fa-solid-900.svg#fontawesome') format('svg'),
-  url('../dist/webfonts/fa-solid-900.woff2') format('woff2'),
-  url('../dist/webfonts/fa-solid-900.woff') format('woff'),
-  url('../dist/webfonts/fa-solid-900.ttf') format('truetype');
+  src: url('../webfonts/fa-solid-900.eot');
+  src: url('../webfonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+  url('../webfonts/fa-solid-900.svg#fontawesome') format('svg'),
+  url('../webfonts/fa-solid-900.woff2') format('woff2'),
+  url('../webfonts/fa-solid-900.woff') format('woff'),
+  url('../webfonts/fa-solid-900.ttf') format('truetype');
 }
 
 


### PR DESCRIPTION
...as documented in https://github.com/conversejs/converse.js/blob/master/docs/source/quickstart.rst#L97 else they'll need to be in `website.tld/dist/dist/webfonts` instead

Partially reverts https://github.com/conversejs/converse.js/commit/a116a1ec8f8fbe01834c94f97043af439adfe412