### PR TITLE
XEP-0122 form type hints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Three config settings have been obsoleted:
   - show_images_inline
   - muc_show_ogp_unfurls
 
+- Use more specific types for form fields based on XEP-0122
 
 ### Breaking Changes
 

--- a/conversejs.doap
+++ b/conversejs.doap
@@ -89,6 +89,13 @@
     </implements>
     <implements>
       <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0122.html"/>
+        <xmpp:status>partial</xmpp:status>
+        <xmpp:note>basic string field sub-type usage</xmpp:note>
+      </xmpp:SupportedXep>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0124.html"/>
       </xmpp:SupportedXep>
     </implements>

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -44,8 +44,26 @@ const XFORM_TYPE_MAP = {
     'list-multi': 'dropdown'
 };
 
+const XFORM_VALIDATE_TYPE_MAP = {
+	'xs:anyURI': 'url',
+	'xs:byte': 'number',
+	'xs:date': 'date',
+	'xs:dateTime': 'datetime',
+	'xs:int': 'number',
+	'xs:integer': 'number',
+	'xs:time': 'time',
+}
+
 function getInputType(field) {
-	return XFORM_TYPE_MAP[field.getAttribute('type')]
+	const type = XFORM_TYPE_MAP[field.getAttribute('type')]
+	if (type == 'text') {
+		const datatypes = field.getElementsByTagNameNS("http://jabber.org/protocol/xdata-validate", "validate");
+		if (datatypes.length === 1) {
+			const datatype = datatypes[0].getAttribute("datatype");
+			return XFORM_VALIDATE_TYPE_MAP[datatype] || type;
+		}
+	}
+	return type;
 }
 
 function slideOutWrapup (el) {


### PR DESCRIPTION
This maps data types provided via [XEP-0122](https://xmpp.org/extensions/xep-0122.html) to more specific types of `<input>` form fields, which enables UI and validation hints in supporting browsers. E.g. number fields may be shown with + and - buttons and on-screen keyboards could show a number pad. 

![image](https://user-images.githubusercontent.com/197474/138714730-b51d01a6-29ba-4d64-82c5-a42fc0bcde7c.png)

![image](https://user-images.githubusercontent.com/197474/138715254-393220d8-cfc2-40fd-9278-9401ada36825.png)

