### PR TITLE
Update Oauth login to current API format

### DIFF
--- a/src/converse-oauth.js
+++ b/src/converse-oauth.js
@@ -109,10 +109,10 @@ converse.plugins.add("converse-oauth", {
             async fetchOAuthProfileDataAndLogin () {
                 const profile = await this.oauth_service.api('me');
                 const response = this.oauth_service.getAuthResponse();
-                _converse.api.user.login({
-                    'jid': `${profile.name}@${this.provider.get('host')}`,
-                    'password': response.access_token
-                });
+                _converse.api.user.login(
+                    `${profile.name}@${this.provider.get('host')}`,
+                    response.access_token
+                );
             },
 
             async oauthLogin (ev) {


### PR DESCRIPTION
Hey,

The login API format changed a while back, and the oauth module wasn't updated. This should fix it.
As the module is not being currently used, I didn't put anything in CHANGES.md (as it's mostly minor).
