### PR TITLE
Fix typo: occupant filter is buggy in MUC with less than 5 occupants.

### DIFF
--- a/src/plugins/muc-views/templates/muc-sidebar.js
+++ b/src/plugins/muc-views/templates/muc-sidebar.js
@@ -50,7 +50,7 @@ export default (el, o) => {
     const is_filter_visible = el.model.get('filter_visible');
 
     const btns = /** @type {TemplateResult[]} */ [];
-    if (el.model.occupants < 6) {
+    if (el.model.occupants?.length < 6) {
         // We don't show the filter
         btns.push(
             html` <i class="hide-occupants" @click=${(/** @type {MouseEvent} */ev) => el.closeSidebar(ev)}>


### PR DESCRIPTION
There was a typo. When less than 5 MUC occupants, the filter action should be removed, but it was not the case.
This was resulting in an empty filter element (see screenshot).

![image](https://github.com/user-attachments/assets/4db1b0b0-305d-4670-aa25-48294b59f072)

Note: perhaps we should always show the filter for MUCs? I'm aware that it is not very usefull when only few participants, but it would make the code simpler.
Currently, the 5 occupant limit is hard coded in several places. Could cause some troubles in the future.