### PR TITLE
#2092 fixes room list update loop with locked muc domains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@ Soon we'll deprecate the latter, so prepare now.
 - #2201: added html to converse.env
 - #2213: added CustomElement to converse.env
 - #2220: fix rendering of emojis in case `use_system_emojis == false` (again).
+- #2092: fixes room list update loop when having the `locked_muc_domain` set to false or hidden
+
 - The `api.archive.query` method no longer accepts an RSM instance as argument.
 - The plugin `converse-uniview` has been removed and its functionality merged into `converse-chatboxviews`
 - Removed the mockups from the project. Recommended to use tests instead.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,8 +34,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2201: added html to converse.env
 - #2213: added CustomElement to converse.env
 - #2220: fix rendering of emojis in case `use_system_emojis == false` (again).
-- #2092: fixes room list update loop when having the `locked_muc_domain` set to false or hidden
-
+- #2092: fixes room list update loop when having the `locked_muc_domain` truthy or `'hidden'`
 - The `api.archive.query` method no longer accepts an RSM instance as argument.
 - The plugin `converse-uniview` has been removed and its functionality merged into `converse-chatboxviews`
 - Removed the mockups from the project. Recommended to use tests instead.

--- a/src/modals/muc-list.js
+++ b/src/modals/muc-list.js
@@ -93,6 +93,11 @@ export default BootstrapModal.extend({
             this.model.save('muc_domain', api.settings.get('muc_domain'));
         }
         this.listenTo(this.model, 'change:muc_domain', this.onDomainChange);
+
+        this.el.addEventListener('shown.bs.modal', () => api.settings.get('locked_muc_domain')
+          ? this.updateRoomsList()
+          : this.el.querySelector('input[name="server"]').focus()
+        );
     },
 
     toHTML () {
@@ -108,17 +113,6 @@ export default BootstrapModal.extend({
                 'submitForm': ev => this.showRooms(ev),
                 'toggleRoomInfo': ev => this.toggleRoomInfo(ev)
             }));
-    },
-
-    afterRender () {
-        if (api.settings.get('locked_muc_domain')) {
-            this.el.addEventListener('shown.bs.modal', () => this.updateRoomsList());
-        } else {
-            this.el.addEventListener('shown.bs.modal',
-                () => this.el.querySelector('input[name="server"]').focus(),
-                false
-            );
-        }
     },
 
     openRoom (ev) {

--- a/src/modals/muc-list.js
+++ b/src/modals/muc-list.js
@@ -112,7 +112,7 @@ export default BootstrapModal.extend({
 
     afterRender () {
         if (api.settings.get('locked_muc_domain')) {
-            this.updateRoomsList();
+            this.el.addEventListener('shown.bs.modal', () => this.updateRoomsList());
         } else {
             this.el.addEventListener('shown.bs.modal',
                 () => this.el.querySelector('input[name="server"]').focus(),


### PR DESCRIPTION
The `updateRoomList` function gets called after each render, and the `onRoomsFound` handler calls `this.render()`. Looks like the problem is fixed when the `updateRoomList` only gets called on the `shown.bs.model` event. This is needed because the list will not update after re-opening the modal (it does not get destroyed on close).

Linked issue: #2092