### PR TITLE
Move the httpToGeoUri util into the core

### DIFF
--- a/src/headless/utils/core.js
+++ b/src/headless/utils/core.js
@@ -528,6 +528,11 @@ u.getUniqueId = function (suffix) {
     }
 }
 
+u.httpToGeoUri = function(text, _converse) {
+    const replacement = 'geo:$1,$2';
+    return text.replace(_converse.api.settings.get("geouri_regex"), replacement);
+};
+
 
 /**
  * Clears the specified timeout and interval.

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -356,11 +356,6 @@ u.filterQueryParamsFromURL = function (url) {
     return parsed_uri.removeQuery(paramsArray).toString();
 };
 
-u.httpToGeoUri = function(text, _converse) {
-    const replacement = 'geo:$1,$2';
-    return text.replace(_converse.api.settings.get("geouri_regex"), replacement);
-};
-
 u.slideInAllElements = function (elements, duration=300) {
     return Promise.all(Array.from(elements).map(e => u.slideIn(e, duration)));
 };


### PR DESCRIPTION
The "sendMessage" function of chatboxes throw an error in the headless build

> converse.env.utils.httpToGeoUri does not exist

Usage:
* src/headless/plugins/chat/model.js:797
* src/headless/plugins/muc/muc.js:946