### PR TITLE
Fix incorrectly detecting every message with a duplicate ID as correction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.0.4
+
+- Bugfix: Don't treat every duplicate message ID as a message correction; since some
+  clients don't use globally unique ID's this causes false positives.
+
 ## 5.0.3 (2019-09-13)
 
 - Emit `chatBoxFocused` and `chatBoxBlurred` events for emoji picker input

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -549,10 +549,10 @@ converse.plugins.add('converse-chatboxes', {
              *     {@link _converse.ChatBox.getMessageAttributesFromStanza}
              */
             correctMessage (attrs) {
-                if (!attrs.msgid || !attrs.from) {
+                if (!attrs.replaced_id || !attrs.from) {
                     return;
                 }
-                const message = this.messages.findWhere({'msgid': attrs.msgid, 'from': attrs.from});
+                const message = this.messages.findWhere({'msgid': attrs.replaced_id, 'from': attrs.from});
                 if (!message) {
                     return;
                 }
@@ -969,6 +969,7 @@ converse.plugins.add('converse-chatboxes', {
                     'is_spoiler': !!spoiler,
                     'message': text,
                     'msgid': msgid,
+                    'replaced_id': replaced_id,
                     'references': this.getReferencesFromStanza(stanza),
                     'subject': _.propertyOf(stanza.querySelector('subject'))('textContent'),
                     'thread': _.propertyOf(stanza.querySelector('thread'))('textContent'),


### PR DESCRIPTION
Some clients don't use globally unique message ID's, but probably restart their sequence every time they (re)start. Since `correctMessage()` only checked for `id` and `from`, this would make completely unrelated messages from the same user overwrite each other's contents.

Tested that the fix prevents the problem and still properly handles actual corrections.