### PR TITLE
Re-add ability to convert OSM URLs into geo-uris

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Updated translations
 - #3123: Contacts do not show up online until chat is opened with them.
 - #3156: Add function to prevent drag stutter effect over iframes when resize is called in overlay mode
+- #3161: Re-add ability to convert OpenStreetMap URLs into `geo:` URIs in sent messages and fix issue #1850
 - #3165: Use configured nickname in profile view in the control box
 
 - New config option [stanza_timeout](https://conversejs.org/docs/html/configuration.html#stanza-timeout)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -928,17 +928,17 @@ Accepts a string or array of strings. Any query strings from URLs that match thi
 geouri_regex
 ------------
 
-* Default:  ``/https:\/\/www.openstreetmap.org\/.*#map=[0-9]+\/([\-0-9.]+)\/([\-0-9.]+)\S*/g``
+* Default:  ``/https:\/\/www\.openstreetmap\.org\/\#map=(?<zoom>[0-9]+)\/(?<lat>[\-0-9.]+)\/(?<lon>[\-0-9.]+)/g``
 
 Regular expression used to extract geo coordinates from links to openstreetmap.
 
 geouri_replacement
 ------------------
 
-* Default:  ``'https://www.openstreetmap.org/?mlat=$1&mlon=$2#map=18/$1/$2'``
+* Default:  ``https://www.openstreetmap.org/?mlat=$<lat>&mlon=$<lon>#map=$<zoom>/$<lat>/$<lon>``
 
-String used to replace geo-URIs with. Ought to be a link to osm or similar. ``$1`` and ``$2`` is replaced by
-latitude and longitude respectively.
+String used to replace geo-URIs with. Ought to be a link to osm or similar. ``$<lat>``, ``$<lon>``, and ``$<zoom>`` is replaced by
+latitude, longitude, and zoom level respectively.
 
 hide_muc_participants
 ---------------------

--- a/src/headless/plugins/chat/model.js
+++ b/src/headless/plugins/chat/model.js
@@ -840,7 +840,7 @@ const ChatBox = ModelWithContact.extend({
         const is_spoiler = !!this.get('composing_spoiler');
         const origin_id = u.getUniqueId();
         const text = attrs?.body;
-        const body = text ? u.shortnamesToUnicode(text) : undefined;
+        const body = text ? u.httpToGeoUri(u.shortnamesToUnicode(text), _converse) : undefined;
         attrs = Object.assign({}, attrs, {
             'from': _converse.bare_jid,
             'fullname': _converse.xmppstatus.get('fullname'),

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -1007,7 +1007,7 @@ const ChatRoomMixin = {
             [text, references] = this.parseTextForReferences(attrs.body);
         }
         const origin_id = getUniqueId();
-        const body = text ? u.shortnamesToUnicode(text) : undefined;
+        const body = text ? u.httpToGeoUri(u.shortnamesToUnicode(text), _converse) : undefined;
         attrs = Object.assign({}, attrs, {
             body,
             is_spoiler,

--- a/src/headless/shared/settings/constants.js
+++ b/src/headless/shared/settings/constants.js
@@ -45,8 +45,8 @@ export const DEFAULT_SETTINGS = {
     connection_options: {},
     credentials_url: null, // URL from where login credentials can be fetched
     discover_connection_methods: true,
-    geouri_regex: /https\:\/\/www.openstreetmap.org\/.*#map=[0-9]+\/([\-0-9.]+)\/([\-0-9.]+)\S*/g,
-    geouri_replacement: 'https://www.openstreetmap.org/?mlat=$1&mlon=$2#map=18/$1/$2',
+    geouri_regex: /https:\/\/www\.openstreetmap\.org\/\#map=(?<zoom>[0-9]+)\/(?<lat>[\-0-9.]+)\/(?<lon>[\-0-9.]+)/g,
+    geouri_replacement: 'https://www.openstreetmap.org/?mlat=$<lat>&mlon=$<lon>#map=$<zoom>/$<lat>/$<lon>',
     i18n: undefined,
     jid: undefined,
     keepalive: true,

--- a/src/headless/utils/core.js
+++ b/src/headless/utils/core.js
@@ -485,6 +485,11 @@ export function getUniqueId (suffix) {
     }
 }
 
+u.httpToGeoUri = function(text) {
+    const replacement = 'geo:$<lat>,$<lon>;z=$<zoom>';
+    const geouri_regex = settings_api.get("geouri_regex");
+    return geouri_regex ? text.replace(geouri_regex, replacement) : text;
+};
 
 /**
  * Clears the specified timeout and interval.

--- a/src/shared/rich-text.js
+++ b/src/shared/rich-text.js
@@ -159,7 +159,7 @@ export class RichText extends String {
      *  the start of the message body text.
      */
     addMapURLs (text, offset) {
-        const regex = /geo:([\-0-9.]+),([\-0-9.]+)(?:,([\-0-9.]+))?(?:\?(.*))?/g;
+        const regex = /geo:(?<lat>[\-0-9.]+),(?<lon>[\-0-9.]+)(?:,(?:[\-0-9.]+))?(?:;\w+(?<!\bz)=\w+)*(?:;z=(?<zoom>\d+))?(?:;\w+=\w+)*/g;
         const matches = text.matchAll(regex);
         for (const m of matches) {
             this.addTemplateResult(


### PR DESCRIPTION
I'd like to re-add the possibility to let converse.js convert OSM-URLs to geo-uris. It is now turned off by default though.