### PR TITLE
Wait for parseMessages before queuing to UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - #2786: Fix webpack configuration not working on Windows OS
 - #2788: `TypeError` when trying to use `@converse/headless`
 - #2789: Implement new hook `parseMessageForCommands` for plugins to add custom commands
+- #2733: Wait for decrypted/parsed message before queuing to UI
 
 
 ## 9.0.0 (2021-11-26)

--- a/src/headless/plugins/mam/utils.js
+++ b/src/headless/plugins/mam/utils.js
@@ -77,9 +77,11 @@ export function preMUCJoinMAMFetch (muc) {
 export async function handleMAMResult (model, result, query, options, should_page) {
     await api.emojis.initialize();
     const is_muc = model.get('type') === _converse.CHATROOMS_TYPE;
-    result.messages = result.messages.map(s =>
-        is_muc ? parseMUCMessage(s, model, _converse) : parseMessage(s, _converse)
-    );
+    
+    const doParseMessage = async (s) => {
+        return await (is_muc ? parseMUCMessage(s, model, _converse) : parseMessage(s, _converse))
+    }
+    const parsed_messages = await Promise.all(result.messages.map(doParseMessage));
 
     /**
      * Synchronous event which allows listeners to first do some

--- a/src/headless/plugins/mam/utils.js
+++ b/src/headless/plugins/mam/utils.js
@@ -81,7 +81,7 @@ export async function handleMAMResult (model, result, query, options, should_pag
     const doParseMessage = async (s) => {
         return await (is_muc ? parseMUCMessage(s, model, _converse) : parseMessage(s, _converse))
     }
-    const parsed_messages = await Promise.all(result.messages.map(doParseMessage));
+    await Promise.all(result.messages.map(doParseMessage));
 
     /**
      * Synchronous event which allows listeners to first do some

--- a/src/plugins/omemo/utils.js
+++ b/src/plugins/omemo/utils.js
@@ -304,7 +304,7 @@ async function handleDecryptedWhisperMessage (attrs, key_and_tag) {
     const from_jid = getJIDForDecryption(attrs);
     const devicelist = await _converse.devicelists.getDeviceList(from_jid);
     const encrypted = attrs.encrypted;
-    let device = devicelist.get(encrypted.device_id);
+    let device = devicelist.devices.get(encrypted.device_id);
     if (!device) {
         device = await devicelist.devices.create({ 'id': encrypted.device_id, 'jid': from_jid }, { 'promise': true });
     }


### PR DESCRIPTION
With recent changes to handle decryption when reconnecting after receiving messages while offline, some MAM messages are still being lost. This PR causes code handling MAM results to wait until decryption and parsing is finishing before queuing the message in the chatbox.

Related to https://github.com/conversejs/converse.js/issues/2733