### PR TITLE
focus now on jid field after controlbox is loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - #1313: Stylistic improvements to the send button
 - #1793: Send button doesn't appear in Firefox in 1:1 chats
 - #1822: Don't log error if user has no bookmarks
+- #1820: Set focus on jid field after controlbox is loaded
 
 ## 6.0.0 (2020-01-09)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -265,7 +265,9 @@ auto_focus
 
 If set to ``true``, the textarea for composing chat messages will automatically
 become focused as soon as a chat is opened. This means you don't need to click
-the textarea first before starting to type a message.
+the textarea first before starting to type a message. This also applies to the
+username field which is automatically focused after the login controlbox is
+loaded.
 
 For applications where chat is not the main feature, automatic focus of the
 chat box might be undesired.
@@ -789,7 +791,7 @@ enable_smacks
 Determines whether `XEP-0198 Stream Management <https://xmpp.org/extensions/xep-0198.html>`_
 support is turned on or not.
 
-Recommended to set to ``true`` if a websocket connection is used. 
+Recommended to set to ``true`` if a websocket connection is used.
 Please see the :ref:`websocket-url` configuration setting.
 
 filter_by_resource

--- a/src/converse-controlbox.js
+++ b/src/converse-controlbox.js
@@ -257,6 +257,9 @@ converse.plugins.add('converse-controlbox', {
                     this.insertBrandHeading();
                 }
                 this.loginpanel.initPopovers();
+                if (_converse.auto_focus) {
+                    this.loginpanel.el.querySelector('#converse-login-jid').focus();
+                }
                 return this;
             },
 


### PR DESCRIPTION
This PR assures that the inital focus is on the jid field after the login-panel in the controlbox is rendered.