### PR TITLE
add Overview to converse.env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2187: Avoid merging initial settings with themselves every time settings are extended.
 - #2199: Fix BOSH session restore.
 - #2201: added html to converse.env
+- #2202: added Overview to converse.env
 - Removed the mockups from the project. Recommended to use tests instead.
 - The API method `api.settings.update` has been deprecated in favor of `api.settings.extend`.
 - Filter roster contacts via all available information (JID, nickname and VCard full name).

--- a/src/headless/converse-core.js
+++ b/src/headless/converse-core.js
@@ -19,6 +19,7 @@ import u from '@converse/headless/utils/core';
 import { Collection } from "@converse/skeletor/src/collection";
 import { Events } from '@converse/skeletor/src/events.js';
 import { Model } from '@converse/skeletor/src/model.js';
+import { Overview } from '@converse/skeletor/src/overview.js';
 import { Router } from '@converse/skeletor/src/router.js';
 import { __, i18n } from './i18n';
 import { assignIn, debounce, invoke, isFunction, isObject, isString, pick } from 'lodash-es';
@@ -1634,7 +1635,7 @@ Object.assign(converse, {
      * @property {function} converse.env.sizzle    - [Sizzle](https://sizzlejs.com) CSS selector engine.
      * @property {object} converse.env.utils       - Module containing common utility methods used by Converse.
      */
-    'env': { $build, $iq, $msg, $pres, Model, Collection, Promise, Strophe, _, dayjs, log, sizzle, stanza_utils, u, 'utils': u, html }
+    'env': { $build, $iq, $msg, $pres, Model, Collection, Overview, Promise, Strophe, _, dayjs, log, sizzle, stanza_utils, u, 'utils': u, html }
 });
 
 /**


### PR DESCRIPTION
Another proposedm addition to converse.env:

It would be nice to be able to access `Overview` from a plugin.
