### PR TITLE
merge only relevant settings when calling api.settings.extend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2006: fix rendering of emojis in case `use_system_emojis == false`
 - #2028: Implement XEP-0333 `displayed` chat marker
 - #2101: Improve contrast of text in control box
+- #2187: Avoid merging initial settings with themselves every time settings are extended.
 - Removed the mockups from the project. Recommended to use tests instead.
 - The API method `api.settings.update` has been deprecated in favor of `api.settings.extend`.
 - Filter roster contacts via all available information (JID, nickname and VCard full name).

--- a/spec/converse.js
+++ b/spec/converse.js
@@ -354,7 +354,7 @@ describe("Converse", function() {
             done();
         }));
         
-        it("extended via settings.extend works and don't override settings passed in via converse.initialize when using a shadowRoot as root specified via converse.initialize",
+        it("only overrides the passed in properties",
                 mock.initConverse([],
                 {
                     'root': document.createElement('div').attachShadow({ 'mode': 'open' }),
@@ -369,7 +369,7 @@ describe("Converse", function() {
                         'emoji_categories': { 'travel': ':motorcycle:', 'food': ':burger:' },
                     });
 
-                    expect(_converse.api.settings.get('emoji_categories')?.travel).toBe(':rocket:');
+                    expect(_converse.api.settings.get('emoji_categories').travel).toBe(':rocket:');
                     expect(_converse.api.settings.get('emoji_categories')?.food).toBe(undefined);
                     done();
                 }

--- a/spec/converse.js
+++ b/spec/converse.js
@@ -370,7 +370,7 @@ describe("Converse", function() {
                     });
 
                     expect(_converse.api.settings.get('emoji_categories').travel).toBe(':rocket:');
-                    expect(_converse.api.settings.get('emoji_categories')?.food).toBe(undefined);
+                    expect(_converse.api.settings.get('emoji_categories').food).toBe(undefined);
                     done();
                 }
             )

--- a/spec/converse.js
+++ b/spec/converse.js
@@ -353,6 +353,28 @@ describe("Converse", function() {
             expect(_converse.api.settings.get('emoji_categories')?.food).toBe(undefined);
             done();
         }));
+        
+        it("extended via settings.extend works and don't override settings passed in via converse.initialize when using a shadowRoot as root specified via converse.initialize",
+                mock.initConverse([],
+                {
+                    'root': document.createElement('div').attachShadow({ 'mode': 'open' }),
+                    'emoji_categories': { 'travel': ':rocket:' },
+                },
+                (done, _converse) => {
+                    expect(_converse.api.settings.get('emoji_categories')?.travel).toBe(':rocket:');
+
+                    // Test that the extend command doesn't override user-provided site
+                    // settings (i.e. settings passed in via converse.initialize).
+                    _converse.api.settings.extend({
+                        'emoji_categories': { 'travel': ':motorcycle:', 'food': ':burger:' },
+                    });
+
+                    expect(_converse.api.settings.get('emoji_categories')?.travel).toBe(':rocket:');
+                    expect(_converse.api.settings.get('emoji_categories')?.food).toBe(undefined);
+                    done();
+                }
+            )
+        );
 
     });
 

--- a/src/headless/converse-core.js
+++ b/src/headless/converse-core.js
@@ -659,7 +659,7 @@ export const api = _converse.api = {
             u.merge(DEFAULT_SETTINGS, settings);
             // When updating the settings, we need to avoid overwriting the
             // initialization_settings (i.e. the settings passed in via converse.initialize).
-            const allowed_keys = Object.keys(DEFAULT_SETTINGS);
+            const allowed_keys = Object.keys(pick(settings,Object.keys(DEFAULT_SETTINGS)));
             const allowed_site_settings = pick(initialization_settings, allowed_keys);
             const updated_settings = assignIn(pick(settings, allowed_keys), allowed_site_settings);
             u.merge(_converse.settings, updated_settings);


### PR DESCRIPTION
Conversejs is unable to start when a shadowRoot is provided as root in settings through converse.initialize. The first plugin calling settings.extend triggers an exception in https://github.com/conversejs/converse.js/blob/master/src/headless/converse-core.js#L665 because it tries to merge the whole initialization_settings defined by the keys in DEFAULT_SETTINGS. As shadowRoot elements have read-only attributes, when the merge tries to overwrite those attributes there's an exception raised .

`TypeError: Cannot assign to read only property 'mode' of object '#<ShadowRoot>'`

The proposed change here solves the issue extending and merging only the settings that  are relevant for the current plugin while keeping the overwrite from the settings passed in to Converse through converse.initialize method (if any).

Although this handles read-only attributes on start-up, if a plugin tried to overwrite a setting containing read-only attributes it would need some kind of custom merger.