### PR TITLE
Fix stall document events

### DIFF
--- a/src/shared/chat/emoji-picker.js
+++ b/src/shared/chat/emoji-picker.js
@@ -38,7 +38,6 @@ export default class EmojiPicker extends CustomElement {
         super();
         this._search_results = [];
         this.debouncedFilter = debounce(input => this.model.set({'query': input.value}), 250);
-        this.registerEvents();
     }
 
     get search_results () {
@@ -124,7 +123,7 @@ export default class EmojiPicker extends CustomElement {
     disconnectedCallback() {
         const body = document.querySelector('body');
         body.removeEventListener('keydown', this.onGlobalKeyDown);
-        super.disconnectedCallback()
+        super.disconnectedCallback();
     }
 
     _onGlobalKeyDown (ev) {

--- a/src/shared/components/dropdown.js
+++ b/src/shared/components/dropdown.js
@@ -9,13 +9,28 @@ const u = converse.env.utils;
 
 export class BaseDropdown extends CustomElement {
 
+    connectedCallback() {
+        super.connectedCallback();
+        this.registerEvents();
+    }
+
+    registerEvents() {
+        this.clickOutside = this._clickOutside.bind(this);
+        document.addEventListener('click', this.clickOutside);
+    }
+
     firstUpdated () {
         this.menu = this.querySelector('.dropdown-menu');
         this.dropdown = this.firstElementChild;
         this.button = this.dropdown.querySelector('button');
         this.dropdown.addEventListener('click', ev => this.toggleMenu(ev));
         this.dropdown.addEventListener('keyup', ev => this.handleKeyUp(ev));
-        document.addEventListener('click', ev => !this.contains(ev.composedPath()[0]) && this.hideMenu(ev));
+    }
+
+    _clickOutside(ev) {
+        if (!this.contains(ev.composedPath()[0])) {
+            this.hideMenu(ev);
+        }
     }
 
     hideMenu () {
@@ -44,6 +59,11 @@ export class BaseDropdown extends CustomElement {
         } else if (ev.keyCode === converse.keycodes.DOWN_ARROW && this.navigator && !this.navigator.enabled) {
             this.enableArrowNavigation(ev);
         }
+    }
+
+    disconnectedCallback () {
+        document.removeEventListener('click', this.clickOutside);
+        super.disconnectedCallback();
     }
 }
 
@@ -75,7 +95,6 @@ export default class DropdownList extends BaseDropdown {
         super.hideMenu();
         this.navigator.disable();
     }
-
 
     firstUpdated () {
         super.firstUpdated();


### PR DESCRIPTION
When openening back and forth the same 2 MUCs, JS heap size goes up without being ever collected by the GC (even forced)

Browsers tested (archlinux):

- Chrome: 90.0.4430.93
- Firefox: 89.0.1

Those event listeners, if not removed properly, keep references to the chatboxes models everytime a room is open (in fullscreen mode)
