### PR TITLE
Fix: missing localization for "A moderator" label.

### DIFF
--- a/src/i18n/converse.pot
+++ b/src/i18n/converse.pot
@@ -1134,6 +1134,10 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
+#: dist/converse-no-dependencies.js:75630
+msgid "A moderator"
+msgstr ""
+
 #: dist/converse-no-dependencies.js:84900
 #: dist/converse-no-dependencies.js:84902
 #, javascript-format

--- a/src/shared/chat/message.js
+++ b/src/shared/chat/message.js
@@ -203,7 +203,7 @@ export default class Message extends CustomElement {
                     chatbox.occupants.findOccupant({'jid': retracted_by_mod}) ||
                     chatbox.occupants.findOccupant({'nick': Strophe.getResourceFromJid(retracted_by_mod)});
             }
-            const modname = this.model.mod ? this.model.mod.getDisplayName() : 'A moderator';
+            const modname = this.model.mod ? this.model.mod.getDisplayName() : __('A moderator');
             return __('%1$s has removed this message', modname);
         } else {
             return __('%1$s has removed this message', this.model.getDisplayName());


### PR DESCRIPTION
There was a label that was not localized: when a message is moderated, but there is no actor (which is allowed by XEP-0245), the label "A moderator" was hardcoded.
