### PR TITLE
Bugfix. Promise.resolve is not a constructor

### DIFF
--- a/src/headless/converse-core.js
+++ b/src/headless/converse-core.js
@@ -942,7 +942,7 @@ export const api = _converse.api = {
             }
         } else {
             _converse.connection.sendIQ(stanza);
-            promise = new Promise.resolve();
+            promise = Promise.resolve();
         }
         api.trigger('send', stanza);
         return promise;


### PR DESCRIPTION
Fixes

> FATAL: error: undefined .../converse.min.js:241 - TypeError: Promise.resolve is not a constructor

as noticed in the console

- [ ] Add a changelog entry for your change in `CHANGES.md`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.

Small fix, changelog entry and test needed?