### PR TITLE
Fix: room information not correctly refreshed when modifications are made by other users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Add an occupants filter to the MUC sidebar
 - Fix: MUC occupant list does not sort itself on nicknames or roles changes
 - Fix: refresh the MUC sidebar when participants collection is sorted
+- Fix: room information not correctly refreshed when modifications are made by other users
 
 ### Breaking changes:
 

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -1829,7 +1829,7 @@ class MUC extends ChatBox {
         // 173: room now semi-anonymous
         // 174: room now fully anonymous
         const codes = ['104', '170', '171', '172', '173', '174'];
-        if (sizzle('status', stanza).filter(e => codes.includes(e.getAttribute('status'))).length) {
+        if (sizzle('status', stanza).filter(e => codes.includes(e.getAttribute('code'))).length) {
             this.refreshDiscoInfo();
         }
     }


### PR DESCRIPTION
MUC informations are not correctly refreshed when another user/browser make changes.

This PR fix this bug.

To test:

> Open the same MUC room in 2 browers (with 2 accounts if possible, one moderator, the other not).
> Open/modify/save the room config form (change the title for example).
> Then, on the second browser, there is the notification for changes, but info are not refreshed. If you open the "room detail popup", old title still applies.

The bug was here:

```javascript
const codes = ['104', '170', '171', '172', '173', '174'];
if (sizzle('status', stanza).filter(e => codes.includes(e.getAttribute('status'))).length) {
```

The correct attribute to read is `code`, not `status`: https://xmpp.org/extensions/xep-0045.html#roomconfig-notify
