### PR TITLE
fix #1963 - Mentions are visually incorrect when used in message replies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #1839: Headline messages are shown in controlbox
 - #1896: Don't send receipts for messages fetched from the archive 
 - #1937: Editing a message removes the mentions highlight
+- #1963: Mentions are visually incorrect when used in message replies
 - Allow ignoring of bootstrap modules at build using environment variable. For xample: `export BOOTSTRAP_IGNORE_MODULES="Modal,Dropdown" && make dist`
 - Bugfix. Handle stanza that clears the MUC subject
 - New config option [modtools_disable_assign](https://conversejs.org/docs/html/configuration.html#modtools-disable-assign)

--- a/spec/muc_messages.js
+++ b/spec/muc_messages.js
@@ -900,6 +900,18 @@
                     'hello <span class="mention">z3r0</span> '+
                     '<span class="mention mention--self badge badge-info">tom</span> '+
                     '<span class="mention">mr.robot</span>, how are you?');
+
+                const quoted_msg = $msg({
+                        from: 'lounge@montague.lit/tom',
+                        id: u.getUniqueId(),
+                        to: 'romeo@montague.lit',
+                        type: 'groupchat'
+                    }).c('body').t('>how are you?\nI am fine. Thanks gibson').up()
+                        .c('reference', {'xmlns':'urn:xmpp:reference:0', 'begin':'32', 'end':'38', 'type':'mention', 'uri':'xmpp:gibson@montague.lit'}).nodeTree;
+                await view.model.queueMessage(quoted_msg);
+                const quoted_message = await u.waitUntil(() => view.el.querySelector('.chat-msg__text'));
+                expect(quoted_message.classList.length).toEqual(1);
+                expect(quoted_message.innerHTML).toBe('&gt;how are you?\nI am fine. Thanks <span class="mention">gibson</span>');
                 done();
             }));
         });

--- a/spec/muc_messages.js
+++ b/spec/muc_messages.js
@@ -900,18 +900,47 @@
                     'hello <span class="mention">z3r0</span> '+
                     '<span class="mention mention--self badge badge-info">tom</span> '+
                     '<span class="mention">mr.robot</span>, how are you?');
+                done();
+            }));
 
