### PR TITLE
fix #2409 - Integrate App Badging API for unread messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - New configuration setting: [send_chat_markers](https://conversejs.org/docs/html/configuration.html#send-chat-markers)
 - #1823: New config options [mam_request_all_pages](https://conversejs.org/docs/html/configuration.html#mam-request-all-pages)
 - Use the MUC stanza id when sending XEP-0333 markers
+- #2409: Integrate App Badging API for unread messages
 
 ### Breaking Changes
 

--- a/src/plugins/notifications/utils.js
+++ b/src/plugins/notifications/utils.js
@@ -25,6 +25,12 @@ export function areDesktopNotificationsEnabled () {
 
 export function clearFavicon () {
     favicon = null;
+
+    if (navigator.clearAppBadge) {
+      navigator.clearAppBadge().catch((error) => {
+        log.error("Could not clear unread count in app badge " + error);
+      });
+    }
 }
 
 export function updateUnreadFavicon () {
@@ -33,6 +39,12 @@ export function updateUnreadFavicon () {
         const chats = _converse.chatboxes.models;
         const num_unread = chats.reduce((acc, chat) => acc + (chat.get('num_unread') || 0), 0);
         favicon.badge(num_unread);
+
+        if (navigator.setAppBadge) {
+          navigator.setAppBadge(num_unread).catch((error) => {
+            log.error("Could set unread count in app badge - " + error);
+          });
+        }
     }
 }
 


### PR DESCRIPTION
I have just made this minor change in Pade and decided to raise a PR to do the same in Converse as I had done it before on the browser tab icon with favico . It does not need a test
