### PR TITLE
A user can now add himself as a contact

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - #1820: Set focus on jid field after controlbox is loaded
 - #1823: New config options [muc_roomid_policy](https://conversejs.org/docs/html/configuration.html#muc-roomid-policy)
   and [muc_roomid_policy_hint](https://conversejs.org/docs/html/configuration.html#muc-roomid-policy-hint)
+- #1826: A user can now add himself as a contact
 
 ## 6.0.0 (2020-01-09)
 

--- a/src/converse-rosterview.js
+++ b/src/converse-rosterview.js
@@ -358,7 +358,8 @@ converse.plugins.add('converse-rosterview', {
                 const ask = this.model.get('ask'),
                     show = this.model.presence.get('show'),
                     requesting  = this.model.get('requesting'),
-                    subscription = this.model.get('subscription');
+                    subscription = this.model.get('subscription'),
+                    jid = this.model.get('jid');
 
                 const classes_to_remove = [
                     'current-xmpp-contact',
@@ -414,7 +415,7 @@ converse.plugins.add('converse-rosterview', {
                             'allow_chat_pending_contacts': _converse.allow_chat_pending_contacts
                         })
                     );
-                } else if (subscription === 'both' || subscription === 'to') {
+                } else if (subscription === 'both' || subscription === 'to' || _converse.rosterview.isSelf(jid)) {
                     this.el.classList.add('current-xmpp-contact');
                     this.el.classList.remove(without(['both', 'to'], subscription)[0]);
                     this.el.classList.add(subscription);
@@ -947,13 +948,18 @@ converse.plugins.add('converse-rosterview', {
                 groups.forEach(g => this.addContactToGroup(contact, g, options));
             },
 
+            isSelf (jid) {
+                return u.isSameBareJID(jid, _converse.connection.jid);
+            },
+
             addRosterContact (contact, options) {
-                if (contact.get('subscription') === 'both' || contact.get('subscription') === 'to') {
+                const jid = contact.get('jid');
+                if (contact.get('subscription') === 'both' || contact.get('subscription') === 'to' || this.isSelf(jid)) {
                     this.addExistingContact(contact, options);
                 } else {
                     if (!_converse.allow_contact_requests) {
                         log.debug(
-                            `Not adding requesting or pending contact ${contact.get('jid')} `+
+                            `Not adding requesting or pending contact ${jid} `+
                             `because allow_contact_requests is false`
                         );
                         return;

--- a/src/headless/converse-roster.js
+++ b/src/headless/converse-roster.js
@@ -655,7 +655,6 @@ converse.plugins.add('converse-roster', {
              */
             updateContact (item) {
                 const jid = item.getAttribute('jid');
-                if (this.isSelf(jid)) { return; }
 
                 const contact = this.get(jid);
                 const subscription = item.getAttribute("subscription");


### PR DESCRIPTION
This is a very much simplified version of https://github.com/conversejs/converse.js/pull/1634.
It does not do anything about the subscription of the self contact and also does not show the correct user status (online/away etc). It is however sufficient to safe your own contact to the roster and use it for whatever you want to do with it (might e.g. be useful to send data such as images from your computer to your smartphone).
The subscription of the self contact is always shown as "both" regardless of what is actually saved in the roster. This is of course not entirely correct but might nevertheless be acceptable taking into account that this solution only needs minimum changes to the code.