### PR TITLE
Fix incrementMsgCounter cleaning up after itself

### DIFF
--- a/src/headless/converse-chatboxes.js
+++ b/src/headless/converse-chatboxes.js
@@ -46,7 +46,7 @@ converse.plugins.add('converse-chatboxes', {
             if (title.search(/^Messages \(\d+\) /) === -1) {
                 document.title = `Messages (${msg_counter}) ${title}`;
             } else {
-                document.title = title.replace(/^Messages \(\d+\) /, `Messages (${msg_counter})`);
+                document.title = title.replace(/^Messages \(\d+\) /, `Messages (${msg_counter}) `);
             }
         };
 


### PR DESCRIPTION
Previously, after increasing the msg_counter from 1 to 2, the window title would be set to "Messages (2)bla", and in the next iteration from 2 to 3 the regex wouldn't match anymore since it expects a space after the closing parentheses. This would spam up your window title with dozens of "Messages (x)" references.

Small enough that I thought it doesn't need a dedicated issue.