### PR TITLE
WIP: Fix message history date format according to locale

### DIFF
--- a/sass/_messages.scss
+++ b/sass/_messages.scss
@@ -74,6 +74,7 @@
                 padding: 0 1em;
                 position: relative;
                 z-index: 5;
+                text-transform: capitalize;
             }
         }
 

--- a/src/headless/core.js
+++ b/src/headless/core.js
@@ -6,6 +6,7 @@
 import './polyfill';
 import Storage from '@converse/skeletor/src/storage.js';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 import dayjs from 'dayjs';
 import log from '@converse/headless/log';
 import pluggable from 'pluggable.js/src/pluggable';
@@ -25,6 +26,7 @@ import { sprintf } from 'sprintf-js';
 
 
 dayjs.extend(advancedFormat);
+dayjs.extend(localizedFormat);
 
 // Add Strophe Namespaces
 Strophe.addNamespace('CARBONS', 'urn:xmpp:carbons:2');

--- a/src/shared/chat/message-history.js
+++ b/src/shared/chat/message-history.js
@@ -63,7 +63,7 @@ function getDayIndicator (model) {
         return tpl_new_day({
             'type': 'date',
             'time': day_date.toISOString(),
-            'datestring': day_date.format("dddd MMM Do YYYY")
+            'datestring': day_date.format("dddd ll").replace(',', '')
         });
     }
 }


### PR DESCRIPTION
Update date delimiter format for when the i18n option is set to "fr"

## Result

![image](https://user-images.githubusercontent.com/1533514/109806892-857b0c00-7c25-11eb-8efd-d6aba772858a.png)

![image](https://user-images.githubusercontent.com/1533514/109807261-eefb1a80-7c25-11eb-8f59-f159e02b458a.png)


## Warning

The suffix on the day number is lost for the english lang
It's now "3" instead of "3rd" because of dayjs, what would be the best way to fix that? 
Recreate the localizedFormat plugin ourselves?

