### PR TITLE
don't notify if only message delivery receipt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - #1712: `TypeError: plugin._features is not a function`
 - Bugfix: process stanzas from mam one-by-one in order to correctly process message
   receipts
+- #1714 Bugfix: Don't notify the user in case we're receiving a message delivery receipt only
 
 ## 5.0.3 (2019-09-13)
 

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -87,6 +87,7 @@ converse.plugins.add('converse-notification', {
             }
             const is_me = Strophe.getBareJidFromJid(message.getAttribute('from')) === _converse.bare_jid;
             return !u.isOnlyChatStateNotification(message) &&
+                !u.isOnlyMessageDeliveryReceipt(message) &&
                 !is_me &&
                 (_converse.show_desktop_notifications === 'all' || _converse.isMessageToHiddenChat(message));
         };

--- a/src/headless/utils/core.js
+++ b/src/headless/utils/core.js
@@ -148,6 +148,18 @@ u.isOnlyChatStateNotification = function (msg) {
     return msg['chat_state'] && u.isEmptyMessage(msg);
 };
 
+u.isOnlyMessageDeliveryReceipt = function (msg) {
+    if (msg instanceof Element) {
+        // See XEP-0184 Message Delivery Receipts
+        return (msg.querySelector('body') === null) &&
+                    (msg.querySelector('received') !== null);
+    }
+    if (msg instanceof Backbone.Model) {
+        msg = msg.attributes;
+    }
+    return msg['received'] && u.isEmptyMessage(msg);
+};
+
 u.isHeadlineMessage = function (_converse, message) {
     const from_jid = message.getAttribute('from');
     if (message.getAttribute('type') === 'headline') {


### PR DESCRIPTION
This PR prevents notification sounds in case we receive a message delivery receipt only.