### PR TITLE
regression of #1317: Don't show errors for CSI messages

### DIFF
--- a/spec/messages.js
+++ b/spec/messages.js
@@ -1589,9 +1589,9 @@ describe("A Chat Message", function () {
                     .c('text', { 'xmlns': "urn:ietf:params:xml:ns:xmpp-stanzas" })
                         .t('Something else went wrong as well');
                 _converse.connection._dataRecv(mock.createRequest(stanza));
-                await u.waitUntil(() => view.model.messages.length > 3);
+                await u.waitUntil(() => view.model.messages.length > 2);
                 await new Promise(resolve => view.model.messages.once('rendered', resolve));
-                expect(view.content.querySelectorAll('.chat-error').length).toEqual(1);
+                expect(view.content.querySelectorAll('.chat-msg__error').length).toEqual(3);
 
                 // Ensure messages with error are not editable
                 document.querySelectorAll('.chat-msg__actions').forEach(elem => {
@@ -1637,6 +1637,9 @@ describe("A Chat Message", function () {
                             .t('User session not found')
                 _converse.connection._dataRecv(mock.createRequest(stanza));
                 const view = _converse.chatboxviews.get(contact_jid);
+                const msg_text = 'This message will show!';
+                await view.model.sendMessage(msg_text);
+                await new Promise(resolve => view.model.messages.once('rendered', resolve));
                 expect(view.content.querySelectorAll('.chat-error').length).toEqual(0);
                 done();
             }));

--- a/src/headless/converse-chat.js
+++ b/src/headless/converse-chat.js
@@ -635,7 +635,7 @@ converse.plugins.add('converse-chat', {
              */
             shouldShowErrorMessage (attrs) {
                 const msg = this.getMessageReferencedByError(attrs);
-                if (!msg && attrs.body === null) {
+                if (!msg && !attrs.body) {
                     // If the error refers to a message not included in our store,
                     // and it doesn't have a <body> tag, we assume that this was a
                     // CSI message (which we don't store).

--- a/src/headless/converse-emoji.js
+++ b/src/headless/converse-emoji.js
@@ -154,7 +154,7 @@ export function getShortnameReferences (text) {
             'To avoid this problem, first await the converse.emojis.initilaized_promise.'
         );
     }
-    const references = [...text.matchAll(shortnames_regex)];
+    const references = [...text.matchAll(shortnames_regex)].filter(ref => ref[0].length > 0);
     return references.map(ref => {
         const cp = converse.emojis.by_sn[ref[0]].cp;
         return {


### PR DESCRIPTION
Unfortunately #1317 is back. This PR fixes it.

I didn't manage to fix the tests though. Maybe I'll find time to fix those tomorrow ...
