### PR TITLE
new config option: allow_message_corrections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Bugfix: process stanzas from mam one-by-one in order to correctly process message
   receipts
 - #1714 Bugfix: Don't notify the user in case we're receiving a message delivery receipt only
+- add config option [allow_message_corrections](https://conversejs.org/docs/html/configuration.html#allow_message_corrections)
+  which, if set to `last`, limits editing of sent messages to the last message sent
 
 ## 5.0.3 (2019-09-13)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -780,6 +780,17 @@ keepalive
 
 Determines whether Converse will attempt to keep you logged in across page loads.
 
+.. _`allow_message_corrections`:
+
+allow_message_corrections
+-------------------------
+
+* Default:  ``'all'``
+
+Configures the last message correction (LMC) feature of Converse. By default you can edit all of your own
+messages. Setting this to ``'last'`` will limit this feature to the message sent most recently as suggested by
+`XEP-0308: Last Message Correction <https://xmpp.org/extensions/xep-0308.html>`_.
+Setting it to anything else (including ``false``) will disable the ability to correct sent messages.
 
 .. _`locales`:
 

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -988,7 +988,7 @@ converse.plugins.add('converse-chatview', {
                     while (idx > 0) {
                         idx -= 1;
                         const candidate = this.model.messages.at(idx);
-                        if (candidate.get('sender') === 'me' && candidate.get('message')) {
+                        if (candidate.get('editable')) {
                             message = candidate;
                             break;
                         }

--- a/src/converse-message-view.js
+++ b/src/converse-message-view.js
@@ -154,7 +154,7 @@ converse.plugins.add('converse-message-view', {
                     return this.renderFileUploadProgresBar();
                 }
                 const isValidChange = prop => Object.prototype.hasOwnProperty.call(this.model.changed, prop);
-                if (['correcting', 'message', 'type', 'upload', 'received'].filter(isValidChange).length) {
+                if (['correcting', 'message', 'type', 'upload', 'received', 'editable'].filter(isValidChange).length) {
                     await this.debouncedRender();
                 }
                 if (edited) {

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -399,6 +399,7 @@ converse.plugins.add('converse-muc', {
                     'name': '',
                     'num_unread': 0,
                     'roomconfig': {},
+                    'time_sent': (new Date(0)).toISOString(),
                     'time_opened': this.get('time_opened') || (new Date()).getTime(),
                     'type': _converse.CHATROOMS_TYPE
                 }
@@ -1578,6 +1579,7 @@ converse.plugins.add('converse-muc', {
                     return _converse.api.trigger('message', {'stanza': original_stanza});
                 }
                 const attrs = await this.getMessageAttributesFromStanza(stanza, original_stanza);
+                this.setEditable(attrs, attrs.time);
                 if (attrs.nick &&
                         !this.subjectChangeHandled(attrs) &&
                         !this.ignorableCSN(attrs) &&

--- a/src/templates/message.html
+++ b/src/templates/message.html
@@ -31,7 +31,7 @@
             </div>
             {[ if (o.received && !o.is_me_message && !o.is_groupchat_message) { ]} <span class="fa fa-check chat-msg__receipt"></span> {[ } ]}
             {[ if (o.edited) { ]} <i title="{{{o.__('This message has been edited')}}}" class="fa fa-edit chat-msg__edit-modal"></i> {[ } ]}
-            {[ if (o.type !== 'headline' && o.sender === 'me') { ]}
+            {[ if (o.editable) { ]}
                 <div class="chat-msg__actions">
                     <button class="chat-msg__action chat-msg__action-edit fa fa-pencil-alt" title="{{{o.__('Edit this message')}}}"></button>
                 </div>


### PR DESCRIPTION
I'd like to be able to configure Converse for allowing edits of the message sent most recently.

This PR introduces a new config option `allow_message_corrections` which makes this possible.