### PR TITLE
fixes #2925

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add a "Add to Contacts" button in MUC occupant modals
+- #2925: Fix missing disco-items in browser storage (after CTRL+F5).
 
 ## 10.0.0 (2022-10-30)
 

--- a/src/headless/plugins/disco/entity.js
+++ b/src/headless/plugins/disco/entity.js
@@ -40,6 +40,13 @@ const DiscoEntity = Model.extend({
         id = `converse.disco-items-${this.get('jid')}`;
         this.items.browserStorage = _converse.createStore(id, 'session');
         await new Promise(f => this.items.fetch({'success': f, 'error': f}));
+        _converse.disco_entities
+            .filter(e => {
+                // XXX: Ignore nodes for now.
+                // See: https://xmpp.org/extensions/xep-0030.html#items-nodes
+                return typeof e.get('name') !== 'undefined';
+            })
+            .forEach(e => this.items.create(e));
 
         this.identities = new Collection();
         id = `converse.identities-${this.get('jid')}`;


### PR DESCRIPTION
fixes #2925

There is the assumption in the Converse disco code that a model can be shared between collections.

In order to avoid to break this assumption, the item collection of `entity.js` is synchronized with the one of utils.js at initialization:

https://github.com/conversejs/converse.js/blob/659a69e7b750656852e69d2fc94f75d167714239/src/headless/plugins/disco/utils.js#L65-L67