### PR TITLE
Fix message dropdown menu placement

### DIFF
--- a/src/shared/chat/message-actions.js
+++ b/src/shared/chat/message-actions.js
@@ -72,13 +72,8 @@ class MessageActions extends CustomElement {
         const buttons = await this.getActionButtons();
         const items = buttons.map(b => MessageActions.getActionsDropdownItem(b));
         if (items.length) {
-            // We want to let the message actions menu drop upwards if we're at the
-            // bottom of the message history, and down otherwise. This is to avoid
-            // the menu disappearing behind the bottom panel (toolbar, textarea etc).
-            // That's difficult to know from state, so we're making an approximation here.
-            const should_drop_up = this.model.collection.length > 3 && this.model === this.model.collection.last();
             return html`<converse-dropdown
-                class="chat-msg__actions btn-group ${should_drop_up ? 'dropup dropup--left' : 'dropstart'}"
+                class="chat-msg__actions btn-group dropstart"
                 .items=${items}
             ></converse-dropdown>`;
         } else {


### PR DESCRIPTION
The renderActions method on messages was trying to guess if the message was the last one, to change the placement of the dropdown menu. It seems that this is no more needed (maybe thanks to the bootstrap v5 upgrade).
This commit removes this code, to always use "dropstart" class.

Note: this should complete @BetaRays PR: https://github.com/conversejs/converse.js/pull/3336

@BetaRays , could you test on your setup, and confirm that it is okay?