### PR TITLE
Fix message reorder issue after edit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2220: fix rendering of emojis in case `use_system_emojis == false` (again).
 - #2092: fixes room list update loop when having the `locked_muc_domain` truthy or `'hidden'`
 - #2285: Rename config option `muc_hats_from_vcard` to [muc_hats](https://conversejs.org/docs/html/configuration.html#muc-hats). Now accepts a list instead of a boolean and allows for more flexible choices regarding user badges.
+- #2300: Fix message reorder issue after message correction.
 - The `api.archive.query` method no longer accepts an RSM instance as argument.
 - The plugin `converse-uniview` has been removed and its functionality merged into `converse-chatboxviews`
 - Removed the mockups from the project. Recommended to use tests instead.

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -63,7 +63,7 @@ export default class Message extends CustomElement {
 
     render () {
         const format = api.settings.get('time_format');
-        this.pretty_time = dayjs(this.time).format(format);
+        this.pretty_time = dayjs(this.edited || this.time).format(format);
         if (this.show_spinner) {
             return tpl_spinner();
         } else if (this.model.get('file') && !this.model.get('oob_url')) {
@@ -264,7 +264,7 @@ export default class Message extends CustomElement {
     renderAvatarByline () {
         return html`
             ${ this.hats.map(h => html`<span class="badge badge-secondary">${h.title}</span>`) }
-            <time timestamp="${this.time}" class="chat-msg__time">${this.pretty_time}</time>
+            <time timestamp="${this.edited || this.time}" class="chat-msg__time">${this.pretty_time}</time>
         `;
     }
 

--- a/src/headless/converse-chat.js
+++ b/src/headless/converse-chat.js
@@ -744,9 +744,14 @@ converse.plugins.add('converse-chat', {
                     message.save({'older_versions': older_versions});
                 } else {
                     // This is a correction of an earlier message we already received
-                    older_versions[message.get('time')] = message.get('message');
+                    if(Object.keys(older_versions).length) {
+                        older_versions[message.get('edited')] = message.get('message');
+                    }else {
+                        older_versions[message.get('time')] = message.get('message');
+                    }
                     attrs = Object.assign(attrs, {'older_versions': older_versions});
                     delete attrs['id']; // Delete id, otherwise a new cache entry gets created
+                    attrs['time'] = message.get('time');
                     message.save(attrs);
                 }
                 return message;

--- a/src/templates/chat_message.js
+++ b/src/templates/chat_message.js
@@ -28,7 +28,7 @@ export default (o) => {
                 <div class="chat-msg__body chat-msg__body--${o.message_type} ${o.received ? 'chat-msg__body--received' : '' } ${o.is_delayed ? 'chat-msg__body--delayed' : '' }">
                     <div class="chat-msg__message">
                         ${ (o.is_me_message) ? html`
-                            <time timestamp="${o.time}" class="chat-msg__time">${o.pretty_time}</time>&nbsp;
+                            <time timestamp="${o.edited || o.time}" class="chat-msg__time">${o.pretty_time}</time>&nbsp;
                             <span class="chat-msg__author">${ o.is_me_message ? '**' : ''}${o.username}</span>&nbsp;` : '' }
                         ${ o.is_retracted ? o.renderRetraction() : o.renderMessageText() }
                     </div>


### PR DESCRIPTION
When a message is corrected it gives the impression that it gets deleted, and the correcting message appears at the bottom of the chat history as if it was a new message that has been edited.
This pull request aims to fix the issue by keeping always the time of the original message while using the last edit timestamp to keep consistency with current behaviour.

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
