### PR TITLE
New "getOccupantActionButtons" hook, so that plugins can add actions on MUC occupants.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Upgrade to Bootstrap 5
 - Add a new theme 'Cyberpunk' and remove the old 'Concord' theme.
 - Improved accessibility.
+- New "getOccupantActionButtons" hook, so that plugins can add actions on MUC occupants.
 
 ### Breaking changes:
 

--- a/src/plugins/muc-views/sidebar.js
+++ b/src/plugins/muc-views/sidebar.js
@@ -55,7 +55,7 @@ export default class MUCSidebar extends CustomElement {
         const tpl = tplMUCSidebar(this, Object.assign(
             this.model.toJSON(), {
                 'occupants': [...this.model.occupants.models],
-                'onOccupantClicked': ev => this.onOccupantClicked(ev),
+                'onOccupantClicked': ev => this.onOccupantClicked(ev)
             }
         ));
         return tpl;

--- a/src/plugins/muc-views/styles/muc-occupants.scss
+++ b/src/plugins/muc-views/styles/muc-occupants.scss
@@ -108,14 +108,17 @@
 
                             .occupant-nick-badge {
                                 display: flex;
-                                justify-content: space-between;
+                                justify-content: flex-start;
                                 flex-wrap: wrap;
+                                align-items: center;
 
                                 .occupant-badges {
                                     display: flex;
                                     justify-content: flex-end;
                                     flex-wrap: wrap;
                                     flex-direction: row;
+
+                                    margin-left: auto; // this tricks align the item to the right.
 
                                     span {
                                         height: 1.6em;

--- a/src/plugins/muc-views/styles/muc-occupants.scss
+++ b/src/plugins/muc-views/styles/muc-occupants.scss
@@ -108,22 +108,32 @@
 
                             .occupant-nick-badge {
                                 display: flex;
-                                justify-content: flex-start;
-                                flex-wrap: wrap;
+                                justify-content: space-between;
+                                flex-wrap: nowrap;
                                 align-items: center;
+                                gap: 0.25rem;
+
+                                .occupant-nick {
+                                    flex-grow: 2;
+                                }
 
                                 .occupant-badges {
                                     display: flex;
                                     justify-content: flex-end;
                                     flex-wrap: wrap;
                                     flex-direction: row;
-
-                                    margin-left: auto; // this tricks align the item to the right.
+                                    flex-shrink: 1;
+                                    gap: 0.25rem;
 
                                     span {
                                         height: 1.6em;
-                                        margin-right: 0.25rem;
                                     }
+                                }
+
+                                .occupant-actions {
+                                    // We must specify the position, else there is a bug:
+                                    // clicking on an action would close the dropdown without triggering the action.
+                                    position: static;
                                 }
                             }
 

--- a/src/plugins/muc-views/templates/occupant.js
+++ b/src/plugins/muc-views/templates/occupant.js
@@ -1,9 +1,11 @@
 /**
  * @typedef {import('@converse/headless').MUCOccupant} MUCOccupant
  */
+import { api } from '@converse/headless';
 import { PRETTY_CHAT_STATUS } from '../constants.js';
 import { __ } from 'i18n';
 import { html } from "lit";
+import { until } from 'lit/directives/until.js';
 import { showOccupantModal } from '../utils.js';
 import { getAuthorStyle } from 'utils/color.js';
 
@@ -29,6 +31,33 @@ const occupant_title = /** @param {MUCOccupant} o */(o) => {
     }
 }
 
+/**
+ * @param {MUCOccupant} o
+ */
+async function tplActionButtons (o) {
+    const buttons = await api.hook('getOccupantActionButtons', o, []);
+    if (!buttons?.length) { return '' }
+
+    const items = buttons.map(b => {
+        return html`
+        <button class="dropdown-item ${b.button_class}" @click=${b.handler}>
+            <converse-icon
+                class="${b.icon_class}"
+                color="var(--inverse-link-color)"
+                size="1em"
+            ></converse-icon>&nbsp;${b.i18n_text}
+        </button>`
+    });
+
+    if (!items.length) {
+        return ''
+    }
+
+    return html`<converse-dropdown
+        class="btn btn--transparent btn--standalone dropdown-toggle dropdown-toggle--no-caret"
+        .items=${items}
+    ></converse-dropdown>`;
+}
 
 /**
  * @param {MUCOccupant} o
@@ -80,6 +109,9 @@ export default (o, chat) => {
                           title="${occupant_title(o)}"
                           @click=${chat.onOccupantClicked}
                           style="${getAuthorStyle(o)}">${o.getDisplayName()}</span>
+                    ${
+                        until(tplActionButtons(o))
+                    }
                     <span class="occupant-badges">
                         ${ (affiliation === "owner") ? html`<span class="badge badge-groupchat">${i18n_owner}</span>` : '' }
                         ${ (affiliation === "admin") ? html`<span class="badge badge-info">${i18n_admin}</span>` : '' }

--- a/src/plugins/muc-views/templates/occupant.js
+++ b/src/plugins/muc-views/templates/occupant.js
@@ -35,6 +35,21 @@ const occupant_title = /** @param {MUCOccupant} o */(o) => {
  * @param {MUCOccupant} o
  */
 async function tplActionButtons (o) {
+    /**
+     * *Hook* which allows plugins to add action buttons on occupants
+     * @event _converse#getOccupantActionButtons
+     * @example
+     *  api.listen.on('getOccupantActionButtons', (el, buttons) => {
+     *      buttons.push({
+     *          'i18n_text': 'Foo',
+     *          'handler': ev => alert('Foo!'),
+     *          'button_class': 'chat-occupant__action-foo',
+     *          'icon_class': 'fa fa-check',
+     *          'name': 'foo'
+     *      });
+     *      return buttons;
+     *  });
+     */
     const buttons = await api.hook('getOccupantActionButtons', o, []);
     if (!buttons?.length) { return '' }
 
@@ -48,10 +63,6 @@ async function tplActionButtons (o) {
             ></converse-icon>&nbsp;${b.i18n_text}
         </button>`
     });
-
-    if (!items.length) {
-        return ''
-    }
 
     return html`<converse-dropdown
         class="occupant-actions chatbox-btn"

--- a/src/plugins/muc-views/templates/occupant.js
+++ b/src/plugins/muc-views/templates/occupant.js
@@ -54,7 +54,7 @@ async function tplActionButtons (o) {
     }
 
     return html`<converse-dropdown
-        class="btn btn--transparent btn--standalone dropdown-toggle dropdown-toggle--no-caret"
+        class="occupant-actions chatbox-btn"
         .items=${items}
     ></converse-dropdown>`;
 }
@@ -109,9 +109,6 @@ export default (o, chat) => {
                           title="${occupant_title(o)}"
                           @click=${chat.onOccupantClicked}
                           style="${getAuthorStyle(o)}">${o.getDisplayName()}</span>
-                    ${
-                        until(tplActionButtons(o))
-                    }
                     <span class="occupant-badges">
                         ${ (affiliation === "owner") ? html`<span class="badge badge-groupchat">${i18n_owner}</span>` : '' }
                         ${ (affiliation === "admin") ? html`<span class="badge badge-info">${i18n_admin}</span>` : '' }
@@ -119,6 +116,9 @@ export default (o, chat) => {
                         ${ (role === "moderator") ? html`<span class="badge badge-info">${i18n_moderator}</span>` : '' }
                         ${ (role === "visitor") ? html`<span class="badge badge-secondary">${i18n_visitor}</span>`  : '' }
                     </span>
+                    ${
+                        until(tplActionButtons(o))
+                    }
                 </div>
             </div>
         </li>

--- a/src/plugins/muc-views/templates/occupant.js
+++ b/src/plugins/muc-views/templates/occupant.js
@@ -55,11 +55,12 @@ async function tplActionButtons (o) {
 
     const items = buttons.map(b => {
         return html`
-        <button class="dropdown-item ${b.button_class}" @click=${b.handler}>
+        <button class="dropdown-item ${b.button_class}" @click=${b.handler} type="button">
             <converse-icon
                 class="${b.icon_class}"
                 color="var(--inverse-link-color)"
                 size="1em"
+                aria-hidden="true"
             ></converse-icon>&nbsp;${b.i18n_text}
         </button>`
     });


### PR DESCRIPTION
Here is a new hook, so that plugins can add an action menu on occupant list.

For example, i have plugins adding following entries:


![image](https://github.com/user-attachments/assets/70739009-3771-44ab-97b7-31c208e82268)


By default, there is no action, so no dropdown.

@jcbrand , i know that you prefer have actions in the occupant modal. But in my case, I prefer having them here.
In the future, we could use the same hook for actions in the occupant modal.

And if an action should only be shown in the modal (or only in the occupant list), we could add some attributes to the buttons, so that we can filter them.

Let me know if this PR is ok for you. (no hurry, it can wait if you don't have the time for now).