### PR TITLE
Fix #3300: Adding the maxWait option for `debouncedPruneHistory`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - #2716: Fix issue with chat display when opening via URL
 - #3033: Add the `muc_grouped_by_domain` option to display MUCs on the same domain in collapsible groups
 - Add an occupants filter to the MUC sidebar
+- #3300: Adding the maxWait option for `debouncedPruneHistory`
 
 ### Breaking changes:
 

--- a/src/headless/shared/chat/utils.js
+++ b/src/headless/shared/chat/utils.js
@@ -108,4 +108,6 @@ export async function handleCorrection (model, attrs) {
 }
 
 
-export const debouncedPruneHistory = debounce(pruneHistory, 500);
+export const debouncedPruneHistory = debounce(pruneHistory, 500, {
+    maxWait: 2000
+});


### PR DESCRIPTION
Adding `maxWait: 2000` to force history pruning after 2 seconds max.