### PR TITLE
cumulative bugfix regarding the following issues: unhandled exception and incorrect unread message counter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 11.0.0 (Unreleased)
 
+- Fix: unhandled exception on new message arriving when user has not permitted playing audio in the browser
+- Fix: incorrect unread messages counter badge on the application icon after switching to new XMPP user
 - #1174: Show MUC avatars in the rooms list
 - #1195: Add actions to quote and copy messages
 - #1349: XEP-0392 Consistent Color Generation

--- a/src/plugins/notifications/utils.js
+++ b/src/plugins/notifications/utils.js
@@ -34,7 +34,7 @@ export function areDesktopNotificationsEnabled () {
  */
 
 export function clearFavicon () {
-    favicon = null;
+    favicon?.badge(0);
     /** @type navigator */(navigator).clearAppBadge?.()
         .catch(e => log.error("Could not clear unread count in app badge " + e));
 }
@@ -302,7 +302,10 @@ export async function handleMessageNotification (data) {
      * @example _converse.api.listen.on('messageNotification', data => { ... });
      */
     api.trigger('messageNotification', data);
-    playSoundNotification();
+    try{
+        // protection from exception: "play() failed because the user didn't interact with the document first" https://goo.gl/xX8pDD"
+        playSoundNotification();
+    } catch (error) {}
     showMessageNotification(data);
 }
 


### PR DESCRIPTION
1. unhandled exception on new message arriving when user has not permitted playing audio in the browser 
2. incorrect unread messages counter badge on the application icon after switching to new XMPP user

Thanks for making a pull request to converse.js!

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
