### PR TITLE
Fix: MUC occupant list does not sort itself on nicknames or roles changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - #2716: Fix issue with chat display when opening via URL
 - #3033: Add the `muc_grouped_by_domain` option to display MUCs on the same domain in collapsible groups
 - Add an occupants filter to the MUC sidebar
+- Fix: MUC occupant list does not sort itself on nicknames or roles changes
 
 ### Breaking changes:
 

--- a/src/headless/plugins/muc/occupants.js
+++ b/src/headless/plugins/muc/occupants.js
@@ -21,6 +21,11 @@ const { u } = converse.env;
 class ChatRoomOccupants extends Collection {
     model = ChatRoomOccupant;
 
+    initialize() {
+        this.on('change:nick', () => this.sort());
+        this.on('change:role', () => this.sort());
+    }
+
     comparator (occupant1, occupant2) { // eslint-disable-line class-methods-use-this
         const role1 = occupant1.get('role') || 'none';
         const role2 = occupant2.get('role') || 'none';


### PR DESCRIPTION
This fix was discussed with @jcbrand  on the ConverseJS chat room.
The Collection object does not sort itself on item changes.
So we manually add a call to sort when nickname or role of a MUC participant change.