### PR TITLE
Updates textarea selector when applying focus after emoji selection

### DIFF
--- a/src/converse-emoji-views.js
+++ b/src/converse-emoji-views.js
@@ -331,7 +331,9 @@ converse.plugins.add('converse-emoji-views', {
                 } else if (ev.keyCode === converse.keycodes.ENTER) {
                     this.onEnterPressed(ev);
                 } else if (ev.keyCode === converse.keycodes.ESCAPE) {
-                    document.querySelector('.chat-textarea').focus();
+                    this.chatview.el.querySelector('.chat-textarea').focus();
+                    ev.stopPropagation();
+                    ev.preventDefault();
                 } else if (
                     ev.keyCode !== converse.keycodes.ENTER &&
                     ev.keyCode !== converse.keycodes.DOWN_ARROW


### PR DESCRIPTION
The current selector is very broad and may have undesired effects outside Converse. Used a more specific selector instead.

Also fixes textarea not focusing in some edge cases by adding stopPropagation and preventDefault.