### PR TITLE
Jcbrand/body transform refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,4 +231,4 @@ doc: node_modules docsdev apidoc
 
 PHONY: apidoc
 apidoc:
-	$(JSDOC) --private --readme docs/source/jsdoc_intro.md -c docs/source/conf.json -d docs/html/api src/*.js src/utils/*.js src/headless/*.js src/headless/utils/*.js
+	$(JSDOC) --private --readme docs/source/jsdoc_intro.md -c docs/source/conf.json -d docs/html/api src/templates/directives/*.js src/components/*.js src/*.js src/utils/*.js src/headless/*.js src/headless/utils/*.js

--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -1663,7 +1663,7 @@ describe("Chatboxes", function () {
             await u.waitUntil(() => view.el.querySelectorAll('.chat-content .chat-msg').length, 1000);
             expect(view.model.sendMessage).toHaveBeenCalled();
             const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
-            expect(msg.innerHTML.replace(/\<!----\>/g, '')).toEqual(
+            await u.waitUntil(() => msg.innerHTML.replace(/\<!----\>/g, '') ===
                 '<a target="_blank" rel="noopener" href="https://www.openstreetmap.org/?mlat=37.786971&amp;'+
                 'mlon=-122.399677#map=18/37.786971/-122.399677">https://www.openstreetmap.org/?mlat=37.786971&amp;mlon=-122.399677#map=18/37.786971/-122.399677</a>');
             done();

--- a/spec/emojis.js
+++ b/spec/emojis.js
@@ -276,7 +276,7 @@ describe("Emojis", function () {
             });
             await new Promise(resolve => view.model.messages.once('rendered', resolve));
             const body = view.el.querySelector('converse-chat-message-body');
-            expect(body.innerHTML.replace(/<!---->/g, '').trim()).toBe(
+            await u.waitUntil(() => body.innerHTML.replace(/<!---->/g, '').trim() ===
                 'Running tests for <img class="emoji" draggable="false" title=":converse:" alt=":converse:" src="/dist/images/custom_emojis/converse.png">');
             done();
         }));

--- a/spec/http-file-upload.js
+++ b/spec/http-file-upload.js
@@ -318,9 +318,9 @@ describe("XEP-0363: HTTP File Upload", function () {
                         `</message>`);
                     await u.waitUntil(() => view.el.querySelector('.chat-image'), 1000);
                     // Check that the image renders
-                    expect(view.el.querySelector('.chat-msg .chat-msg__media').innerHTML.trim()).toEqual(
-                        `<!----><a class="chat-image__link" target="_blank" rel="noopener" href="${base_url}/logo/conversejs-filled.svg">`+
-                        `<img class="chat-image img-thumbnail" src="${base_url}/logo/conversejs-filled.svg"></a><!---->`);
+                    expect(view.el.querySelector('.chat-msg .chat-msg__media').innerHTML.replace(/<!---->/g, '').trim()).toEqual(
+                        `<a class="chat-image__link" target="_blank" rel="noopener" href="${base_url}/logo/conversejs-filled.svg">`+
+                        `<img class="chat-image img-thumbnail" src="${base_url}/logo/conversejs-filled.svg"></a>`);
                     XMLHttpRequest.prototype.send = send_backup;
                     done();
                 }));
@@ -422,9 +422,9 @@ describe("XEP-0363: HTTP File Upload", function () {
                         `</message>`);
                     await u.waitUntil(() => view.el.querySelector('.chat-image'), 1000);
                     // Check that the image renders
-                    expect(view.el.querySelector('.chat-msg .chat-msg__media').innerHTML.trim()).toEqual(
-                        `<!----><a class="chat-image__link" target="_blank" rel="noopener" href="${base_url}/logo/conversejs-filled.svg">`+
-                        `<img class="chat-image img-thumbnail" src="${base_url}/logo/conversejs-filled.svg"></a><!---->`);
+                    expect(view.el.querySelector('.chat-msg .chat-msg__media').innerHTML.replace(/<!---->/g, '').trim()).toEqual(
+                        `<a class="chat-image__link" target="_blank" rel="noopener" href="${base_url}/logo/conversejs-filled.svg">`+
+                        `<img class="chat-image img-thumbnail" src="${base_url}/logo/conversejs-filled.svg"></a>`);
 
                     XMLHttpRequest.prototype.send = send_backup;
                     done();

--- a/spec/messages.js
+++ b/spec/messages.js
@@ -104,7 +104,7 @@ describe("A Chat Message", function () {
         expect(textarea.value).toBe('');
 
         const first_msg = view.model.messages.findWhere({'message': 'But soft, what light through yonder airlock breaks?'});
-        expect(view.el.querySelectorAll('.chat-msg .chat-msg__action').length).toBe(2);
+        await u.waitUntil(() => view.el.querySelectorAll('.chat-msg .chat-msg__action').length === 2);
         let action = view.el.querySelector('.chat-msg .chat-msg__action');
         expect(action.textContent.trim()).toBe('Edit');
 
@@ -891,8 +891,8 @@ describe("A Chat Message", function () {
         await new Promise(resolve => view.model.messages.once('rendered', resolve));
         const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
         expect(msg.textContent).toEqual(message);
-        expect(msg.innerHTML.replace(/<!---->/g, ''))
-            .toEqual('This message contains a hyperlink: <a target="_blank" rel="noopener" href="http://www.opkode.com">www.opkode.com</a>');
+        await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
+            'This message contains a hyperlink: <a target="_blank" rel="noopener" href="http://www.opkode.com">www.opkode.com</a>');
         done();
     }));
 
@@ -921,7 +921,7 @@ describe("A Chat Message", function () {
             </message>`);
         _converse.connection._dataRecv(mock.createRequest(stanza));
         await new Promise(resolve => view.model.messages.once('rendered', resolve));
-        expect(view.content.querySelector('converse-chat-message:last-child .chat-msg__text').innerHTML.replace(/<!---->/g, '')).toBe('Hey\n\nHave you heard the news?');
+        await u.waitUntil(() => view.content.querySelector('converse-chat-message:last-child .chat-msg__text').innerHTML.replace(/<!---->/g, '') === 'Hey\n\nHave you heard the news?');
         stanza = u.toStanza(`
             <message from="${contact_jid}"
                      type="chat"

--- a/spec/xss.js
+++ b/spec/xss.js
@@ -144,28 +144,32 @@ describe("XSS", function () {
             let msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
             expect(msg.innerHTML.replace(/<!---->/g, ''))
-                .toEqual('<a target="_blank" rel="noopener" href="http://www.opkode.com/%27onmouseover=%27alert%281%29%27whatever">http://www.opkode.com/\'onmouseover=\'alert(1)\'whatever</a>');
+                .toEqual('http://www.opkode.com/\'onmouseover=\'alert(1)\'whatever');
+
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
+                '<a target="_blank" rel="noopener" href="http://www.opkode.com/%27onmouseover=%27alert%281%29%27whatever">http://www.opkode.com/\'onmouseover=\'alert(1)\'whatever</a>');
 
             message = 'http://www.opkode.com/"onmouseover="alert(1)"whatever';
             await mock.sendMessage(view, message);
 
             msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
-            expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual('<a target="_blank" rel="noopener" href="http://www.opkode.com/%22onmouseover=%22alert%281%29%22whatever">http://www.opkode.com/"onmouseover="alert(1)"whatever</a>');
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
+                '<a target="_blank" rel="noopener" href="http://www.opkode.com/%22onmouseover=%22alert%281%29%22whatever">http://www.opkode.com/"onmouseover="alert(1)"whatever</a>');
 
             message = "https://en.wikipedia.org/wiki/Ender's_Game";
             await mock.sendMessage(view, message);
 
             msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
-            expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual('<a target="_blank" rel="noopener" href="https://en.wikipedia.org/wiki/Ender%27s_Game">'+message+'</a>');
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') === '<a target="_blank" rel="noopener" href="https://en.wikipedia.org/wiki/Ender%27s_Game">'+message+'</a>');
 
             message = "<https://bugs.documentfoundation.org/show_bug.cgi?id=123737>";
             await mock.sendMessage(view, message);
 
             msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
-            expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual(
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
                 `&lt;<a target="_blank" rel="noopener" href="https://bugs.documentfoundation.org/show_bug.cgi?id=123737">https://bugs.documentfoundation.org/show_bug.cgi?id=123737</a>&gt;`);
 
             message = '<http://www.opkode.com/"onmouseover="alert(1)"whatever>';
@@ -173,7 +177,7 @@ describe("XSS", function () {
 
             msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
-            expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual(
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
                 '&lt;<a target="_blank" rel="noopener" href="http://www.opkode.com/%22onmouseover=%22alert%281%29%22whatever">http://www.opkode.com/"onmouseover="alert(1)"whatever</a>&gt;');
 
             message = `https://www.google.com/maps/place/Kochstraat+6,+2041+CE+Zandvoort/@52.3775999,4.548971,3a,15y,170.85h,88.39t/data=!3m6!1e1!3m4!1sQ7SdHo_bPLPlLlU8GSGWaQ!2e0!7i13312!8i6656!4m5!3m4!1s0x47c5ec1e56f845ad:0x1de0bc4a5771fb08!8m2!3d52.3773668!4d4.5489388!5m1!1e2`
@@ -181,7 +185,7 @@ describe("XSS", function () {
 
             msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             expect(msg.textContent).toEqual(message);
-            expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual(
+            await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') ===
                 `<a target="_blank" rel="noopener" href="https://www.google.com/maps/place/Kochstraat+6,+2041+CE+Zandvoort/@52.3775999,4.548971,3a,15y,170.85h,88.39t/data=%213m6%211e1%213m4%211sQ7SdHo_bPLPlLlU8GSGWaQ%212e0%217i13312%218i6656%214m5%213m4%211s0x47c5ec1e56f845ad:0x1de0bc4a5771fb08%218m2%213d52.3773668%214d4.5489388%215m1%211e2">https://www.google.com/maps/place/Kochstraat+6,+2041+CE+Zandvoort/@52.3775999,4.548971,3a,15y,170.85h,88.39t/data=!3m6!1e1!3m4!1sQ7SdHo_bPLPlLlU8GSGWaQ!2e0!7i13312!8i6656!4m5!3m4!1s0x47c5ec1e56f845ad:0x1de0bc4a5771fb08!8m2!3d52.3773668!4d4.5489388!5m1!1e2</a>`);
             done();
         }));
@@ -229,16 +233,16 @@ describe("XSS", function () {
                 expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual(url);
             }
 
-            function checkParsedURL ({ entered, href }) {
+            async function checkParsedURL ({ entered, href }) {
                 const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
                 expect(msg.textContent).toEqual(entered);
-                expect(msg.innerHTML.replace(/<!---->/g, '')).toEqual(`<a target="_blank" rel="noopener" href="${href}">${entered}</a>`);
+                await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '') === `<a target="_blank" rel="noopener" href="${href}">${entered}</a>`);
             }
 
-            function checkParsedXMPPURL ({ entered, href }) {
+            async function checkParsedXMPPURL ({ entered, href }) {
                 const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
                 expect(msg.textContent.trim()).toEqual(entered);
-                expect(msg.innerHTML.replace(/<!---->/g, '').trim()).toEqual(`<a target="_blank" rel="noopener" href="${href}">${entered}</a>`);
+                await u.waitUntil(() => msg.innerHTML.replace(/<!---->/g, '').trim() === `<a target="_blank" rel="noopener" href="${href}">${entered}</a>`);
             }
 
             await mock.sendMessage(view, bad_urls[0]);
@@ -248,22 +252,22 @@ describe("XSS", function () {
             checkNonParsedURL(bad_urls[1]);
 
             await mock.sendMessage(view, good_urls[0].entered);
-            checkParsedURL(good_urls[0]);
+            await checkParsedURL(good_urls[0]);
 
             await mock.sendMessage(view, good_urls[1].entered);
-            checkParsedURL(good_urls[1]);
+            await checkParsedURL(good_urls[1]);
 
             await mock.sendMessage(view, good_urls[2].entered);
-            checkParsedURL(good_urls[2]);
+            await checkParsedURL(good_urls[2]);
 
             await mock.sendMessage(view, good_urls[3].entered);
-            checkParsedXMPPURL(good_urls[3]);
+            await checkParsedXMPPURL(good_urls[3]);
 
             await mock.sendMessage(view, good_urls[4].entered);
-            checkParsedURL(good_urls[4]);
+            await checkParsedURL(good_urls[4]);
 
             await mock.sendMessage(view, good_urls[5].entered);
-            checkParsedURL(good_urls[5]);
+            await checkParsedURL(good_urls[5]);
 
             done();
         }));

--- a/src/components/emoji-picker-content.js
+++ b/src/components/emoji-picker-content.js
@@ -92,7 +92,7 @@ export default class EmojiPickerContent extends CustomElement {
               return true;
           }
       } else {
-          if (this.current_skintone && _converse.emojis.toned.includes(shortname)) {
+          if (this.current_skintone && converse.emojis.toned.includes(shortname)) {
               return true;
           }
       }

--- a/src/components/emoji-picker.js
+++ b/src/components/emoji-picker.js
@@ -169,6 +169,7 @@ export default class EmojiPicker extends CustomElement {
         } else if (ev.keyCode === converse.keycodes.ENTER) {
             this.onEnterPressed(ev);
         } else if (ev.keyCode === converse.keycodes.ESCAPE) {
+            u.ancestor(this, 'converse-emoji-dropdown').hideMenu();
             this.chatview.el.querySelector('.chat-textarea').focus();
             ev.stopPropagation();
             ev.preventDefault();
@@ -238,10 +239,8 @@ export default class EmojiPicker extends CustomElement {
     }
 
     enableArrowNavigation (ev) {
-        if (ev) {
-            ev.preventDefault();
-            ev.stopPropagation();
-        }
+        ev?.preventDefault?.();
+        ev?.stopPropagation?.();
         this.disableArrowNavigation();
         this.navigator.enable();
         this.navigator.handleKeydown(ev);

--- a/src/components/emoji-picker.js
+++ b/src/components/emoji-picker.js
@@ -283,9 +283,10 @@ export class EmojiDropdown extends BaseDropdown {
                         data-toggle="dropdown"
                         aria-haspopup="true"
                         aria-expanded="false">
-                    <converse-icon class="fa fa-smile "
-                             path-prefix="${api.settings.get('assets_path')}"
-                             size="1em"></converse-icon>
+                    <converse-icon
+                        class="fa fa-smile "
+                        path-prefix="${api.settings.get('assets_path')}"
+                        size="1em"></converse-icon>
                 </button>
                 <div class="dropdown-menu">
                     ${until(this.initModel().then(() => html`
@@ -314,14 +315,14 @@ export class EmojiDropdown extends BaseDropdown {
     }
 
     async showMenu () {
-        await this.init_promise;
+        await this.initModel();
         if (!this.render_emojis) {
             // Trigger an update so that emojis are rendered
             this.render_emojis = true;
-            this.requestUpdate();
+            await this.requestUpdate();
         }
         super.showMenu();
-        this.querySelector('.emoji-search')?.focus();
+        setTimeout(() => this.querySelector('.emoji-search')?.focus());
     }
 }
 

--- a/src/headless/converse-emoji.js
+++ b/src/headless/converse-emoji.js
@@ -72,7 +72,7 @@ function getTonedEmojis () {
 }
 
 
-function convertASCII2Emoji (str) {
+export function convertASCII2Emoji (str) {
     // Replace ASCII smileys
     return str.replace(ASCII_REPLACE_REGEX, (entire, m1, m2, m3) => {
         if( (typeof m3 === 'undefined') || (m3 === '') || (!(u.unescapeHTML(m3) in ASCII_LIST)) ) {
@@ -86,7 +86,7 @@ function convertASCII2Emoji (str) {
 }
 
 
-function getEmojiMarkup (data, options={unicode_only: false, add_title_wrapper: false}) {
+export function getEmojiMarkup (data, options={unicode_only: false, add_title_wrapper: false}) {
     const emoji = data.emoji;
     const shortname = data.shortname;
     if (emoji) {
@@ -111,7 +111,7 @@ function getEmojiMarkup (data, options={unicode_only: false, add_title_wrapper: 
 }
 
 
-function getShortnameReferences (text) {
+export function getShortnameReferences (text) {
     const references = [...text.matchAll(shortnames_regex)];
     return references.map(ref => {
         const cp = converse.emojis.by_sn[ref[0]].cp;
@@ -126,7 +126,7 @@ function getShortnameReferences (text) {
 }
 
 
-function getCodePointReferences (text) {
+export function getCodePointReferences (text) {
     const references = [];
     const how = {
         callback: (icon_id) => {
@@ -228,18 +228,6 @@ converse.plugins.add('converse-emoji', {
         const emojis_by_attribute = {};
 
         Object.assign(u, {
-            /**
-             * Replaces emoji shortnames in the passed-in string with unicode or image-based emojis
-             * (based on the value of `use_system_emojis`).
-             * @method u.addEmoji
-             * @param { String } text = The text
-             * @returns { String } The text with shortnames replaced with emoji unicodes or images.
-             */
-            addEmoji (text) {
-                const options = {add_title_wrapper: true, unicode_only: false};
-                return u.shortnamesToEmojis(text, options);
-            },
-
             /**
              * Returns an emoji represented by the passed in shortname.
              * Scans the passed in text for shortnames and replaces them with

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -206,9 +206,8 @@ class MessageBodyRenderer {
 
 
 export const renderBodyText = directive(component => part => {
-    const model = component.model;
     const renderer = new MessageBodyRenderer(component);
     part.setValue(renderer.render());
-    part.commit();
+    const model = component.model;
     model.collection?.trigger('rendered', model);
 });

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -1,111 +1,214 @@
+import URI from "urijs";
+import log from '@converse/headless/log';
 import { _converse, api, converse } from  "@converse/headless/converse-core";
+import { convertASCII2Emoji, getEmojiMarkup, getCodePointReferences, getShortnameReferences } from "@converse/headless/converse-emoji.js";
 import { directive, html } from "lit-html";
 import { isString } from "lodash-es";
+import { until } from 'lit-html/directives/until.js';
 
 const u = converse.env.utils;
 
 
-class MessageBodyRenderer extends String {
+/**
+ * @class MessageText
+ * A String subclass that is used to represent the rich text
+ * of a chat message.
+ *
+ * The "rich" parts of the text is represented by lit-html TemplateResult
+ * objects which are added via the {@link MessageText.addTemplateResult}
+ * method and saved as metadata.
+ *
+ * By default Converse adds TemplateResults to support emojis, hyperlinks,
+ * images, map URIs and mentions.
+ *
+ * 3rd party plugins can listen for the `beforeMessageBodyTransformed`
+ * and/or `afterMessageBodyTransformed` events and then call
+ * `addTemplateResult` on the MessageText instance in order to add their own
+ * rich features.
+ */
+class MessageText extends String {
 
-    constructor (component) {
-        super();
-        this.text = component.model.getMessageText();
-        this.model = component.model;
-        this.component = component;
+    /**
+     * Create a new {@link MessageText} instance.
+     * @param { String } text - The plain text that was received from the `<message>` stanza.
+     */
+    constructor (text) {
+        super(text);
+        this.references = [];
     }
 
-    async transform () {
-        /**
-         * Synchronous event which provides a hook for transforming a chat message's body text
-         * before the default transformations have been applied.
-         * @event _converse#beforeMessageBodyTransformed
-         * @param { _converse.Message } model - The model representing the message
-         * @param { string } text - The message text
-         * @example _converse.api.listen.on('beforeMessageBodyTransformed', (view, text) => { ... });
-         */
-        await api.trigger('beforeMessageBodyTransformed', this.model, this.text, {'Synchronous': true});
-
-        let text = this.component.is_me_message ? this.text.substring(4) : this.text;
-        // Collapse multiple line breaks into at most two
-        text = text.replace(/\n\n+/g, '\n\n');
-        text = u.geoUriToHttp(text, _converse.geouri_replacement);
-
-        let list = await Promise.all(u.addHyperlinks(text));
-
-        await api.emojis.initialize();
-        list = list.reduce((acc, i) => isString(i) ? [...acc, ...u.addEmoji(i)] : [...acc, i], []);
-
-        const addMentions = text => addMentionsMarkup(text, this.model.get('references'), this.model.collection.chatbox)
-        list = list.reduce((acc, i) => isString(i) ? [...acc, ...addMentions(i)] : [...acc, i], []);
-        /**
-         * Synchronous event which provides a hook for transforming a chat message's body text
-         * after the default transformations have been applied.
-         * @event _converse#afterMessageBodyTransformed
-         * @param { _converse.Message } model - The model representing the message
-         * @param { string } text - The message text
-         * @example _converse.api.listen.on('afterMessageBodyTransformed', (view, text) => { ... });
-         */
-        await api.trigger('afterMessageBodyTransformed', this.model, text, {'Synchronous': true});
-        return list;
+    /**
+     * The "rich" markup parts of a chat message are represented by lit-html
+     * TemplateResult objects.
+     *
+     * This method can be used to add new template results to this message's
+     * text.
+     *
+     * @method MessageText.addTemplateResult
+     * @param { Number } begin - The starting index of the plain message text
+     * which is being replaced with markup.
+     * @param { Number } end - The ending index of the plain message text
+     * which is being replaced with markup.
+     * @param { Object } template - The lit-html TemplateResult instance
+     */
+    addTemplateResult (begin, end, template) {
+        this.references.push({begin, end, template});
     }
 
-    async render () {
-        return html`${await this.transform()}`
+    isMeCommand () {
+        const text = this.toString();
+        if (!text) {
+            return false;
+        }
+        return text.startsWith('/me ');
     }
 
-    get length () {
-        return this.text.length;
+    static replaceText (text) {
+        return convertASCII2Emoji(text.replace(/\n\n+/g, '\n\n'));
     }
 
-    toString () {
-        return "" + this.text;
-    }
+    marshall () {
+        let list = [this.toString()];
+        this.references
+            .sort((a, b) => b.begin - a.begin)
+            .forEach(ref => {
+                const text = list.shift();
+                list = [
+                    text.slice(0, ref.begin),
+                    ref.template,
+                    text.slice(ref.end),
+                    ...list
+                ];
+            });
 
-    textOf () {
-        return this.toString();
+        // Subtract `/me ` from 3rd person messages
+        if (this.isMeCommand()) list[0] = list[0].substring(4);
+
+        return list.reduce((acc, i) => isString(i) ? [...acc, MessageText.replaceText(i)] : [...acc, i], []);
     }
 }
+
+
+function addMapURLs (text) {
+    const regex = /geo:([\-0-9.]+),([\-0-9.]+)(?:,([\-0-9.]+))?(?:\?(.*))?/g;
+    const matches = text.matchAll(regex);
+    for (const m of matches) {
+        text.addTemplateResult(
+            m.index,
+            m.index+m.input.length,
+            u.convertUrlToHyperlink(m.input.replace(regex, _converse.geouri_replacement))
+        );
+    }
+}
+
+
+function addHyperlinks (text) {
+    const objs = [];
+    try {
+        const parse_options = { 'start': /\b(?:([a-z][a-z0-9.+-]*:\/\/)|xmpp:|mailto:|www\.)/gi };
+        URI.withinString(text, (url, start, end) => {
+            objs.push({url, start, end})
+            return url;
+        } , parse_options);
+    } catch (error) {
+        log.debug(error);
+        return;
+    }
+    const show_images = api.settings.get('show_images_inline');
+    objs.forEach(url_obj => {
+        const url_text = text.slice(url_obj.start, url_obj.end);
+        text.addTemplateResult(
+            url_obj.start,
+            url_obj.end,
+            show_images && u.isImageURL(url_text) ? u.convertToImageTag(url_text) : u.convertUrlToHyperlink(url_text),
+        );
+    });
+}
+
+
+async function addEmojis (text) {
+    await api.emojis.initialize();
+    const references = [...getShortnameReferences(text.toString()), ...getCodePointReferences(text.toString())];
+    references.forEach(e => {
+        text.addTemplateResult(
+            e.begin,
+            e.end,
+            getEmojiMarkup(e, {'add_title_wrapper': true})
+        );
+    });
+}
+
 
 const tpl_mention_with_nick = (o) => html`<span class="mention mention--self badge badge-info">${o.mention}</span>`;
 const tpl_mention = (o) => html`<span class="mention">${o.mention}</span>`;
 
 
-function addMentionsMarkup (text, references, chatbox) {
-    if (chatbox.get('message_type') === 'groupchat' && references.length) {
-        let list = [text];
-        const nick = chatbox.get('nick');
-        references
-            .sort((a, b) => b.begin - a.begin)
-            .forEach(ref => {
-                const text = list.shift();
-                const mention = text.slice(ref.begin, ref.end);
-                if (mention === nick) {
-                    list = [
-                        text.slice(0, ref.begin),
-                        tpl_mention_with_nick({mention}),
-                        text.slice(ref.end),
-                        ...list
-                    ];
-                } else {
-                    list = [
-                        text.slice(0, ref.begin),
-                        tpl_mention({mention}),
-                        text.slice(ref.end),
-                        ...list
-                    ];
-                }
-            });
-        return list;
-    } else {
-        return [text];
+function addReferences (text, model) {
+    const nick = model.collection.chatbox.get('nick');
+    model.get('references')?.forEach(ref => {
+        const mention = text.slice(ref.begin, ref.end);
+        if (mention === nick) {
+            text.addTemplateResult(ref.begin, ref.end, tpl_mention_with_nick({mention}));
+        } else {
+            text.addTemplateResult(ref.begin, ref.end, tpl_mention({mention}));
+        }
+    });
+}
+
+
+class MessageBodyRenderer {
+
+    constructor (component) {
+        this.model = component.model;
+        this.component = component;
+        this.text = this.component.model.getMessageText();
+    }
+
+    async transform () {
+        const text = new MessageText(this.text);
+        /**
+         * Synchronous event which provides a hook for transforming a chat message's body text
+         * before the default transformations have been applied.
+         * @event _converse#beforeMessageBodyTransformed
+         * @param { _converse.Message } model - The model representing the message
+         * @param { MessageText } text - A {@link MessageText } instance. You
+         * can call {@link MessageText#addTemplateResult } on it in order to
+         * add TemplateResult objects meant to render rich parts of the
+         * message.
+         * @example _converse.api.listen.on('beforeMessageBodyTransformed', (view, text) => { ... });
+         */
+        await api.trigger('beforeMessageBodyTransformed', this.model, text, {'Synchronous': true});
+
+        addHyperlinks(text);
+        addMapURLs(text);
+        await addEmojis(text);
+        addReferences(text, this.model);
+
+        /**
+         * Synchronous event which provides a hook for transforming a chat message's body text
+         * after the default transformations have been applied.
+         * @event _converse#afterMessageBodyTransformed
+         * @param { _converse.Message } model - The model representing the message
+         * @param { MessageText } text - A {@link MessageText } instance. You
+         * can call {@link MessageText#addTemplateResult} on it in order to
+         * add TemplateResult objects meant to render rich parts of the
+         * message.
+         * @example _converse.api.listen.on('afterMessageBodyTransformed', (view, text) => { ... });
+         */
+        await api.trigger('afterMessageBodyTransformed', this.model, text, {'Synchronous': true});
+        return text.marshall();
+    }
+
+    render () {
+        return html`${until(this.transform(), html`${this.text}`)}`;
     }
 }
 
 
-export const renderBodyText = directive(component => async part => {
+export const renderBodyText = directive(component => part => {
     const model = component.model;
     const renderer = new MessageBodyRenderer(component);
-    part.setValue(await renderer.render());
+    part.setValue(renderer.render());
     part.commit();
     model.collection?.trigger('rendered', model);
 });

--- a/src/templates/directives/image.js
+++ b/src/templates/directives/image.js
@@ -1,0 +1,16 @@
+import { directive, html } from "lit-html";
+
+
+export const renderImage = directive(url => part => {
+    function onError () {
+        part.setValue(converse.env.utils.convertUrlToHyperlink(url));
+        part.commit();
+    }
+    part.setValue(
+        html`<a href="${url}"
+                class="chat-image__link"
+                target="_blank"
+                rel="noopener"
+            ><img class="chat-image img-thumbnail" src="${url}" @error=${onError}/></a>`
+    );
+});

--- a/src/templates/image.js
+++ b/src/templates/image.js
@@ -1,3 +1,4 @@
 import { html } from "lit-html";
+import { renderImage } from "./directives/image.js";
 
-export default (o) => html`<a href="${o.url}" class="chat-image__link" target="_blank" rel="noopener"><img class="chat-image img-thumbnail" src="${o.url}"/></a>`;
+export default (o) => html`${renderImage(o.url)}`;

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -409,11 +409,6 @@ u.addHyperlinks = function (text) {
     return list;
 }
 
-u.geoUriToHttp = function(text, geouri_replacement) {
-    const regex = /geo:([\-0-9.]+),([\-0-9.]+)(?:,([\-0-9.]+))?(?:\?(.*))?/g;
-    return text.replace(regex, geouri_replacement);
-};
-
 u.httpToGeoUri = function(text, _converse) {
     const replacement = 'geo:$1,$2';
     return text.replace(_converse.api.settings.get("geouri_regex"), replacement);

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -99,11 +99,7 @@ function renderImageURL (_converse, uri) {
     if (!_converse.api.settings.get('show_images_inline')) {
         return u.convertURIoHyperlink(uri);
     }
-    const { __ } = _converse;
-    return tpl_image({
-        'url': uri.toString(),
-        'label_download': __('Download image "%1$s"', getFileName(uri))
-    })
+    return tpl_image({'url': uri.toString()});
 }
 
 function renderFileURL (_converse, uri) {
@@ -160,24 +156,6 @@ u.applyDragResistance = function (value, default_value) {
     }
     return value;
 };
-
-
-function loadImage (url) {
-    return new Promise((resolve, reject) => {
-        const err_msg = `Could not determine whether it's an image: ${url}`;
-        const img = new Image();
-        const timer = window.setTimeout(() => reject(new Error(err_msg)), 20000);
-        img.onerror = img.onabort = function () {
-            clearTimeout(timer);
-            reject(new Error(err_msg));
-        };
-        img.onload = function () {
-            clearTimeout(timer);
-            resolve(img);
-        };
-        img.src = url;
-    });
-}
 
 
 u.calculateElementHeight = function (el) {
@@ -311,24 +289,17 @@ u.escapeHTML = function (string) {
         .replace(/"/g, "&quot;");
 };
 
-u.convertToImageTag = async function (url) {
+
+u.convertToImageTag = function (url) {
     const uri = getURI(url);
     const img_url_without_ext = ['imgur.com', 'pbs.twimg.com'].includes(uri.hostname());
-    let src;
     if (u.isImageURL(url) || img_url_without_ext) {
         if (img_url_without_ext) {
             const format = (uri.hostname() === 'pbs.twimg.com') ? uri.search(true).format : 'png';
-            src = uri.removeSearch(/.*/).toString() + `.${format}`;
+            return tpl_image({'url': uri.removeSearch(/.*/).toString() + `.${format}`});
         } else {
-            src = url;
+            return tpl_image({url});
         }
-        try {
-            await loadImage(src);
-        } catch (e) {
-            log.error(e);
-            return u.convertUrlToHyperlink(url);
-        }
-        return tpl_image({url, src});
     }
 }
 


### PR DESCRIPTION
Refactor how the message body text is updated in order to add rich markup features.

We now have a MessageText class which subclasses String and which allows you to store lit-html TemplateResult objects as metadata on it. These TemplateResult objects represent the markup parts of the message.
