### PR TITLE
Refactors notification function

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1348,6 +1348,13 @@ notification_icon
 This option specifies which icon is shown in HTML5 notifications, as provided
 by the ``src/converse-notification.js`` plugin.
 
+notify_nicknames_without_references
+-----------------------------------
+
+* Default: ``false``
+
+Enables desktop notification when user nickname is mentioned without the ``@`` sign.
+
 oauth_providers
 ---------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1353,7 +1353,10 @@ notify_nicknames_without_references
 
 * Default: ``false``
 
-Enables desktop notification when user nickname is mentioned without the ``@`` sign.
+Enables notifications for nicknames in messages that don't have associated
+XEP-0372 references linking them to the JID of the person being mentioned.
+
+In Converse, these would be nicknames that weren't mentioned via the ``@`` sign.
 
 oauth_providers
 ---------------

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -176,6 +176,7 @@ describe("Notifications", function () {
                     to: 'romeo@montague.lit',
                     type: 'groupchat'
                 }).c('body').t(text);
+                _converse.api.settings.set('notify_all_room_messages', true);
                 await view.model.handleMessageStanza(message.nodeTree);
                 await u.waitUntil(() => _converse.playSoundNotification.calls.count());
                 expect(_converse.playSoundNotification).toHaveBeenCalled();

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -35,46 +35,6 @@ describe("Notifications", function () {
                     done();
                 }));
 
