### PR TITLE
Fix: MUC config form fails when no image avatar field.

### DIFF
--- a/src/headless/plugins/muc/constants.js
+++ b/src/headless/plugins/muc/constants.js
@@ -62,6 +62,7 @@ export const ROOM_FEATURES = [
     'moderated',
     'unmoderated',
     'mam_enabled',
+    'vcard-temp'
 ];
 
 export const MUC_NICK_CHANGED_CODE = '303';

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -2800,7 +2800,7 @@ class MUC extends ChatBox {
                 // Accept default configuration
                 await this.sendConfiguration().then(() => this.refreshDiscoInfo());
             } else {
-                this.session.save({ 'view': converse.MUC.VIEWS.CONFIG });
+                api.modal.show('converse-muc-config-modal', { model: this });
             }
         }
     }

--- a/src/plugins/muc-views/modals/config.js
+++ b/src/plugins/muc-views/modals/config.js
@@ -49,7 +49,7 @@ export default class MUCConfigModal extends BaseModal {
         const form_data = new FormData(/** @type {HTMLFormElement} */ (ev.target));
         const image_file = /** @type {File} */ (form_data.get('avatar_image'));
 
-        if (image_file.size) {
+        if (image_file?.size) {
             const image_data = isImageWithAlphaChannel ? image_file : await compressImage(image_file);
             const reader = new FileReader();
             reader.onloadend = async () => {

--- a/src/plugins/muc-views/modals/config.js
+++ b/src/plugins/muc-views/modals/config.js
@@ -46,6 +46,9 @@ export default class MUCConfigModal extends BaseModal {
      * @param {SubmitEvent} ev
      */
     async setAvatar (ev) {
+        if (!this.model.features.get('vcard-temp')) {
+            return;
+        }
         const form_data = new FormData(/** @type {HTMLFormElement} */ (ev.target));
         const image_file = /** @type {File} */ (form_data.get('avatar_image'));
 

--- a/src/plugins/muc-views/modals/templates/muc-config.js
+++ b/src/plugins/muc-views/modals/templates/muc-config.js
@@ -1,3 +1,4 @@
+import 'shared/components/image-picker.js';
 import tplSpinner from 'templates/spinner.js';
 import { __ } from 'i18n';
 import { api, converse, parsers } from '@converse/headless';

--- a/src/plugins/muc-views/modals/templates/muc-config.js
+++ b/src/plugins/muc-views/modals/templates/muc-config.js
@@ -44,7 +44,7 @@ export default (el) => {
                 <legend class="centered">${title}</legend>
                 ${title !== instructions ? html`<p class="form-help">${instructions}</p>` : ''}
 
-                ${fieldTemplates.length ? html`<div class="row">
+                ${fieldTemplates.length && el.model.features.get('vcard-temp') ? html`<div class="row">
                     <converse-image-picker .model=${el.model} width="96" height="96"></converse-image-picker>
                 </div>` : ''}
 

--- a/src/plugins/profile/modals/profile.js
+++ b/src/plugins/profile/modals/profile.js
@@ -71,7 +71,7 @@ export default class ProfileModal extends BaseModal {
             url: form_data.get('url'),
         });
 
-        if (image_file.size) {
+        if (image_file?.size) {
             const image_data = isImageWithAlphaChannel ? image_file : await compressImage(image_file);
             const reader = new FileReader();
             reader.onloadend = async () => {

--- a/src/shared/tests/mock.js
+++ b/src/shared/tests/mock.js
@@ -702,7 +702,7 @@ async function _initConverse (settings) {
         discover_connection_methods: false,
         enable_smacks: false,
         i18n: 'en',
-        loglevel: window.location.pathname === 'debug.html' ? 'debug' : 'error',
+        loglevel: window.location.pathname === '/debug.html' ? 'debug' : 'error',
         no_trimming: true,
         persistent_store: 'localStorage',
         play_sounds: false,


### PR DESCRIPTION
When the MUC component offers no avatar field, the MUC room config save fails.
This PR fixes it.
