### PR TITLE
Ensure that the converse session is actually present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - #2633: Excessive logging of warning
 - #2634: Image previews not loading when not serving Converse locally
 - Bugfix: Don't show minimized chats when logged out
+- Bugfix: Ensure that the converse session is actually present before trying to get things from it
 
 ## 8.0.0 (2021-09-03)
 

--- a/src/headless/plugins/smacks/utils.js
+++ b/src/headless/plugins/smacks/utils.js
@@ -196,7 +196,7 @@ export async function enableStreamManagement () {
     smacks_handlers.push(conn.addHandler(stanzaHandler));
     smacks_handlers.push(conn.addHandler(sendAck, Strophe.NS.SM, 'r'));
     smacks_handlers.push(conn.addHandler(handleAck, Strophe.NS.SM, 'a'));
-    if (_converse.session.get('smacks_stream_id')) {
+    if (_converse.session && _converse.session.get('smacks_stream_id')) {
         await sendResumeStanza();
     } else {
         resetSessionData();


### PR DESCRIPTION
Sometimes, when registering, and when it tries to log you in, it tries to `get` something from the `shared_converse.session` object without it actually being there:

![image](https://user-images.githubusercontent.com/791672/132446000-b00e1bb0-9b1e-4465-b9b2-95424e79f80e.png)

I noticed the expectation that I write a test, but I'm not 100% certain how to replicate it and therefore don't know how to test it. I doubt this works on all servers, or with all settings combinations, otherwise it would be noticed sooner. However, this is such a small change that hopefully the lack of a test can be allowed to slide.

Thanks!