### PR TITLE
only send bookmark stanza if connected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Bugfix: process stanzas from mam one-by-one in order to correctly process message
   receipts
 - #1714 Bugfix: Don't notify the user in case we're receiving a message delivery receipt only
+- Bugfix: only send bookmark stanza if connected in order to avoid error mesage
+  `improper-addressing` after logging out
 
 ## 5.0.3 (2019-09-13)
 

--- a/src/headless/converse-bookmarks.js
+++ b/src/headless/converse-bookmarks.js
@@ -142,6 +142,9 @@ converse.plugins.add('converse-bookmarks', {
             },
 
             sendBookmarkStanza () {
+                if (!_converse.connection.connected) {
+                    return;
+                }
                 const stanza = $iq({
                         'type': 'set',
                         'from': _converse.connection.jid,


### PR DESCRIPTION
I always see the following error message when logging out:

![error_improper_addressing](https://user-images.githubusercontent.com/15179432/65620197-b03d4b80-dfc1-11e9-9de1-ed06c42bb5ee.png)

I found that this is due to the fact, that converse tries to send a bookmark stanza even after the connection is down.

This PR prevents this and thus the error message is gone.