### PR TITLE
Fix endless loop of adding .png to image URL.

### DIFF
--- a/src/headless/utils/url.js
+++ b/src/headless/utils/url.js
@@ -21,7 +21,7 @@ export function getURI (url) {
 
 function checkFileTypes (types, url) {
     const uri = getURI(url);
-    if (uri === null || (window.location.protocol !== 'chrome-extension:' && !checkTLS(uri))) {
+    if (uri === null || (!['chrome-extension:','file:'].includes(window.location.protocol) && !checkTLS(uri))) {
         return false;
     }
     const filename = uri.filename().toLowerCase();


### PR DESCRIPTION
If an image fails to load, converse-desktop ends up in an endless loop of adding .png to the image url and trying again.  Adding the file protocol as an exception resolves the problem.