### PR TITLE
add html to converse.env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2101: Improve contrast of text in control box
 - #2187: Avoid merging initial settings with themselves every time settings are extended.
 - #2199: Fix BOSH session restore.
+- #2201: added html to converse.env
 - Removed the mockups from the project. Recommended to use tests instead.
 - The API method `api.settings.update` has been deprecated in favor of `api.settings.extend`.
 - Filter roster contacts via all available information (JID, nickname and VCard full name).

--- a/src/headless/converse-core.js
+++ b/src/headless/converse-core.js
@@ -22,6 +22,7 @@ import { Model } from '@converse/skeletor/src/model.js';
 import { Router } from '@converse/skeletor/src/router.js';
 import { __, i18n } from './i18n';
 import { assignIn, debounce, invoke, isFunction, isObject, isString, pick } from 'lodash-es';
+import { html } from 'lit-element';
 
 
 dayjs.extend(advancedFormat);
@@ -1633,7 +1634,7 @@ Object.assign(converse, {
      * @property {function} converse.env.sizzle    - [Sizzle](https://sizzlejs.com) CSS selector engine.
      * @property {object} converse.env.utils       - Module containing common utility methods used by Converse.
      */
-    'env': { $build, $iq, $msg, $pres, Model, Collection, Promise, Strophe, _, dayjs, log, sizzle, stanza_utils, u, 'utils': u }
+    'env': { $build, $iq, $msg, $pres, Model, Collection, Promise, Strophe, _, dayjs, log, sizzle, stanza_utils, u, 'utils': u, html }
 });
 
 /**


### PR DESCRIPTION
I'd like to have `html` from `lit-element` in `converse.env`. Otherwise it does not seem to be possible to add toolbar-buttons from plugins. (See here: https://github.com/Polymer/lit-element/issues/390)