-                it("is shown when you are mentioned in a groupchat",
-                        mock.initConverse(['rosterGroupsFetched'], {}, async (done, _converse) => {
-
-                    await mock.waitForRoster(_converse, 'current');
-                    await mock.openAndEnterChatRoom(_converse, 'lounge@montague.lit', 'romeo');
-                    const view = _converse.api.chatviews.get('lounge@montague.lit');
-                    if (!view.el.querySelectorAll('.chat-area').length) {
-                        view.renderChatArea();
-                    }
-                    let no_notification = false;
-                    if (typeof window.Notification === 'undefined') {
-                        no_notification = true;
-                        window.Notification = function () {
-                            return {
-                                'close': function () {}
-                            };
-                        };
-                    }
-                    spyOn(_converse, 'showMessageNotification').and.callThrough();
-                    spyOn(_converse, 'areDesktopNotificationsEnabled').and.returnValue(true);
-
-                    const message = 'romeo: This message will show a desktop notification';
-                    const nick = mock.chatroom_names[0],
-                        msg = $msg({
-                            from: 'lounge@montague.lit/'+nick,
-                            id: u.getUniqueId(),
-                            to: 'romeo@montague.lit',
-                            type: 'groupchat'
-                        }).c('body').t(message).tree();
-                    _converse.connection._dataRecv(mock.createRequest(msg));
-                    await new Promise(resolve => view.model.messages.once('rendered', resolve));
-
-                    await u.waitUntil(() => _converse.areDesktopNotificationsEnabled.calls.count() === 1);
-                    expect(_converse.showMessageNotification).toHaveBeenCalled();
-                    if (no_notification) {
-                        delete window.Notification;
-                    }
-                    done();
-                }));
-
                 it("is shown for headline messages",
                         mock.initConverse(['rosterGroupsFetched'], {}, async (done, _converse) => {
 
@@ -146,57 +106,6 @@ describe("Notifications", function () {
                 _converse.api.trigger('contactRequest', {'fullname': 'Peter Parker', 'jid': 'peter@parker.com'});
                 expect(_converse.areDesktopNotificationsEnabled).toHaveBeenCalled();
                 expect(_converse.showContactRequestNotification).toHaveBeenCalled();
-                done();
-            }));
-        });
-    });
-
-    describe("When play_sounds is set to true", function () {
-        describe("A notification sound", function () {
-
-            it("is played when the current user is mentioned in a groupchat",
-                    mock.initConverse(['rosterGroupsFetched'], {}, async (done, _converse) => {
-
-                mock.createContacts(_converse, 'current');
-                await mock.openAndEnterChatRoom(_converse, 'lounge@montague.lit', 'romeo');
-                _converse.play_sounds = true;
-                spyOn(_converse, 'playSoundNotification');
-                const view = _converse.chatboxviews.get('lounge@montague.lit');
-                if (!view.el.querySelectorAll('.chat-area').length) {
-                    view.renderChatArea();
-                }
-                let text = 'This message will play a sound because it mentions romeo';
-                let message = $msg({
-                    from: 'lounge@montague.lit/otheruser',
-                    id: '1',
-                    to: 'romeo@montague.lit',
-                    type: 'groupchat'
-                }).c('body').t(text);
-                await view.model.handleMessageStanza(message.nodeTree);
-                await u.waitUntil(() => _converse.playSoundNotification.calls.count());
-                expect(_converse.playSoundNotification).toHaveBeenCalled();
-
-                text = "This message won't play a sound";
-                message = $msg({
-                    from: 'lounge@montague.lit/otheruser',
-                    id: '2',
-                    to: 'romeo@montague.lit',
-                    type: 'groupchat'
-                }).c('body').t(text);
-                await view.model.handleMessageStanza(message.nodeTree);
-                expect(_converse.playSoundNotification, 1);
-                _converse.play_sounds = false;
-
-                text = "This message won't play a sound because it is sent by romeo";
-                message = $msg({
-                    from: 'lounge@montague.lit/romeo',
-                    id: '3',
-                    to: 'romeo@montague.lit',
-                    type: 'groupchat'
-                }).c('body').t(text);
-                await view.model.handleMessageStanza(message.nodeTree);
-                expect(_converse.playSoundNotification, 1);
-                _converse.play_sounds = false;
                 done();
             }));
         });

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -38,26 +38,12 @@ converse.plugins.add('converse-notification', {
         _converse.shouldNotifyOfGroupMessage = function (message) {
             /* Is this a group message worthy of notification?
              */
-            let notify_all = api.settings.get('notify_all_room_messages');
-            const jid = message.getAttribute('from'),
-                resource = Strophe.getResourceFromJid(jid),
-                room_jid = Strophe.getBareJidFromJid(jid),
-                sender = resource && Strophe.unescapeNode(resource) || '';
-            if (sender === '' || message.querySelectorAll('delay').length > 0) {
-                return false;
-            }
-            const room = _converse.chatboxes.get(room_jid);
-            const body = message.querySelector('body');
-            if (body === null) {
-                return false;
-            }
-            const mentioned = (new RegExp(`\\b${room.get('nick')}\\b`)).test(body.textContent);
-            notify_all = notify_all === true ||
-                (Array.isArray(notify_all) && notify_all.includes(room_jid));
-            if (sender === room.get('nick') || (!notify_all && !mentioned)) {
-                return false;
-            }
-            return true;
+            const jid = message.getAttribute('from');
+            const room_jid = Strophe.getBareJidFromJid(jid);
+            const notify_all = api.settings.get('notify_all_room_messages');
+            const result = notify_all === true
+                || (Array.isArray(notify_all) && notify_all.includes(room_jid));
+            return !!result;
         };
 
         _converse.isMessageToHiddenChat = function (message) {

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -32,7 +32,8 @@ converse.plugins.add('converse-notification', {
             play_sounds: true,
             sounds_path: api.settings.get("assets_path")+'/sounds/',
             notification_icon: 'logo/conversejs-filled.svg',
-            notification_delay: 5000
+            notification_delay: 5000,
+            notify_nicknames_without_references: false
         });
 
         _converse.shouldNotifyOfGroupMessage = function (message) {
@@ -41,8 +42,17 @@ converse.plugins.add('converse-notification', {
             const jid = message.getAttribute('from');
             const room_jid = Strophe.getBareJidFromJid(jid);
             const notify_all = api.settings.get('notify_all_room_messages');
+            let is_mentioned = false;
+            
+            if (api.settings.get('notify_nicknames_without_references')) {
+                const room = _converse.chatboxes.get(room_jid);
+                const body = message.querySelector('body');
+                is_mentioned = (new RegExp(`\\b${room.get('nick')}\\b`)).test(body.textContent);
+            }
+            
             const result = notify_all === true
-                || (Array.isArray(notify_all) && notify_all.includes(room_jid));
+                || (Array.isArray(notify_all) && notify_all.includes(room_jid))
+                || is_mentioned;
             return !!result;
         };
 

--- a/src/converse-notification.js
+++ b/src/converse-notification.js
@@ -42,18 +42,21 @@ converse.plugins.add('converse-notification', {
             const jid = message.getAttribute('from');
             const room_jid = Strophe.getBareJidFromJid(jid);
             const notify_all = api.settings.get('notify_all_room_messages');
+            const room = _converse.chatboxes.get(room_jid);
+            const resource = Strophe.getResourceFromJid(jid);
+            const sender = resource && Strophe.unescapeNode(resource) || '';
             let is_mentioned = false;
             
             if (api.settings.get('notify_nicknames_without_references')) {
-                const room = _converse.chatboxes.get(room_jid);
                 const body = message.querySelector('body');
                 is_mentioned = (new RegExp(`\\b${room.get('nick')}\\b`)).test(body.textContent);
             }
             
-            const result = notify_all === true
+            const is_not_mine = sender !== room.get('nick');
+            const should_notify_user = notify_all === true
                 || (Array.isArray(notify_all) && notify_all.includes(room_jid))
                 || is_mentioned;
-            return !!result;
+            return is_not_mine && !!should_notify_user;
         };
 
         _converse.isMessageToHiddenChat = function (message) {

--- a/src/headless/converse-chat.js
+++ b/src/headless/converse-chat.js
@@ -1224,7 +1224,7 @@ converse.plugins.add('converse-chat', {
              * @property { XMLElement } stanza
              * @example _converse.api.listen.on('message', obj => { ... });
              */
-            api.trigger('message', {'stanza': stanza});
+            api.trigger('message', {stanza, attrs});
         }
 
 

--- a/src/headless/converse-headlines.js
+++ b/src/headless/converse-headlines.js
@@ -98,7 +98,7 @@ converse.plugins.add('converse-headlines', {
                 });
                 const attrs = await st.parseMessage(stanza, _converse);
                 await chatbox.createMessage(attrs);
-                api.trigger('message', {'chatbox': chatbox, 'stanza': stanza});
+                api.trigger('message', {chatbox, stanza, attrs});
             }
         }
 

--- a/src/headless/converse-muc.js
+++ b/src/headless/converse-muc.js
@@ -669,10 +669,10 @@ converse.plugins.add('converse-muc', {
                     // they shouldn't have a `type` attribute.
                     return log.warn(`Received a MAM message with type "groupchat"`);
                 }
-                api.trigger('message', {'stanza': stanza});
                 this.createInfoMessages(stanza);
                 this.fetchFeaturesIfConfigurationChanged(stanza);
                 const attrs = await st.parseMUCMessage(stanza, this, _converse);
+                api.trigger('message', {stanza, attrs});
                 return attrs && this.queueMessage(attrs);
             },
 


### PR DESCRIPTION
The original intention was to remove the notification by default when a user is mentioned (captured by RegExp).
However, ideally I would have this function return `true` only in the required cases, vs always returning `true` with exceptions.
Is there any other case where this function should return `true`, besides when `notify_all` is true or has a room jid?