### PR TITLE
AutoComplete: the groups that are bookmarked but not joined will be s…

### DIFF
--- a/src/plugins/muc-views/templates/add-muc.js
+++ b/src/plugins/muc-views/templates/add-muc.js
@@ -4,6 +4,7 @@ import { api } from '@converse/headless/core.js';
 import { html } from "lit";
 import { modal_header_close_button } from "plugins/modal/templates/buttons.js"
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { getAutoCompleteList } from "../utils.js";
 
 
 const nickname_input = (o) => {
@@ -34,7 +35,10 @@ export default (o) => {
                         <div class="form-group">
                             <label for="chatroom">${o.label_room_address}:</label>
                             ${ (o.muc_roomid_policy_error_msg) ? html`<label class="roomid-policy-error">${o.muc_roomid_policy_error_msg}</label>` : '' }
-                            <input type="text" required="required" name="chatroom" class="form-control roomjid-input" placeholder="${o.chatroom_placeholder}"/>
+                            <converse-autocomplete
+                            .getAutoCompleteList="${getAutoCompleteList}"
+                            placeholder="${o.chatroom_placeholder}"
+                            name="chatroom"/>
                         </div>
                         ${ o.muc_roomid_policy_hint ?  html`<div class="form-group">${unsafeHTML(DOMPurify.sanitize(o.muc_roomid_policy_hint, {'ALLOWED_TAGS': ['b', 'br', 'em']}))}</div>` : '' }
                         ${ !api.settings.get('locked_muc_nickname') ? nickname_input(o) : '' }

--- a/src/shared/autocomplete/autocomplete.js
+++ b/src/shared/autocomplete/autocomplete.js
@@ -266,6 +266,9 @@ export class AutoComplete {
         }
 
         const list = typeof this._list === "function" ? await this._list() : this._list;
+        if (typeof (list) === 'undefined') {
+            return 0;
+        }
         if (list.length === 0) {
             return;
         }


### PR DESCRIPTION
Resolves: #1841 

So, the issue describes having XMPP muc's fetched from [search.jabber.network](https://search.jabber.network/rooms/1). While implementing the API, I faced an error:- 
```
Access to fetch at '[https://search.jabber.network/api/1.0/rooms' from origin 'http://127.0.0.1:8000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin]
```

Given that it's a problem from jabber.search.network, @jcbrand suggested that we instead add autocomplete using bookmarked group chats.

[Click here to see the working of unjoined bookmarks](https://github.com/conversejs/converse.js/files/8504991/2022-04-18.15-33-13.mp4.zip)

Working after 38b0033f0c342a7ba36e5c90f8e6ef18a315be99:

https://user-images.githubusercontent.com/48093317/164402865-46d567ba-7f3b-4163-b50a-bd6d7d590488.mp4

