### PR TITLE
oauth_providers settings should be an array

### DIFF
--- a/src/converse-oauth.js
+++ b/src/converse-oauth.js
@@ -74,7 +74,7 @@ converse.plugins.add("converse-oauth", {
         const { __ } = _converse;
 
         api.settings.update({
-            'oauth_providers': {},
+            'oauth_providers': [],
         });
 
         _converse.OAuthProviders = Collection.extend({


### PR DESCRIPTION
The oauth_providers settings should be an array as a forEach is used on the settings later in the script.

No changelog entry has been made in CHANGES.md as the change is minor.