### PR TITLE
don't log error if user has no bookmarks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - #1313: Stylistic improvements to the send button
 - #1793: Send button doesn't appear in Firefox in 1:1 chats
+- #1822: Don't log error if user has no bookmarks
 
 ## 6.0.0 (2020-01-09)
 

--- a/src/headless/converse-bookmarks.js
+++ b/src/headless/converse-bookmarks.js
@@ -237,18 +237,19 @@ converse.plugins.add('converse-bookmarks', {
                         [__("The server did not return your bookmarks within the allowed time. "+
                             "You can reload the page to request them again.")]
                     );
-                } else {
-                    log.error('Error while fetching bookmarks');
-                    log.error(iq);
-                }
-                if (deferred) {
+                } else if (deferred) {
                     if (iq.querySelector('error[type="cancel"] item-not-found')) {
                         // Not an exception, the user simply doesn't have any bookmarks.
                         window.sessionStorage.setItem(this.fetched_flag, true);
                         return deferred.resolve();
                     } else {
+                        log.error('Error while fetching bookmarks');
+                        log.error(iq);
                         return deferred.reject(new Error("Could not fetch bookmarks"));
                     }
+                } else {
+                    log.error('Error while fetching bookmarks');
+                    log.error(iq);
                 }
             },
 


### PR DESCRIPTION
I think converse should not log an error in case the user simply has no bookmarks.