### PR TITLE
Fix custom emojis path when assets_path is not the default path.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Change contacts filter to rename the anachronistic `Online` state to `Available`.
 - Enable [reuse_scram_keys](https://conversejs.org/docs/html/configuration.html#reuse-scram-keys) by default.
 - New loadEmojis hook, to customize emojis at runtime.
+- Fix custom emojis path when assets_path is not the default path.
 
 ### Breaking changes:
 

--- a/src/headless/plugins/emoji/plugin.js
+++ b/src/headless/plugins/emoji/plugin.js
@@ -15,6 +15,27 @@ converse.emojis = {
     'initialized_promise': getOpenPromise(),
 };
 
+/**
+ * The emoji.json file uses path starting with '/dist' for custom emojis.
+ * But if the assets_path settings is not the default one, these paths are wrong.
+ * This functions fixes this.
+ * @param json
+ */
+function fixCustomEmojisPath (json) {
+    let path = api.settings.get('assets_path')
+    if (path[path.length - 1] !== '/') { path = path + '/' }
+    if (path === '/dist/') {
+        return;
+    }
+    if (!('custom' in json) || (typeof json.custom !== 'object')) {
+        return;
+    }
+    for (const e of Object.values(json.custom)) {
+        if (typeof e.url !== 'string') { continue; }
+        e.url = e.url.replace(/^\/dist\//, path);
+    }
+}
+
 converse.plugins.add('converse-emoji', {
     initialize () {
         /* The initialize function gets called as soon as the plugin is
@@ -99,6 +120,7 @@ converse.plugins.add('converse-emoji', {
                          *  });
                          */
                         const json = await api.hook('loadEmojis', {}, module.default);
+                        fixCustomEmojisPath(json);
                         converse.emojis.json = json;
 
                         


### PR DESCRIPTION
Custom emojis are broken when the assets_path is not the default one.
Here is a fix. Could be done otherwise, just tell me if this is ok for you.