### PR TITLE
use jed1.x for po2json

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -39,7 +39,7 @@ module.exports = {
             {
                 loader: 'po-loader',
                 options: {
-                    'format': 'jed',
+                    'format': 'jed1.x',
                     'domain': 'converse'
                 }
             }


### PR DESCRIPTION
I have strange issue when build po.js.
`npm run build` generate following json:

> "Username": [null, "Translated Username"]

It seems same issue:
https://github.com/mikeedwards/po2json/issues/71

Adding the plural_forms header mentioned `translations.rst` didn't help.
The solution is to use the `jed1.x` format instead.
No additional headers are needed for the po file downloaded from weblate.

Before submitting your request, please make sure the following conditions are met:

- [ ] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