-                const quoted_msg = $msg({
-                        from: 'lounge@montague.lit/tom',
+            it("highlights all users mentioned via XEP-0372 references in a quoted message",
+                mock.initConverse(
+                    ['rosterGroupsFetched'], {},
+                    async function (done, _converse) {
+
+                const muc_jid = 'lounge@montague.lit';
+                await test_utils.openAndEnterChatRoom(_converse, muc_jid, 'tom');
+                const view = _converse.api.chatviews.get(muc_jid);
+                ['z3r0', 'mr.robot', 'gibson', 'sw0rdf1sh'].forEach((nick) => {
+                    _converse.connection._dataRecv(test_utils.createRequest(
+                        $pres({
+                            'to': 'tom@montague.lit/resource',
+                            'from': `lounge@montague.lit/${nick}`
+                        })
+                        .c('x', {xmlns: Strophe.NS.MUC_USER})
+                        .c('item', {
+                            'affiliation': 'none',
+                            'jid': `${nick}@montague.lit/resource`,
+                            'role': 'participant'
+                        }))
+                    );
+                });
+                const msg = $msg({
+                        from: 'lounge@montague.lit/gibson',
                         id: u.getUniqueId(),
                         to: 'romeo@montague.lit',
                         type: 'groupchat'
-                    }).c('body').t('>how are you?\nI am fine. Thanks gibson').up()
-                        .c('reference', {'xmlns':'urn:xmpp:reference:0', 'begin':'32', 'end':'38', 'type':'mention', 'uri':'xmpp:gibson@montague.lit'}).nodeTree;
-                await view.model.queueMessage(quoted_msg);
-                const quoted_message = await u.waitUntil(() => view.el.querySelector('.chat-msg__text'));
-                expect(quoted_message.classList.length).toEqual(1);
-                expect(quoted_message.innerHTML).toBe('&gt;how are you?\nI am fine. Thanks <span class="mention">gibson</span>');
+                    }).c('body').t('>hello z3r0 tom mr.robot, how are you?').up()
+                        .c('reference', {'xmlns':'urn:xmpp:reference:0', 'begin':'7', 'end':'11', 'type':'mention', 'uri':'xmpp:z3r0@montague.lit'}).up()
+                        .c('reference', {'xmlns':'urn:xmpp:reference:0', 'begin':'12', 'end':'15', 'type':'mention', 'uri':'xmpp:romeo@montague.lit'}).up()
+                        .c('reference', {'xmlns':'urn:xmpp:reference:0', 'begin':'16', 'end':'24', 'type':'mention', 'uri':'xmpp:mr.robot@montague.lit'}).nodeTree;
+                await view.model.queueMessage(msg);
+                const message = await u.waitUntil(() => view.el.querySelector('.chat-msg__text'));
+                expect(message.classList.length).toEqual(1);
+                expect(message.innerHTML).toBe(
+                    '&gt;hello <span class="mention">z3r0</span> '+
+                    '<span class="mention mention--self badge badge-info">tom</span> '+
+                    '<span class="mention">mr.robot</span>, how are you?');
                 done();
             }));
         });

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -372,12 +372,16 @@ u.addMentionsMarkup = function (text, references, chatbox) {
     references
         .sort((a, b) => b.begin - a.begin)
         .forEach(ref => {
-            const mention = text.slice(ref.begin, ref.end)
-            chatbox;
+            const prefix = text.slice(0, ref.begin);
+            const offset = ((prefix.match(/&lt;/g) || []).length + (prefix.match(/&gt;/g) || []).length) * 3;
+            const begin = parseInt(ref.begin) + parseInt(offset);
+            const end = parseInt(ref.end) + parseInt(offset);
+            const mention = text.slice(begin, end);
+
             if (mention === nick) {
-                text = text.slice(0, ref.begin) + `<span class="mention mention--self badge badge-info">${mention}</span>` + text.slice(ref.end);
+                text = text.slice(0, begin) + `<span class="mention mention--self badge badge-info">${mention}</span>` + text.slice(end);
             } else {
-                text = text.slice(0, ref.begin) + `<span class="mention">${mention}</span>` + text.slice(ref.end);
+                text = text.slice(0, begin) + `<span class="mention">${mention}</span>` + text.slice(end);
             }
         });
     return text;

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -374,8 +374,8 @@ u.addMentionsMarkup = function (text, references, chatbox) {
         .forEach(ref => {
             const prefix = text.slice(0, ref.begin);
             const offset = ((prefix.match(/&lt;/g) || []).length + (prefix.match(/&gt;/g) || []).length) * 3;
-            const begin = parseInt(ref.begin) + parseInt(offset);
-            const end = parseInt(ref.end) + parseInt(offset);
+            const begin = parseInt(ref.begin, 10) + parseInt(offset, 10);
+            const end = parseInt(ref.end, 10) + parseInt(offset, 10);
             const mention = text.slice(begin, end)
             chatbox;
 

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -376,7 +376,8 @@ u.addMentionsMarkup = function (text, references, chatbox) {
             const offset = ((prefix.match(/&lt;/g) || []).length + (prefix.match(/&gt;/g) || []).length) * 3;
             const begin = parseInt(ref.begin) + parseInt(offset);
             const end = parseInt(ref.end) + parseInt(offset);
-            const mention = text.slice(begin, end);
+            const mention = text.slice(begin, end)
+            chatbox;
 
             if (mention === nick) {
                 text = text.slice(0, begin) + `<span class="mention mention--self badge badge-info">${mention}</span>` + text.slice(end);


### PR DESCRIPTION
Third attempt at fixing this by modifying addMentionsMarkup. I now adjust reference start and end based on the count for prior occurences of the &_lt; and &_gt; characters.

I really dislike the start/end value system used in the references instead of a simple markdown like the colon delimters used with emojis. It reminds me of fixed length records used in very old school COBOL programming.