### PR TITLE
#2290 fix dayjs locale format

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -73,12 +73,14 @@ function isLocaleAvailable (locale, available) {
  */
 async function fetchTranslations (_converse) {
     const { api, locale } = _converse;
+    const dayjs_locale = locale.toLowerCase().replace('_', '-');
+
     if (!isConverseLocale(locale, api.settings.get("locales")) || locale === 'en') {
         return;
     }
     const { default: data } = await import(/*webpackChunkName: "locales/[request]" */ `../i18n/${locale}/LC_MESSAGES/converse.po`);
-    await import(/*webpackChunkName: "locales/dayjs/[request]" */ `dayjs/locale/${locale.toLowerCase().replace('_', '-')}`);
-    dayjs.locale(getLocale(locale, l => dayjs.locale(l)));
+    await import(/*webpackChunkName: "locales/dayjs/[request]" */ `dayjs/locale/${dayjs_locale}`);
+    dayjs.locale(getLocale(dayjs_locale, l => dayjs.locale(l)));
     jed_instance = new Jed(data);
 }
 


### PR DESCRIPTION
fixed the formatting of the dayjs locale to allow the use of compound locale such as "pt_BR"

![conversejs-screenshots (4)](https://user-images.githubusercontent.com/31113941/96103752-5f540a00-0ed8-11eb-8afe-225be2fe4aac.png)
