### PR TITLE
fix #2307 - BootstrapModal no more accessible to plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2092: fixes room list update loop when having the `locked_muc_domain` truthy or `'hidden'`
 - #2285: Rename config option `muc_hats_from_vcard` to [muc_hats](https://conversejs.org/docs/html/configuration.html#muc-hats). Now accepts a list instead of a boolean and allows for more flexible choices regarding user badges.
 - #2304: Custom emojis (stickers) images not shown 
+- #2307: BootstrapModal no more accessible to plugins
 - The `trusted` configuration setting has been removed in favor of two new settings:
     [allow_user_trust_override](https://conversejs.org/docs/html/configuration.html#allow-user-trust-override)
     [clear_cache_on_logout](https://conversejs.org/docs/html/configuration.html#clear-cache-on-logout)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@ Soon we'll deprecate the latter, so prepare now.
 - #2092: fixes room list update loop when having the `locked_muc_domain` truthy or `'hidden'`
 - #2285: Rename config option `muc_hats_from_vcard` to [muc_hats](https://conversejs.org/docs/html/configuration.html#muc-hats). Now accepts a list instead of a boolean and allows for more flexible choices regarding user badges.
 - #2304: Custom emojis (stickers) images not shown 
-- #2307: BootstrapModal no more accessible to plugins
+- #2307: BootstrapModal is not accessible to plugins
 - The `trusted` configuration setting has been removed in favor of two new settings:
     [allow_user_trust_override](https://conversejs.org/docs/html/configuration.html#allow-user-trust-override)
     [clear_cache_on_logout](https://conversejs.org/docs/html/configuration.html#clear-cache-on-logout)

--- a/src/converse-modal.js
+++ b/src/converse-modal.js
@@ -86,6 +86,7 @@ export const BootstrapModal = View.extend({
     }
 });
 
+converse.env.BootstrapModal = BootstrapModal; // expose to plugins
 
 export const Confirm = BootstrapModal.extend({
     events: {


### PR DESCRIPTION
This fix can be tested from the search plugin. The plugin and PR are currently running at https://conversejs.github.io/community-plugins
