### PR TITLE
Fix missing import when trying to display into modal popin an uploaded image.

### DIFF
--- a/src/shared/chat/message-body.js
+++ b/src/shared/chat/message-body.js
@@ -1,4 +1,5 @@
 import 'shared/registry.js';
+import 'shared/modals/image.js';
 import renderRichText from 'shared/directives/rich-text.js';
 import { CustomElement } from 'shared/components/element.js';
 import { api } from "@converse/headless";


### PR DESCRIPTION
If this import is not indicated, the component is not registered.
So when it is called directly by the modal API's show method, the component is not found.