### PR TITLE
Prevents exception caused by reference being an empty string

### DIFF
--- a/src/headless/converse-emoji.js
+++ b/src/headless/converse-emoji.js
@@ -147,7 +147,7 @@ export function getEmojiMarkup (data, options={unicode_only: false, add_title_wr
 export function getShortnameReferences (text) {
     const references = [...text.matchAll(shortnames_regex)];
     return references.map(ref => {
-        const cp = converse.emojis.by_sn[ref[0]].cp;
+        const cp = converse.emojis.by_sn?.[ref[0]]?.cp;
         return {
             cp,
             'begin': ref.index,


### PR DESCRIPTION
Apparently calling the `sendMessage` function too soon causes the `0` index reference in `getShortnameReferences ` to be an empty string, which causes an exception and therefore the message is not sent.