### PR TITLE
Fix: removing the "add to contact" button in occupant modal in singleton mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - New loadEmojis hook, to customize emojis at runtime.
 - New `loadEmojis` hook, to customize emojis at runtime.
 - Upgrade to Bootstrap 5
+- Fix: removing the "add to contact" button in occupant modal in singleton mode (as there is no roster).
 
 ### Breaking changes:
 

--- a/src/plugins/muc-views/modals/templates/occupant.js
+++ b/src/plugins/muc-views/modals/templates/occupant.js
@@ -28,9 +28,11 @@ export default (el) => {
     const bare_jid = _converse.session.get('bare_jid');
     const not_me =  jid != bare_jid;
 
-    const add_to_contacts = api.contacts.get(jid)
-        .then(contact => !contact && not_me && can_see_real_jids)
-        .then(add => add ? html`<li><button class="btn btn-primary" type="button" @click=${() => el.addToContacts()}>${i18n_add_to_contacts}</button></li>` : '');
+    const add_to_contacts = api.settings.get('singleton')
+        ? '' // in singleton mode, there is no roster, so adding to contact makes no sense.
+        : api.contacts.get(jid)
+            .then(contact => !contact && not_me && can_see_real_jids)
+            .then(add => add ? html`<li><button class="btn btn-primary" type="button" @click=${() => el.addToContacts()}>${i18n_add_to_contacts}</button></li>` : '');
 
     return html`
         <div class="row">


### PR DESCRIPTION
There is no roster in singleton mode, so I think the "add to contact" button make no sense.
