### PR TITLE
Fix regression for MUC message avatars.

### DIFF
--- a/src/shared/chat/templates/message.js
+++ b/src/shared/chat/templates/message.js
@@ -20,6 +20,10 @@ export default (el, o) => {
     const contact = el.model.occupant || el.model.contact;
     const author_style = getAuthorStyle(contact);
 
+    // The model to use for the avatar.
+    // Note: it can happen that the contact has not the vcard attribute but the message has.
+    const avatar_model = contact?.vcard ? contact : el.model
+
     return html`
         ${ o.is_first_unread ? html`<div class="message separator">
             <hr class="separator">
@@ -37,10 +41,10 @@ export default (el, o) => {
             ${ (o.should_show_avatar && !is_followup) ?
                 html`<a class="show-msg-author-modal" @click=${el.showUserModal}>
                     <converse-avatar
-                        .model=${contact || el.model}
+                        .model=${avatar_model}
                         class="avatar align-self-center"
                         name="${el.model.getDisplayName()}"
-                        nonce="${el.model.vcard?.get('vcard_updated')}"
+                        nonce="${avatar_model.vcard?.get('vcard_updated')}"
                         height="40" width="40"></converse-avatar>
                 </a>` : '' }
 


### PR DESCRIPTION
There is a regression in some rare case (comes with the new colorized avatars).

If for some reason we haven't loaded all occupants vcards, the code will load avatars, but not display them next to messages.
This PR fixes it: if the vcard is not on the contact model, we fallback to the message (as before, but code wasn't checking if the vcard is on the contact).


Note: this bug is visible in my project, were i have an optimization: i do not load all occupants vcards on join, if the occupant list is hidden (for performance reason). So, without this fix, message won't show the avatar, because `contact.vcard` is not set (we haven't called setVCardOnOccupant), but `message.vcard` is (thanks to setVCardOnMUCMessage).