### PR TITLE
prevent message correction for files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.5
+
+- Prevent editing of sent file uploads.
+
 ## 5.0.4 (2019-10-08)
 
 - New config option [allow_message_corrections](https://conversejs.org/docs/html/configuration.html#allow_message_corrections)

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -954,7 +954,7 @@ converse.plugins.add('converse-chatview', {
                     while (idx < this.model.messages.length-1) {
                         idx += 1;
                         const candidate = this.model.messages.at(idx);
-                        if (candidate.get('sender') === 'me' && candidate.get('message')) {
+                        if (candidate.get('editable')) {
                             message = candidate;
                             break;
                         }
@@ -982,7 +982,7 @@ converse.plugins.add('converse-chatview', {
                         }
                     }
                 }
-                message = message || this.getOwnMessages().reverse().find(m => m.get('message'));
+                message = message || this.getOwnMessages().reverse().find(m => m.get('editable'));
                 if (message) {
                     this.insertIntoTextArea(message.get('message'), true, true);
                     message.save('correcting', true);

--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -785,7 +785,7 @@ converse.plugins.add('converse-chatboxes', {
                     return;
                 }
                 if (_converse.allow_message_corrections === 'all') {
-                    attrs.editable = true;
+                    attrs.editable = !(attrs.file || 'oob_url' in attrs);
                 } else if ((_converse.allow_message_corrections === 'last') &&
                            (send_time > this.get('time_sent'))) {
                     this.set({'time_sent': send_time});
@@ -793,7 +793,7 @@ converse.plugins.add('converse-chatboxes', {
                     if (msg) {
                         msg.save({'editable': false});
                     }
-                    attrs.editable = true;
+                    attrs.editable = !(attrs.file || 'oob_url' in attrs);
                 }
             },
 
@@ -889,14 +889,14 @@ converse.plugins.add('converse-chatboxes', {
                             'ephemeral': true
                         });
                     } else {
-                        const message = this.messages.create(
-                            Object.assign(
-                                this.getOutgoingMessageAttributes(), {
-                                'file': true,
-                                'progress': 0,
-                                'slot_request_url': slot_request_url
-                            }), {'silent': true}
-                        );
+                        const attrs = Object.assign(
+                            this.getOutgoingMessageAttributes(), {
+                            'file': true,
+                            'progress': 0,
+                            'slot_request_url': slot_request_url
+                        });
+                        this.setEditable(attrs, (new Date()).toISOString());
+                        const message = this.messages.create(attrs, {'silent': true});
                         message.file = file;
                         this.messages.trigger('add', message);
                         message.getRequestSlotURL();


### PR DESCRIPTION
I believe Converse should not allow editing of sent file upload messages, as this would only make sense if you actually upload another file. This PR prevents editing of sent file uploads.