### PR TITLE
Fixes for Issue #2857: Text Styling Should Not Be Applied In The Middle Of URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - Remove the `converse-carbons` plugin and make carbons part of the `converse-chat` plugin.
 - Remove the `message_carbons` configuration setting. Carbons are now always enabled.
 
+## 9.1.2 (2022-05-15)
+- Added fixes for Issue #2857. The fix is regarding Converse.js incorrectly applying text styling effects to HTTP URLs that contain special characters(`_`, `\``, `\`\`\``, `~`, `*`). With the fixes applied, the hyperlinks encompass the entire HTTP URL instead of only part of it
+- Added integration test for the fixes above to the following file: `/src/plugins/chatview/tests/chatbox.js/`
+
 ## 9.1.1 (2022-05-05)
 
 - GIFs don't render inside unfurls and cause a TypeError

--- a/src/plugins/chatview/tests/chatbox.js
+++ b/src/plugins/chatview/tests/chatbox.js
@@ -892,6 +892,45 @@ describe("Chatboxes", function () {
                 }));
             });
         });
+
+        describe("Chatbox Message Styling", function() {
+
+            it("is not applied when sending a chat message containing a HTTP URL with styling template characters( _, \`, \`\`\`, ~, *) in the middle of it",
+                mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+
+                await mock.waitForRoster(_converse, 'current');
+                await mock.openControlBox(_converse);
+                const contact_jid = mock.cur_names[0].replace(/ /g,'.').toLowerCase() + '@montague.lit';
+    
+                spyOn(_converse.api, "trigger").and.callThrough();
+                await mock.openChatBoxFor(_converse, contact_jid);
+                const view = _converse.chatboxviews.get(contact_jid);
+                let message = 'https://nitter.kavin.rocks/_MG_/~/*/1506109152665382920';
+                await mock.sendMessage(view, message);
+    
+                expect(view.model.messages.length === 1).toBeTruthy();
+                const stored_messages = await view.model.messages.browserStorage.findAll();
+                expect(view.model.messages.models[0].attributes.message).toEqual(message);
+                expect(view.model.messages.length).toBe(1);
+
+                // try second URL 
+                let message2 = 'https://nitter.george.rocks/_G*_/\`/\`\`\`/665382920';
+                await mock.sendMessage(view, message2);
+    
+                expect(view.model.messages.length === 2).toBeTruthy();
+                expect(view.model.messages.models[1].attributes.message).toEqual(message2);
+                expect(view.model.messages.length).toBe(2);
+
+                // try third URL 
+                let message3 = 'https://nitter.frank.rocks/_OP_/_NP_/\`\`\`/*/~/_qweq_665382920';
+                await mock.sendMessage(view, message3);
+    
+                expect(view.model.messages.length === 3).toBeTruthy();
+                expect(view.model.messages.models[2].attributes.message).toEqual(message3);
+                expect(view.model.messages.length).toBe(3);
+            }));
+
+        });;
     });
 
     describe("Special Messages", function () {
@@ -1052,5 +1091,7 @@ describe("Chatboxes", function () {
             await mock.openChatBoxFor(_converse, sender_jid);
             expect(select_msgs_indicator().textContent).toBe('1');
         }));
+
+ 
     });
 });

--- a/src/shared/rich-text.js
+++ b/src/shared/rich-text.js
@@ -251,6 +251,13 @@ export class RichText extends String {
         references.forEach(ref => this.addTemplateResult(ref.begin, ref.end, ref.template));
     }
 
+    checkIfHttpsUrl (text) {
+        if(text.slice(0, 8) === "https://"){
+            return true;
+        }
+        return false;
+    }
+
     trimMeMessage () {
         if (this.offset === 0) {
             // Subtract `/me ` from 3rd person messages
@@ -300,7 +307,15 @@ export class RichText extends String {
          */
         await api.trigger('beforeMessageBodyTransformed', this, { 'Synchronous': true });
 
-        this.render_styling && this.addStyling();
+        var text = this.toString();
+
+        if(!this.checkIfHttpsUrl(text)){
+            this.render_styling && this.addStyling();
+        }else{
+            this.render_styling;
+        }
+
+        // this.render_styling && this.addStyling();
         this.addAnnotations(this.addMentions);
         this.addAnnotations(this.addHyperlinks);
         this.addAnnotations(this.addMapURLs);
@@ -341,6 +356,8 @@ export class RichText extends String {
     addTemplateResult (begin, end, template) {
         this.references.push({ begin, end, template });
     }
+
+ 
 
     isMeCommand () {
         const text = this.toString();


### PR DESCRIPTION
# Description:

This fix is regarding Converse.js incorrectly applying text styling effects to HTTP URLs that contain special characters( _, \`, \`\`\`, ~, *). 

Previously the hyperlink in the sent chat message would end prematurely due to the special characters contained in the HTTP URL. Now, the hyperlink in the sent chat message encompass the whole HTTP URL regardless of the presence of special characters.

Here is a screenshot of the chat window after applying the fix:
![Image of fix to address incorrect text styling for HTTP URLs](https://user-images.githubusercontent.com/24355366/168490410-9c2796b7-06a2-4a1d-905c-972f4dfc5435.png)



## Fixes #2857

# Testing:

I added a new passing integration test in the following path: `/src/plugins/chatview/tests/chatbox.js` 
Test name: `Chatbox Message Styling > is not applied when sending a chat message containing a HTTP URL with styling template character in the middle of it`

I have run `make check` which resulted in all 507 tests passing.

# Conditions: 
I have ensured that the following conditions are met:

- [X] Add a changelog entry for your change in `CHANGES.md`
- [X] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [X] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
