### PR TITLE
Fix missing test case on dangling_moderation

### DIFF
--- a/src/shared/chat/message-history.js
+++ b/src/shared/chat/message-history.js
@@ -32,7 +32,7 @@ export default class MessageHistory extends CustomElement {
     }
 
     renderMessage (model) {
-        if (model.get('dangling_retraction') || model.get('is_only_key')) {
+        if (model.get('dangling_retraction') || model.get('dangling_moderation') ||  model.get('is_only_key')) {
             return '';
         }
         const template_hook = model.get('template_hook')


### PR DESCRIPTION
Seems this test was missing.

The bug was not visible in Converse v10.1.6 for an unknown reason. But it is with the current Converse master branch.