### PR TITLE
Fix custom emoji category documentation:

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -846,15 +846,16 @@ settings, it's not possible to add new emoji categories. There is however a
 "stickers").
 
 Please note that the ``custom`` category is disabled by default, as it does not
-rely on a standard for now, and will only work for users that are using the same
-Converse.
-If you want to enable the ``custom`` category, please use ``:converse:`` as
-value.
+rely on a standard for now, and will only work for users that are using versions
+of Converse that support it.
 
-To add custom emojis, you need to edit ``src/headless/emojis.json`` to add new
-entries to the map under the  ``custom`` key.
+To enable the ``custom`` category, set it to one of the keys under the
+``custom`` section in ``src/headless/plugins/emoji/emojis.json`` (for example
+``:converse:``). You can also add new entries there, to create more custom
+emojis.
 
-You can also listen for the ``loadEmojis`` hook, that allows you to modify emojis.json at runtime.
+You can also listen for the ``loadEmojis`` hook, that allows you to modify
+``emojis.json`` at runtime.
 
 emoji_categories_label
 ----------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -847,7 +847,7 @@ settings, it's not possible to add new emoji categories. There is however a
 
 Please note that the ``custom`` category is disabled by default, as it does not
 rely on a standard for now, and will only work for users that are using the same
-ConverseJS.
+Converse.
 If you want to enable the ``custom`` category, please use ``:converse:`` as
 value.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -827,7 +827,7 @@ emoji_categories
       "food": ":hotdog:",
       "symbols": ":musical_note:",
       "flags": ":flag_ac:",
-      "custom": ":converse:"
+      "custom": null
     }
 
 
@@ -844,6 +844,12 @@ Due to restrictions intended to prevent addition of undeclared configuration
 settings, it's not possible to add new emoji categories. There is however a
 ``custom`` category where you can put your own custom emojis (also known as
 "stickers").
+
+Please note that the ``custom`` category is disabled by default, as it does not
+rely on a standard for now, and will only work for users that are using the same
+ConverseJS.
+If you want to enable the ``custom`` category, please use ``:converse:`` as
+value.
 
 To add custom emojis, you need to edit ``src/headless/emojis.json`` to add new
 entries to the map under the  ``custom`` key.


### PR DESCRIPTION
* custom default value is null.
* adding text to explain why custom category is disabled by default, and how to enable it.
