### PR TITLE
WIP: Message filters and middleware plugin

### DIFF
--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -1654,7 +1654,7 @@ describe("Chatboxes", function () {
 
             await mock.waitForRoster(_converse, 'current', 1);
 
-            const message = "geo:37.786971,-122.399677";
+            const message = "Parsing a geo url geo:37.786971,-122.399677";
             const contact_jid = mock.cur_names[0].replace(/ /g,'.').toLowerCase() + '@montague.lit';
             await mock.openChatBoxFor(_converse, contact_jid);
             const view = _converse.chatboxviews.get(contact_jid);
@@ -1664,7 +1664,7 @@ describe("Chatboxes", function () {
             expect(view.model.sendMessage).toHaveBeenCalled();
             const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text', view.el).pop();
             await u.waitUntil(() => msg.innerHTML.replace(/\<!----\>/g, '') ===
-                '<a target="_blank" rel="noopener" href="https://www.openstreetmap.org/?mlat=37.786971&amp;'+
+                'Parsing a geo url <a target="_blank" rel="noopener" href="https://www.openstreetmap.org/?mlat=37.786971&amp;'+
                 'mlon=-122.399677#map=18/37.786971/-122.399677">https://www.openstreetmap.org/?mlat=37.786971&amp;mlon=-122.399677#map=18/37.786971/-122.399677</a>');
             done();
         }));

--- a/src/converse.js
+++ b/src/converse.js
@@ -29,6 +29,8 @@ import "converse-roomslist";       // Show currently open chat rooms
 import "converse-rosterview";
 import "converse-singleton";
 import "converse-uniview";
+import "./plugins/message-parser";
+import "./plugins/urlparser";
 /* END: Removable components */
 
 import "../sass/converse.scss";
@@ -56,7 +58,9 @@ const WHITELISTED_PLUGINS = [
     'converse-roomslist',
     'converse-rosterview',
     'converse-singleton',
-    'converse-uniview'
+    'converse-message-parser',
+    'converse-uniview',
+    'converse-urlparser'
 ];
 
 const initialize = converse.initialize;

--- a/src/headless/utils/functional.js
+++ b/src/headless/utils/functional.js
@@ -1,0 +1,7 @@
+/**
+ * @copyright 2020, the Converse.js contributors
+ * @license Mozilla Public License (MPLv2)
+ * @description Functional programming hepers.
+ */
+
+export const pipe = (...functions) => args => functions.reduce((arg, fn) => fn(arg), args);

--- a/src/plugins/message-parser/MessageParser.js
+++ b/src/plugins/message-parser/MessageParser.js
@@ -1,0 +1,86 @@
+import { html } from 'lit-html';
+import { pipe } from '@converse/headless/utils/functional';
+import RichMessage from './RichMessage';
+import log from '@converse/headless/log';
+
+class MessageParser {
+
+    constructor () {
+        this._filters = [];
+        this._middleware = [];
+    }
+
+    get filters () {
+        return this._filters;
+    }
+
+    get middleware () {
+        return this._middleware;
+    }
+
+    static checkReferenceCollision (reference, rich_message) {
+        const collides = rich_message.references.some(msg_ref => {
+          const is_after = reference.begin > msg_ref.end;
+          const is_before = reference.end < msg_ref.begin;
+          return !is_after && !is_before;
+        });
+        return collides;
+    }
+
+    static makeTemplateResultFromString (string_or_templateresult) {
+        const is_template_result = !!string_or_templateresult.getTemplateElement;
+        return is_template_result
+          ? string_or_templateresult
+          : html`${string_or_templateresult}`;
+    }
+
+    static addSingleReferenceToMessage (reference, rich_message) {
+        if (!MessageParser.isReferenceCollition(reference, rich_message)) {
+            const { begin, end, template } = reference;
+            const template_result = MessageParser.makeTemplateResultFromString(template);
+            rich_message.addTemplateResult(begin, end, template_result);
+        } else {
+            throw new Error('Reference collision');
+        }
+    }
+
+    static addReferencesToMessage (references, rich_message) {
+        references.forEach(reference =>
+            MessageParser.addSingleReferenceToMessage(reference, rich_message)
+        );
+    }
+
+    addFilters (...filters) {
+        this._filters.push(...filters);
+    }
+
+    addMiddleware (...middleware) {
+        this._middleware.push(...middleware);
+    }
+
+    richMessageFromText (text) {
+        return new RichMessage(text);
+    }
+
+    runFilters (text) {
+        return pipe(...this.filters)(text);
+    }
+
+    runMiddleware (rich_message) {
+        this.middleware.forEach(middleware => {
+            try {
+                const references = middleware(rich_message.text);
+                MessageParser.addReferencesToMessage(references, rich_message);
+            } catch (error) {
+                // log.error(`Reference collision caused by middleware "${middleware.name}"`)
+            }
+        });
+    }
+
+    toTransform (rich_message) {
+        return rich_message.marshall();
+    }
+
+}
+
+export default MessageParser;

--- a/src/plugins/message-parser/MessageParser.js
+++ b/src/plugins/message-parser/MessageParser.js
@@ -35,7 +35,7 @@ class MessageParser {
     }
 
     static addSingleReferenceToMessage (reference, rich_message) {
-        if (!MessageParser.isReferenceCollition(reference, rich_message)) {
+        if (!MessageParser.checkReferenceCollision(reference, rich_message)) {
             const { begin, end, template } = reference;
             const template_result = MessageParser.makeTemplateResultFromString(template);
             rich_message.addTemplateResult(begin, end, template_result);
@@ -72,7 +72,7 @@ class MessageParser {
                 const references = middleware(rich_message.text);
                 MessageParser.addReferencesToMessage(references, rich_message);
             } catch (error) {
-                // log.error(`Reference collision caused by middleware "${middleware.name}"`)
+                log.error(`Reference collision caused by middleware "${middleware.name}"`)
             }
         });
     }

--- a/src/plugins/message-parser/README.md
+++ b/src/plugins/message-parser/README.md
@@ -1,0 +1,34 @@
+# MessageParser plugin
+
+## Filters
+
+Filter functions transform the raw message text before middleware kicks in.
+
+They receive a string as argument and return a transformed string. 
+
+```javascript
+function exampleFilter (message_string) {
+    const transformed_message_string = doSomeMagicTo(message_string);
+    return transformed_message_string;
+}
+
+api.message.addFilters(exampleMiddleware);
+```
+
+## Middleware
+
+Middleware functions take the raw message text and return an array of reference objects to be added to the RichMessage object.
+
+```javascript
+function exampleMiddleware (message_string) {
+    const matching_urls = message_string.matchAll(/https?:\/\/(\w+\.com)/gi);
+    const references = Array.from(matching_urls).map(url => ({
+        begin: url.index,
+        end: url.index + url[0].length,
+        template: `<a href="${url[0]}">${url[0]}</a>`
+    }));
+    return references;
+}
+
+api.message.addMiddleware(exampleMiddleware);
+```

--- a/src/plugins/message-parser/RichMessage.js
+++ b/src/plugins/message-parser/RichMessage.js
@@ -1,0 +1,83 @@
+import { convertASCII2Emoji } from "@converse/headless/converse-emoji.js";
+
+/**
+ * @class RichMessage
+ * A String subclass that is used to represent the rich text
+ * of a chat message.
+ *
+ * The "rich" parts of the text is represented by lit-html TemplateResult
+ * objects which are added via the {@link RichMessage.addTemplateResult}
+ * method and saved as metadata.
+ *
+ * By default Converse adds TemplateResults to support emojis, hyperlinks,
+ * images, map URIs and mentions.
+ *
+ * 3rd party plugins can listen for the `beforeMessageBodyTransformed`
+ * and/or `afterMessageBodyTransformed` events and then call
+ * `addTemplateResult` on the RichMessage instance in order to add their own
+ * rich features.
+ */
+class RichMessage extends String {
+
+  /**
+   * Create a new {@link RichMessage} instance.
+   * @param { String } text - The plain text that was received from the `<message>` stanza.
+   */
+  constructor (text) {
+      super(text);
+      this.text = text;
+      this.references = [];
+  }
+
+  /**
+   * The "rich" markup parts of a chat message are represented by lit-html
+   * TemplateResult objects.
+   *
+   * This method can be used to add new template results to this message's
+   * text.
+   *
+   * @method RichMessage.addTemplateResult
+   * @param { Number } begin - The starting index of the plain message text
+   * which is being replaced with markup.
+   * @param { Number } end - The ending index of the plain message text
+   * which is being replaced with markup.
+   * @param { Object } template - The lit-html TemplateResult instance
+   */
+  addTemplateResult (begin, end, template) {
+      this.references.push({begin, end, template});
+  }
+
+  isMeCommand () {
+      const text = this.toString();
+      return !!text && text.startsWith('/me ');
+  }
+
+  // @TODO Find a better place for `convertASCII2Emoji`
+  static replaceText (text) {
+      return convertASCII2Emoji(text.replace(/\n\n+/g, '\n\n'));
+  }
+
+  marshall () {
+      let list = [this.toString()];
+      this.references
+          .sort((a, b) => b.begin - a.begin)
+          .forEach(ref => {
+              const text = list.shift();
+              list = [
+                  text.slice(0, ref.begin),
+                  ref.template,
+                  text.slice(ref.end),
+                  ...list
+              ];
+          });
+
+      // Subtract `/me ` from 3rd person messages
+      if (this.isMeCommand()) {
+          list[0] = list[0].substring(4);
+      }
+
+      return list.reduce((acc, i) => typeof i === 'string' ? [...acc, RichMessage.replaceText(i)] : [...acc, i], []);
+  }
+}
+
+export default RichMessage;

--- a/src/plugins/message-parser/api.js
+++ b/src/plugins/message-parser/api.js
@@ -1,0 +1,22 @@
+import MessageParser from './MessageParser';
+
+const parser = new MessageParser();
+const {
+  filters,
+  middleware,
+  addFilters,
+  addMiddleware
+} = parser;
+
+const api = {
+    message: {
+        parser,
+        filters,
+        middleware,
+        addFilters: addFilters.bind(parser),
+        addFilter: addFilters.bind(parser), // Alias of `addFilters`
+        addMiddleware: addMiddleware.bind(parser)
+    }
+};
+
+export default api;

--- a/src/plugins/message-parser/index.js
+++ b/src/plugins/message-parser/index.js
@@ -1,0 +1,10 @@
+import { converse, api } from "@converse/headless/converse-core";
+
+import custom_api from './api';
+
+
+converse.plugins.add('converse-message-parser', {
+    initialize () {
+        Object.assign(api, custom_api);
+    }
+});

--- a/src/plugins/urlparser/index.js
+++ b/src/plugins/urlparser/index.js
@@ -1,0 +1,27 @@
+import URI from "urijs";
+
+import { converse, api } from "@converse/headless/converse-core";
+
+import plugin_settings from './settings';
+import { URL_START_REGEX } from '../../utils/html';
+
+
+const filterUrl = (unwanted_query_params) => (url) => {
+    const uri = URI(url)
+    uri.removeQuery(unwanted_query_params);
+    uri.hasQuery('s', 21) && uri.removeQuery('s'); // remove twitter's ?s=21
+    return uri.toString();
+}
+
+const filterQueryParams = (unwanted_query_params) => (text) => 
+    URI.withinString(text, filterUrl(unwanted_query_params), { start: URL_START_REGEX });
+
+
+converse.plugins.add('converse-urlparser', {
+    initialize () {
+        api.settings.extend(plugin_settings)
+        const settings = api.settings.get('filter_url_query_params');
+        const messageFilter = filterQueryParams(settings);
+        api.message.addFilters(messageFilter);
+    }
+});

--- a/src/plugins/urlparser/index.js
+++ b/src/plugins/urlparser/index.js
@@ -1,10 +1,13 @@
 import URI from "urijs";
 
-import { converse, api } from "@converse/headless/converse-core";
+import { api, _converse, converse } from "@converse/headless/converse-core";
+import { getEmojiMarkup, getCodePointReferences, getShortnameReferences } from "@converse/headless/converse-emoji.js";
 
 import plugin_settings from './settings';
 import { URL_START_REGEX } from '../../utils/html';
 
+
+const u = converse.env.utils;
 
 const filterUrl = (unwanted_query_params) => (url) => {
     const uri = URI(url)
@@ -16,12 +19,58 @@ const filterUrl = (unwanted_query_params) => (url) => {
 const filterQueryParams = (unwanted_query_params) => (text) => 
     URI.withinString(text, filterUrl(unwanted_query_params), { start: URL_START_REGEX });
 
+function mapURLsMiddleware (message_text) {
+    const regex = /geo:([\-0-9.]+),([\-0-9.]+)(?:,([\-0-9.]+))?(?:\?(.*))?/g;
+    const matches = message_text.matchAll(regex);
+    const references = [...matches].map(url => ({
+        begin: url.index,
+        end: url.index + url[0].length,
+        template: u.convertUrlToHyperlink(url[0].replace(regex, _converse.geouri_replacement))
+    }));
+    return references;
+}
+
+// function emojiMiddleware (text) {
+//     const matches = [...getShortnameReferences(text.toString()), ...getCodePointReferences(text.toString())];
+//     const references = matches.map(emoji => ({
+//         begin: emoji.begin,
+//         end: emoji.end,
+//         template: getEmojiMarkup(e, {'add_title_wrapper': true})
+//     }));
+//     return references;
+// }
+
+const middlewareForMentions = (references, nick) => (message_text) => {
+    const result = [...references].map(r => {
+        const mention = message_text.slice(r.begin, r.end);
+        const template = mention === nick
+            ? `<span class="mention mention--self badge badge-info">${mention}</span>`
+            : `<span class="mention">${mention}</span>`
+        return {
+            begin: r.begin,
+            end: r.end,
+            template
+        }
+    })
+    return result;
+}
 
 converse.plugins.add('converse-urlparser', {
     initialize () {
+        // Message filters
         api.settings.extend(plugin_settings)
         const settings = api.settings.get('filter_url_query_params');
         const messageFilter = filterQueryParams(settings);
         api.message.addFilters(messageFilter);
+
+        const model = null; // @TODO where is the model here?
+
+        // Message middleware
+        const mentionsMiddleware = middlewareForMentions(
+            model.get('references'),
+            model.collection.chatbox.get('nick')
+        );
+        api.message.addMiddleware(mapURLsMiddleware);
+        // api.message.addMiddleware(mentionsMiddleware);
     }
 });

--- a/src/plugins/urlparser/settings.js
+++ b/src/plugins/urlparser/settings.js
@@ -1,0 +1,3 @@
+export default {
+    filter_url_query_params: []
+};

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -109,7 +109,7 @@ class MessageBodyRenderer {
             () => this.scrollDownOnImageLoad(),
             ev => this.component.showImageModal(ev)
         );
-        addMapURLs(rich_message);
+        // addMapURLs(rich_message);
         await addEmojis(rich_message);
         addReferences(rich_message, this.model);
 

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -1,92 +1,12 @@
 import URI from "urijs";
 import log from '@converse/headless/log';
 import { _converse, api, converse } from  "@converse/headless/converse-core";
-import { convertASCII2Emoji, getEmojiMarkup, getCodePointReferences, getShortnameReferences } from "@converse/headless/converse-emoji.js";
+import { getEmojiMarkup, getCodePointReferences, getShortnameReferences } from "@converse/headless/converse-emoji.js";
+import { pipe } from '@converse/headless/utils/functional';
 import { directive, html } from "lit-html";
-import { isString } from "lodash-es";
 import { until } from 'lit-html/directives/until.js';
 
 const u = converse.env.utils;
-
-
-/**
- * @class MessageText
- * A String subclass that is used to represent the rich text
- * of a chat message.
- *
- * The "rich" parts of the text is represented by lit-html TemplateResult
- * objects which are added via the {@link MessageText.addTemplateResult}
- * method and saved as metadata.
- *
- * By default Converse adds TemplateResults to support emojis, hyperlinks,
- * images, map URIs and mentions.
- *
- * 3rd party plugins can listen for the `beforeMessageBodyTransformed`
- * and/or `afterMessageBodyTransformed` events and then call
- * `addTemplateResult` on the MessageText instance in order to add their own
- * rich features.
- */
-class MessageText extends String {
-
-    /**
-     * Create a new {@link MessageText} instance.
-     * @param { String } text - The plain text that was received from the `<message>` stanza.
-     */
-    constructor (text) {
-        super(text);
-        this.references = [];
-    }
-
-    /**
-     * The "rich" markup parts of a chat message are represented by lit-html
-     * TemplateResult objects.
-     *
-     * This method can be used to add new template results to this message's
-     * text.
-     *
-     * @method MessageText.addTemplateResult
-     * @param { Number } begin - The starting index of the plain message text
-     * which is being replaced with markup.
-     * @param { Number } end - The ending index of the plain message text
-     * which is being replaced with markup.
-     * @param { Object } template - The lit-html TemplateResult instance
-     */
-    addTemplateResult (begin, end, template) {
-        this.references.push({begin, end, template});
-    }
-
-    isMeCommand () {
-        const text = this.toString();
-        if (!text) {
-            return false;
-        }
-        return text.startsWith('/me ');
-    }
-
-    static replaceText (text) {
-        return convertASCII2Emoji(text.replace(/\n\n+/g, '\n\n'));
-    }
-
-    marshall () {
-        let list = [this.toString()];
-        this.references
-            .sort((a, b) => b.begin - a.begin)
-            .forEach(ref => {
-                const text = list.shift();
-                list = [
-                    text.slice(0, ref.begin),
-                    ref.template,
-                    text.slice(ref.end),
-                    ...list
-                ];
-            });
-
-        // Subtract `/me ` from 3rd person messages
-        if (this.isMeCommand()) list[0] = list[0].substring(4);
-
-        return list.reduce((acc, i) => isString(i) ? [...acc, MessageText.replaceText(i)] : [...acc, i], []);
-    }
-}
 
 
 function addMapURLs (text) {
@@ -179,42 +99,22 @@ class MessageBodyRenderer {
     }
 
     async transform () {
-        const text = new MessageText(this.text);
-        /**
-         * Synchronous event which provides a hook for transforming a chat message's body text
-         * before the default transformations have been applied.
-         * @event _converse#beforeMessageBodyTransformed
-         * @param { _converse.Message } model - The model representing the message
-         * @param { MessageText } text - A {@link MessageText } instance. You
-         * can call {@link MessageText#addTemplateResult } on it in order to
-         * add TemplateResult objects meant to render rich parts of the
-         * message.
-         * @example _converse.api.listen.on('beforeMessageBodyTransformed', (view, text) => { ... });
-         */
-        await api.trigger('beforeMessageBodyTransformed', this.model, text, {'Synchronous': true});
+        const { parser } = api.message;
+        let filtered_text = parser.runFilters(this.text);
+        const rich_message = parser.richMessageFromText(filtered_text);
 
+        // @TODO The following should be middleware set by default
         addHyperlinks(
-            text,
+            rich_message,
             () => this.scrollDownOnImageLoad(),
             ev => this.component.showImageModal(ev)
         );
-        addMapURLs(text);
-        await addEmojis(text);
-        addReferences(text, this.model);
+        addMapURLs(rich_message);
+        await addEmojis(rich_message);
+        addReferences(rich_message, this.model);
 
-        /**
-         * Synchronous event which provides a hook for transforming a chat message's body text
-         * after the default transformations have been applied.
-         * @event _converse#afterMessageBodyTransformed
-         * @param { _converse.Message } model - The model representing the message
-         * @param { MessageText } text - A {@link MessageText } instance. You
-         * can call {@link MessageText#addTemplateResult} on it in order to
-         * add TemplateResult objects meant to render rich parts of the
-         * message.
-         * @example _converse.api.listen.on('afterMessageBodyTransformed', (view, text) => { ... });
-         */
-        await api.trigger('afterMessageBodyTransformed', this.model, text, {'Synchronous': true});
-        return text.marshall();
+        parser.runMiddleware(rich_message);
+        return parser.toTransform(rich_message);
     }
 
     render () {


### PR DESCRIPTION
Includes built-in functionality to prevent double parsing / reference collision.

Former `MessageText` class is now `RichMessage` to differentiate from the raw text messages.

---

From the `README.md` file:

# MessageParser plugin

## Filters

Filter functions transform the raw message text before middleware kicks in.

They receive a string as argument and return a transformed string. 

```javascript
function exampleFilter (message_string) {
    const transformed_message_string = doSomeMagicTo(message_string);
    return transformed_message_string;
}

api.message.addFilters(exampleMiddleware);
```

## Middleware

Middleware functions take the raw message text and return an array of reference objects to be added to the RichMessage object.

```javascript
function exampleMiddleware (message_string) {
    const matching_urls = message_string.matchAll(/https?:\/\/(\w+\.com)/gi);
    const references = Array.from(matching_urls).map(url => ({
        begin: url.index,
        end: url.index + url[0].length,
        template: `<a href="${url[0]}">${url[0]}</a>`
    }));
    return references;
}

api.message.addMiddleware(exampleMiddleware);
```

## Note:

Filters update the message text, affecting XMPP reference positions. This is something to solve.
