### PR TITLE
Show nickname in status if fullname is not provided

### DIFF
--- a/src/plugins/profile/templates/profile.js
+++ b/src/plugins/profile/templates/profile.js
@@ -21,7 +21,7 @@ function tpl_user_settings_button (o) {
 
 export default (el) => {
     const chat_status = el.model.get('status') || 'offline';
-    const fullname = el.model.vcard?.get('fullname') || _converse.bare_jid;
+    const fullname = el.model.vcard?.get('fullname') || el.model.vcard?.get('nickname') || _converse.bare_jid;
     const status_message = el.model.get('status_message') || __("I am %1$s", getPrettyStatus(chat_status));
     const i18n_change_status = __('Click to change your chat status');
     const show_settings_button = api.settings.get('show_client_info') || api.settings.get('allow_adhoc_commands');


### PR DESCRIPTION
Currently the logic of what’s show in the status is : 

1. vCard fullname if there is one
2. fall back to JID

This patch adds nickname between the two, so if the user has a vCard nickname but no fullname, it is shown instead of the JID : 

1. vCard fullname if there is one
2. vCard nickname if there is one
3. fall back to JID

