### PR TITLE
Prevent message actions dropdown from being closed after event retargeting when bubbl…

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -15,7 +15,7 @@ export class BaseDropdown extends CustomElement {
         this.button = this.dropdown.querySelector('button');
         this.dropdown.addEventListener('click', ev => this.toggleMenu(ev));
         this.dropdown.addEventListener('keyup', ev => this.handleKeyUp(ev));
-        document.addEventListener('click', ev => !this.contains(ev.originalTarget || ev.path[0]) && this.hideMenu(ev));
+        document.addEventListener('click', ev => !this.contains(ev.composedPath()[0]) && this.hideMenu(ev));
     }
 
     hideMenu () {

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -15,7 +15,7 @@ export class BaseDropdown extends CustomElement {
         this.button = this.dropdown.querySelector('button');
         this.dropdown.addEventListener('click', ev => this.toggleMenu(ev));
         this.dropdown.addEventListener('keyup', ev => this.handleKeyUp(ev));
-        document.addEventListener('click', ev => !this.contains(ev.target) && this.hideMenu(ev));
+        document.addEventListener('click', ev => !this.contains(ev.originalTarget || ev.path[0]) && this.hideMenu(ev));
     }
 
     hideMenu () {


### PR DESCRIPTION
…ing out of a shadowRoot.

When the click event bubbles out of the shadowRoot, the event gets re-targeted to the shadowRoot host. The event listener is expecting the same target so when the target changes the dropdown gets closed prematurely.
This change uses the original target instead of the re-targeted one allowing the dropdown to work as expected even when using converse in a shadowRoot. 