### PR TITLE
Allow getHats method to be overriden

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2220: fix rendering of emojis in case `use_system_emojis == false` (again).
 - #2092: fixes room list update loop when having the `locked_muc_domain` truthy or `'hidden'`
 - #2285: Rename config option `muc_hats_from_vcard` to [muc_hats](https://conversejs.org/docs/html/configuration.html#muc-hats). Now accepts a list instead of a boolean and allows for more flexible choices regarding user badges.
+- #2308: Allow getHats method to be overriden in the `overrides` object in plugins.
 - The `trusted` configuration setting has been removed in favor of two new settings:
     [allow_user_trust_override](https://conversejs.org/docs/html/configuration.html#allow-user-trust-override)
     [clear_cache_on_logout](https://conversejs.org/docs/html/configuration.html#clear-cache-on-logout)

--- a/src/components/message-history.js
+++ b/src/components/message-history.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import tpl_new_day from "../templates//new_day.js";
 import { CustomElement } from './element.js';
 import { __ } from '../i18n';
-import { api } from "@converse/headless/converse-core";
+import { _converse, api } from "@converse/headless/converse-core";
 import { html } from 'lit-element';
 import { repeat } from 'lit-html/directives/repeat.js';
 
@@ -67,8 +67,10 @@ function getDayIndicator (model) {
         });
     }
 }
-
-function getHats (model) {
+// This is set to _converse so that it can be overriden. An attempt was made to use
+// a hook instead, but hook returns a promise and it forces the asynchronicity up
+// to the render method.
+_converse.getHats = function (model) {
     if (model.get('type') === 'groupchat') {
         const allowed_hats = api.settings.get('muc_hats').filter(hat => hat).map((hat) => (hat.toLowerCase()));
         let vcard_roles = []
@@ -93,7 +95,7 @@ export function getDerivedMessageProps (chatbox, model) {
     const is_groupchat = model.get('type') === 'groupchat';
     return {
         'has_mentions': is_groupchat && model.get('sender') === 'them' && chatbox.isUserMentioned(model),
-        'hats': getHats(model),
+        'hats': _converse.getHats(model),
         'is_first_unread': chatbox.get('first_unread_id') === model.get('id'),
         'is_me_message': model.isMeCommand(),
         'is_retracted': model.get('retracted') || model.get('moderated') === 'retracted',


### PR DESCRIPTION
Just for the record and future reference:

This change was attempted firstly by using a hook. Unfortunately `hook()` returns a promise which forces the call stack to be asynchronous all the way up to the `render()` method. Workarounds do exist but are not worth the effort. 
So, while the general direction of the project in this regard is to move towards the use of `hook()`, the solution agreed for this particular case is to allow `getHats()` to be overriden in the `overrides` object of plugins.