### PR TITLE
adds setting to set non-image-extension image urls

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -907,6 +907,13 @@ and an idle presence according to XEP-0319 is sent.
 
 If the given value is negative or ``0``, this feature is disabled.
 
+image_urls_regex
+----------------
+
+Any URLs in a message that matches the regex in this setting will be considered an image and displayed inline.
+
+E.g. ``/^https?:\/\/(?:www.)?(?:imgur\.com\/\w{7})\/?$/i``
+
 jid
 ---
 

--- a/spec/messages.js
+++ b/spec/messages.js
@@ -979,6 +979,13 @@ describe("A Chat Message", function () {
         expect(view.content.querySelectorAll('img').length).toBe(4);
         mock.sendMessage(view, message);
         expect(view.content.querySelectorAll('img').length).toBe(4);
+
+        // Configured image URLs are rendered
+        _converse.api.settings.set('image_urls_regex', /^https?:\/\/(?:www.)?(?:imgur\.com\/\w{7})\/?$/i);
+        message = 'http://imgur.com/xxxxxxx';
+        mock.sendMessage(view, message);
+        await u.waitUntil(() => view.el.querySelectorAll('.chat-content .chat-image').length === 5, 1000);
+        expect(view.content.querySelectorAll('img').length).toBe(5);
         done();
     }));
 

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -67,6 +67,7 @@ converse.plugins.add('converse-chatview', {
                 'emoji': true,
                 'spoiler': true
             },
+            'image_urls_regex': null
         });
 
 

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -52,6 +52,7 @@ converse.plugins.add('converse-chatview', {
         api.settings.extend({
             'auto_focus': true,
             'debounced_content_rendering': true,
+            'image_urls_regex': null,
             'message_limit': 0,
             'muc_hats_from_vcard': false,
             'show_images_inline': true,
@@ -67,7 +68,6 @@ converse.plugins.add('converse-chatview', {
                 'emoji': true,
                 'spoiler': true
             },
-            'image_urls_regex': null
         });
 
 

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -120,7 +120,7 @@ function addHyperlinks (text, onImgLoad, onImgClick) {
         text.addTemplateResult(
             url_obj.start,
             url_obj.end,
-            show_images && u.isImageURL(url_text) ?
+            show_images && (u.isImageURL(url_text) || u.isWhitelistedImageURL(url_text)) ?
                 u.convertToImageTag(url_text, onImgLoad, onImgClick) :
                 u.convertUrlToHyperlink(url_text),
         );

--- a/src/templates/directives/body.js
+++ b/src/templates/directives/body.js
@@ -120,7 +120,7 @@ function addHyperlinks (text, onImgLoad, onImgClick) {
         text.addTemplateResult(
             url_obj.start,
             url_obj.end,
-            show_images && (u.isImageURL(url_text) || u.isWhitelistedImageURL(url_text)) ?
+            show_images && u.isImageURL(url_text) ?
                 u.convertToImageTag(url_text, onImgLoad, onImgClick) :
                 u.convertUrlToHyperlink(url_text),
         );

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -75,8 +75,12 @@ function checkFileTypes (types, url) {
 }
 
 u.isAudioURL = url => checkFileTypes(['.ogg', '.mp3', '.m4a'], url);
-u.isImageURL = url => checkFileTypes(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.svg'], url);
 u.isVideoURL = url => checkFileTypes(['.mp4', '.webm'], url);
+u.isImageURL = url => checkFileTypes(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.svg'], url);
+u.isWhitelistedImageURL = url => {
+    const regex = _converse.api.settings.get('image_urls_regex');
+    return regex ? regex.test(url) : false;
+}
 
 function getFileName (uri) {
     try {

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -76,10 +76,11 @@ function checkFileTypes (types, url) {
 
 u.isAudioURL = url => checkFileTypes(['.ogg', '.mp3', '.m4a'], url);
 u.isVideoURL = url => checkFileTypes(['.mp4', '.webm'], url);
-u.isImageURL = url => checkFileTypes(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.svg'], url);
-u.isWhitelistedImageURL = url => {
-    const regex = _converse.api.settings.get('image_urls_regex');
-    return regex ? regex.test(url) : false;
+u.isImageURL = url => {
+    const regex = api.settings.get('image_urls_regex');
+    return regex
+        ? regex.test(url)
+        : checkFileTypes(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.svg'], url);
 }
 
 function getFileName (uri) {


### PR DESCRIPTION
Example RegExp:

`/^https?:\/\/(?:www.)?(?:imgur\.com\/\w{7}|tradingview.com\/\w\/\w{8})\/?$/i`

Parsing function unit-tested here:
https://codepen.io/arielfuggini/pen/YzqVjyg