### PR TITLE
Controlbox text color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2002: fix rendering of `muc_roomid_policy_hint`
 - #2006: fix rendering of emojis in case `use_system_emojis == false`
 - #2028: Implement XEP-0333 `displayed` chat marker
+- #2101: Improve contrast of text in control box
 - The API method `api.settings.update` has been deprecated in favor of `api.settings.extend`.
 - Filter roster contacts via all available information (JID, nickname and VCard full name).
 - Allow ignoring of bootstrap modules at build using environment variable. For xample: `export BOOTSTRAP_IGNORE_MODULES="Modal,Dropdown" && make dist`

--- a/sass/_controlbox.scss
+++ b/sass/_controlbox.scss
@@ -68,6 +68,8 @@
     #controlbox {
         order: -1;
 
+        color: var(--controlbox-text-color);
+
         .open-rooms-toggle, .open-rooms-toggle .fa {
             color: var(--groupchats-header-color) !important;
             &:hover {
@@ -152,7 +154,7 @@
                 color: gray;
                 font-size: 85%;
                 &:hover {
-                    color: var(--text-color);
+                    color: var(--controlbox-text-color);
                 }
             }
         }
@@ -420,7 +422,7 @@
             min-height: 0;
 
             .brand-heading {
-                color: var(--text-color);
+                color: var(--controlbox-text-color);
                 font-size: 2em;
             }
             .chatbox-btn {

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -203,6 +203,8 @@ $mobile_portrait_length: 480px !default;
     --chat-correcting-color: #FFFFC0;
     --chat-head-text-color: #AAA;
 
+    --controlbox-text-color: #DDD;
+
     --chat-info-color: var(--subdued-color);
 
     --chatbox-border-radius: 0px;

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -29,6 +29,7 @@ $mobile_portrait_length: 480px !default;
     --inverse-link-color: white;
     --text-shadow-color: #FAFAFA;
     --text-color: #666;
+    --controlbox-text-color: #666;
     --text-color-lighten-15-percent: #8c8c8c; // lighten(#666, 15%)
     --message-text-color: #555;
     --message-receipt-color: var(--green);


### PR DESCRIPTION
Creates a separate `--controlbox-text-color` as suggested in https://github.com/conversejs/converse.js/issues/2101#issuecomment-650022225 and uses that to fix  #2101


![image](https://user-images.githubusercontent.com/197474/85851853-c7f36b80-b7af-11ea-9d88-7a0a1cf81537.png)

![image](https://user-images.githubusercontent.com/197474/85851971-05f08f80-b7b0-11ea-8fcd-071ff5756149.png)

*Ignore the fonts, disabled custom fonts in the browser due to rendering issues*