### PR TITLE
Fix #3307: Fix inconsistency between browsers on textarea outlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - #2716: Fix issue with chat display when opening via URL
 - #3033: Add the `muc_grouped_by_domain` option to display MUCs on the same domain in collapsible groups
 - Add an occupants filter to the MUC sidebar
+- #3307: Fix inconsistency between browsers on textarea outlines
 
 ### Breaking changes:
 

--- a/src/plugins/chatview/styles/chat-bottom-panel.scss
+++ b/src/plugins/chatview/styles/chat-bottom-panel.scss
@@ -40,8 +40,9 @@
                 }
 
                 .chat-textarea, input {
+                    outline: 1px solid var(--chat-head-color);
                     &:active, &:focus{
-                        outline-color: var(--chat-head-color);
+                        outline-width: 2px;
                     }
                     &.correcting {
                         background-color: var(--chat-correcting-color);

--- a/src/plugins/muc-views/styles/muc-bottom-panel.scss
+++ b/src/plugins/muc-views/styles/muc-bottom-panel.scss
@@ -31,8 +31,9 @@
                     bottom: 4.5em;
                 }
                 .chat-textarea, input {
+                    outline: 1px solid var(--chatroom-head-bg-color) !important;
                     &:active, &:focus{
-                        outline-color: var(--chatroom-head-bg-color) !important;
+                        outline-width: 2px !important;
                     }
                     &.correcting {
                         background-color: var(--chatroom-correcting-color);


### PR DESCRIPTION



- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
