### PR TITLE
Fix Issue #1679

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Don't query for MAM MUC messages before the cached messages have been restored (another cause of duplicate messages).
 - Show an error message and option to retry when fetching of the MAM archive times out
 - Bugfix: `TypeError: o.getAttribute is not a function converse-chatview.js` (can cause messages to not appear).
+- #1679: Room invitation fails with singleton and random server assigned room name
 
 ## 5.0.0 (2019-08-08)
 

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -405,7 +405,7 @@ converse.plugins.add('converse-chatboxes', {
                 }
                 const room_jids = _converse.auto_join_rooms.map(s => _.isObject(s) ? s.jid : s);
                 const auto_join = _converse.auto_join_private_chats.concat(room_jids);
-                if (_converse.singleton && !_.includes(auto_join, attrs.jid)) {
+                if (_converse.singleton && !_.includes(auto_join, attrs.jid) && !_converse.auto_join_on_invite) {                
                     const msg = `${attrs.jid} is not allowed because singleton is true and it's not being auto_joined`;
                     _converse.log(msg, Strophe.LogLevel.WARN);
                     return msg;

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -405,7 +405,7 @@ converse.plugins.add('converse-chatboxes', {
                 }
                 const room_jids = _converse.auto_join_rooms.map(s => _.isObject(s) ? s.jid : s);
                 const auto_join = _converse.auto_join_private_chats.concat(room_jids);
-                if (_converse.singleton && !_.includes(auto_join, attrs.jid) && !_converse.auto_join_on_invite) {                
+                if (_converse.singleton && !_.includes(auto_join, attrs.jid) && !_converse.auto_join_on_invite) {
                     const msg = `${attrs.jid} is not allowed because singleton is true and it's not being auto_joined`;
                     _converse.log(msg, Strophe.LogLevel.WARN);
                     return msg;


### PR DESCRIPTION
This fix forces Converse.js to respect auto_join_rooms and allow auto join room to occur with server-side generated random room names as required for XEP 0142 - workgroup queues