### PR TITLE
CSS: Enlarge room title in 'embedded' view mode

### DIFF
--- a/sass/_chatbox.scss
+++ b/sass/_chatbox.scss
@@ -484,6 +484,7 @@
         padding: 0.5em;
     }
     .chat-head {
+        font-size: var(--font-size-huge);
         border-top-left-radius: var(--chatbox-border-radius);
         border-top-right-radius: var(--chatbox-border-radius);
         @media screen and (max-height: $mobile-landscape-height) {


### PR DESCRIPTION
This makes it the same size as in the 'fullscreen' view mode.

Before:
![image](https://user-images.githubusercontent.com/197474/86391711-845e9d00-bc9a-11ea-955e-1355cc034be0.png)

With `view_mode = "fullscreen"`
![image](https://user-images.githubusercontent.com/197474/86391903-d30c3700-bc9a-11ea-987c-0b772a2b2e0c.png)


After:
![image](https://user-images.githubusercontent.com/197474/86391767-9d674e00-bc9a-11ea-859a-4c0c692566f6.png)
