### PR TITLE
fix #2751 - Media not rendered when Converse runs in a browser extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.0.1 (2021-??-??)
+
+- #2751: Media not rendered when Converse runs in a browser extension
+
 ## 9.0.0 (2021-11-26)
 
 - Compress new avatar images before uploading them

--- a/src/headless/utils/url.js
+++ b/src/headless/utils/url.js
@@ -21,7 +21,7 @@ export function getURI (url) {
 
 function checkFileTypes (types, url) {
     const uri = getURI(url);
-    if (uri === null || !checkTLS(uri)) {
+    if (window.location.protocol !== 'chrome-extension:' && (uri === null || !checkTLS(uri))) {
         return false;
     }
     const filename = uri.filename().toLowerCase();

--- a/src/headless/utils/url.js
+++ b/src/headless/utils/url.js
@@ -21,7 +21,8 @@ export function getURI (url) {
 
 function checkFileTypes (types, url) {
     const uri = getURI(url);
-    if (window.location.protocol !== 'chrome-extension:' && (uri === null || !checkTLS(uri))) {
+	
+    if (uri === null || (window.location.protocol !== 'chrome-extension:' && !checkTLS(uri))) {
         return false;
     }
     const filename = uri.filename().toLowerCase();


### PR DESCRIPTION
Thanks for making a pull request to converse.js!

Before submitting your request, please make sure the following conditions are met:

- [x ] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
