### PR TITLE
notification is now clickable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - #1792: Fix: modals don't have scrollbars
 - #1796: Don't show "back" arrow navigation (on mobile) in the chat header when in `singleton` mode
 - #1821: Errors caused by malformed URLs are now handled
+- #1819: Click on a desktop notification now opens corresponding chat.
 
 ### Breaking changes
 

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -183,6 +183,13 @@ converse.plugins.add('converse-notification', {
             if (_converse.notification_delay) {
                 setTimeout(n.close.bind(n), _converse.notification_delay);
             }
+            n.onclick = function (event) {
+                event.preventDefault();
+                window.focus();
+                const chat = _converse.chatboxes.get(from_jid);
+                chat.maybeShow(true);
+            }
+            n.onclick.bind(_converse);
         };
 
         _converse.showChatStateNotification = function (contact) {


### PR DESCRIPTION
This PR makes desktop notifications clickable: A click on a desktop notification now opens the corresponding chat.