### PR TITLE
Added Fixes For Issue #1850(OpenStreetMap URL parameters discarded)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## 9.1.1 (2022-05-05)
+## 9.1.2 (2022-05-10)
 
+- Added fixes for Issue #1850: 
+  - Added `u.httpToGeoUriWithOriginalString()` method to `src/headless/utils/core.js` file
+  - Changed `u.httpToGeoUri(u.shortnamesToUnicode(text), _converse)` to `u.httpToGeoUriWithOriginalString(u.shortnamesToUnicode(text), _converse)` in `src/headless/plugins/muc/muc.js` file
+  - Added integration test for the above changes in the `src/headless/plugins/muc/tests/muc.js` file(`Original URL is displayed alongside the Geo Coordinates...`)
+
+## 9.1.1 (2022-05-05)
+ 
 - GIFs don't render inside unfurls and cause a TypeError
 - Improve how the `muc_domain` setting is populated via service discovery
 - Remove local (non-requesting) contacts not returned from a full roster response

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -987,7 +987,7 @@ const ChatRoomMixin = {
             [text, references] = this.parseTextForReferences(attrs.body);
         }
         const origin_id = getUniqueId();
-        const body = text ? u.httpToGeoUri(u.shortnamesToUnicode(text), _converse) : undefined;
+        const body = text ? u.httpToGeoUriWithOriginalString(u.shortnamesToUnicode(text), _converse) : undefined;
         attrs = Object.assign({}, attrs, {
             body,
             is_spoiler,

--- a/src/headless/utils/core.js
+++ b/src/headless/utils/core.js
@@ -464,6 +464,14 @@ u.httpToGeoUri = function(text) {
     return text.replace(settings_api.get("geouri_regex"), replacement);
 };
 
+u.httpToGeoUriWithOriginalString = function(text){
+    const replacement = 'geo:$1,$2';
+    if(text.replace(settings_api.get('geouri_regex'), replacement) === text){
+        return text.replace(settings_api.get('geouri_regex'), replacement) 
+    }else{
+        return text.replace(settings_api.get('geouri_regex'), replacement) + '\n' + text;
+    }
+}
 
 /**
  * Clears the specified timeout and interval.


### PR DESCRIPTION
# Description

This fix is regarding Converse.js turning OSM URLS into `geo:` URIs. Previously the entered full URL was removed from the chat message shown on screen, now the `geo:` URI and the full OSM URL are included in the published chat message.

Here is a GIF of the new changes:
![GIF of the new changes](https://user-images.githubusercontent.com/24355366/167976615-370ecaf8-a716-44e1-8764-439535158076.gif)

### Fixes #1850

## Testing
I have ran all tests via the command: `make check`. Also, I added an integration test of my own to the file: ` src/headless/plugins/muc/tests/muc.js` file(`Original URL is displayed alongside the Geo Coordinates...`)

All tests have passed successfully.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Requirements
I can confirm that the following conditions are met prior to submitting this PR:

- [X] Add a changelog entry for your change in `CHANGES.md`
- [X] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [X] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
