### PR TITLE
bugfixing: image modal dialog cannot be opened second time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 11.0.0 (Unreleased)
 
+- Fix: image modal dialog cannot be opened the second time because the dialog is left in undefined, not initial state
 - #1174: Show MUC avatars in the rooms list
 - #1195: Add actions to quote and copy messages
 - #1349: XEP-0392 Consistent Color Generation

--- a/src/shared/chat/message-body.js
+++ b/src/shared/chat/message-body.js
@@ -37,6 +37,7 @@ export default class MessageBody extends CustomElement {
 
     onImgClick (ev) { // eslint-disable-line class-methods-use-this
         ev.preventDefault();
+        api.modal.remove('converse-image-modal');
         api.modal.show('converse-image-modal', {'src': ev.target.src}, ev);
     }
 


### PR DESCRIPTION
Bugfixing: Image modal dialog is opened only once. Next time user clicks image modal dialog is not shown

I did not update unit test for the fix verification because unit test to check showing image in modal dialog does not exist. I tested the fix manually

https://github.com/conversejs/converse.js/assets/2598832/b6e60846-60c7-44f0-b36b-fbf0e885c81c

 

Before submitting your request, please make sure the following conditions are met:

- [ x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
