### PR TITLE
fix #1963 - Mentions are visually incorrect when used in message replies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #1839: Headline messages are shown in controlbox
 - #1896: Don't send receipts for messages fetched from the archive 
 - #1937: Editing a message removes the mentions highlight
+- #1963: Mentions are visually incorrect when used in message replies
 - Allow ignoring of bootstrap modules at build using environment variable. For xample: `export BOOTSTRAP_IGNORE_MODULES="Modal,Dropdown" && make dist`
 - Bugfix. Handle stanza that clears the MUC subject
 - New config option [modtools_disable_assign](https://conversejs.org/docs/html/configuration.html#modtools-disable-assign)

--- a/src/converse-message-view.js
+++ b/src/converse-message-view.js
@@ -207,12 +207,20 @@ converse.plugins.add('converse-message-view', {
                  */
                 await api.trigger('beforeMessageBodyTransformed', this, text, {'Synchronous': true});
                 text = this.model.isMeCommand() ? text.substring(4) : text;
+
+                // mask < and > characters with unprintable character \x02 and \x03
+                text = text.replace(/</g, '\x02').replace(/>/g, '\x03');
+
                 text = xss.filterXSS(text, {'whiteList': {}, 'onTag': onTagFoundDuringXSSFilter});
                 text = u.geoUriToHttp(text, api.settings.get("geouri_replacement"));
                 text = u.addMentionsMarkup(text, this.model.get('references'), this.model.collection.chatbox);
                 text = u.addHyperlinks(text);
                 text = u.renderNewLines(text);
                 text = u.addEmoji(text);
+
+                // unmask < and > characters and replace with escaped characters
+                text = text.replace(/\x02/g, '&lt;').replace(/\x03/g, '&gt;');
+
                 /**
                  * Synchronous event which provides a hook for transforming a chat message's body text
                  * after the default transformations have been applied.

--- a/src/converse-message-view.js
+++ b/src/converse-message-view.js
@@ -208,8 +208,8 @@ converse.plugins.add('converse-message-view', {
                 await api.trigger('beforeMessageBodyTransformed', this, text, {'Synchronous': true});
                 text = this.model.isMeCommand() ? text.substring(4) : text;
 
-                // mask < and > characters with unprintable character \x02 and \x03
-                text = text.replace(/</g, '\x02').replace(/>/g, '\x03');
+                // mask < and > characters with unprintable character \0x8F and \0x90
+                text = text.replace(/</g, '\x8F').replace(/>/g, '\x90');
 
                 text = xss.filterXSS(text, {'whiteList': {}, 'onTag': onTagFoundDuringXSSFilter});
                 text = u.geoUriToHttp(text, api.settings.get("geouri_replacement"));
@@ -219,7 +219,7 @@ converse.plugins.add('converse-message-view', {
                 text = u.addEmoji(text);
 
                 // unmask < and > characters and replace with escaped characters
-                text = text.replace(/\x02/g, '&lt;').replace(/\x03/g, '&gt;');
+                text = text.replace(/\x8F/g, '&lt;').replace(/\x90/g, '&gt;');
 
                 /**
                  * Synchronous event which provides a hook for transforming a chat message's body text

--- a/src/converse-message-view.js
+++ b/src/converse-message-view.js
@@ -208,18 +208,16 @@ converse.plugins.add('converse-message-view', {
                 await api.trigger('beforeMessageBodyTransformed', this, text, {'Synchronous': true});
                 text = this.model.isMeCommand() ? text.substring(4) : text;
 
-                // mask < and > characters with unprintable character \0x8F and \0x90
+                // mask < and > characters with unprintable character \0x8F and \0x90 and reverse after adding mentions
                 text = text.replace(/</g, '\x8F').replace(/>/g, '\x90');
-
                 text = xss.filterXSS(text, {'whiteList': {}, 'onTag': onTagFoundDuringXSSFilter});
-                text = u.geoUriToHttp(text, api.settings.get("geouri_replacement"));
                 text = u.addMentionsMarkup(text, this.model.get('references'), this.model.collection.chatbox);
+                text = text.replace(/\x8F/g, '&lt;').replace(/\x90/g, '&gt;');
+
+                text = u.geoUriToHttp(text, api.settings.get("geouri_replacement"));
                 text = u.addHyperlinks(text);
                 text = u.renderNewLines(text);
                 text = u.addEmoji(text);
-
-                // unmask < and > characters and replace with escaped characters
-                text = text.replace(/\x8F/g, '&lt;').replace(/\x90/g, '&gt;');
 
                 /**
                  * Synchronous event which provides a hook for transforming a chat message's body text


### PR DESCRIPTION
This solution leaves XSSFilter as it and solves the problem by masking < and > into unprintable characters  \x02 and \x03 before applying XSSFilter and then unmasks them back before escaping them explicitly into &_lt; and &_gt;
