### PR TITLE
Accessibility improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - New `loadEmojis` hook, to customize emojis at runtime.
 - Upgrade to Bootstrap 5
 - Add a new theme 'Cyberpunk' and remove the old 'Concord' theme.
+- Improved accessibility.
 
 ### Breaking changes:
 

--- a/src/plugins/bookmark-views/components/templates/item.js
+++ b/src/plugins/bookmark-views/components/templates/item.js
@@ -13,6 +13,7 @@ export default (bm) => {
                 @click=${openRoomViaEvent}>${bm.getDisplayName()}</a>
 
             <a class="list-item-action remove-bookmark align-self-center ${ bm.get('bookmarked') ? 'button-on' : '' }"
+                tabindex="0"
                 data-room-jid="${jid}"
                 data-bookmark-name="${bm.getDisplayName()}"
                 title="${info_remove_bookmark}"

--- a/src/plugins/chatview/templates/chat-head.js
+++ b/src/plugins/chatview/templates/chat-head.js
@@ -22,7 +22,7 @@ export default (o) => {
             <div class="chatbox-title--row">
                 ${ (!_converse.api.settings.get("singleton")) ?  html`<converse-controlbox-navback jid="${o.jid}"></converse-controlbox-navback>` : '' }
                 ${ (o.type !== HEADLINES_TYPE) ? html`<a class="show-msg-author-modal" @click=${o.showUserDetailsModal}>${ avatar }</a>` : '' }
-                <div class="chatbox-title__text" title="${o.jid}">
+                <div class="chatbox-title__text" title="${o.jid}" role="heading" aria-level="2">
                     ${ (o.type !== HEADLINES_TYPE) ? html`<a class="user show-msg-author-modal" @click=${o.showUserDetailsModal}>${ display_name }</a>` : display_name }
                 </div>
             </div>

--- a/src/plugins/headlines-view/templates/feeds-list.js
+++ b/src/plugins/headlines-view/templates/feeds-list.js
@@ -24,7 +24,9 @@ export default (el) => {
     return html`
         <div class="controlbox-section" id="headline">
             <div class="d-flex controlbox-padded ${ feeds.length ? '' : 'hidden' }">
-                <span class="w-100 controlbox-heading controlbox-heading--headline">${heading_headline}</span>
+                <span class="w-100 controlbox-heading controlbox-heading--headline"
+                    role="heading" aria-level="3"
+                >${heading_headline}</span>
             </div>
         </div>
         <div class="list-container list-container--headline ${ feeds.length ? '' : 'hidden' }">

--- a/src/plugins/muc-views/templates/muc-head.js
+++ b/src/plugins/muc-views/templates/muc-head.js
@@ -34,6 +34,7 @@ export default (el) => {
                 ${ (!_converse.api.settings.get("singleton")) ?
                         html`<converse-controlbox-navback jid="${o.jid}"></converse-controlbox-navback>` : '' }
                 <div class="chatbox-title__text"
+                     role="heading" aria-level="2"
                      title="${ (api.settings.get('locked_muc_domain') !== 'hidden') ? o.jid : '' }">
                     ${ el.model.getDisplayName() }
                     ${ (o.bookmarked) ?

--- a/src/plugins/muc-views/templates/muc-password-form.js
+++ b/src/plugins/muc-views/templates/muc-password-form.js
@@ -11,7 +11,8 @@ export default (o) => {
             <fieldset>
                 <label class="form-label">${i18n_heading}</label>
                 <p class="validation-message">${o.validation_message}</p>
-                <input class="hidden-username" type="text" autocomplete="username" value="${o.jid}"></input>
+                <input class="hidden-username" aria-hidden="true" type="text"
+                    autocomplete="username" value="${o.jid}"></input>
                 <input type="password"
                     name="password"
                     required="required"

--- a/src/plugins/muc-views/templates/muc-sidebar.js
+++ b/src/plugins/muc-views/templates/muc-sidebar.js
@@ -57,6 +57,7 @@ export default (el, o) => {
         btns.push(html`
             <a href="#"
                class="dropdown-item open-invite-modal"
+               role="button"
                title="${i18n_invite_title}"
                @click=${(/** @type {MouseEvent} */ev) => el.showInviteModal(ev)}>
                 <converse-icon size="1em" class="fa fa-user-plus"></converse-icon>
@@ -69,6 +70,7 @@ export default (el, o) => {
         btns.push(html`
             <a href="#"
                class="dropdown-item toggle-filter"
+               role="button"
                @click=${(/** @type {MouseEvent} */ev) => el.toggleFilter(ev)}>
                 <converse-icon size="1em" class="fa fa-filter"></converse-icon>
                 ${is_filter_visible ? i18n_hide_filter : i18n_show_filter}
@@ -78,7 +80,8 @@ export default (el, o) => {
 
     if (btns.length) {
         btns.push(html`
-            <a href="#" class="dropdown-item" @click=${(/** @type {MouseEvent} */ev) => el.closeSidebar(ev)}>
+            <a href="#" class="dropdown-item" role="button"
+                @click=${(/** @type {MouseEvent} */ev) => el.closeSidebar(ev)}>
                 <converse-icon size="1em" class="fa fa-times"></converse-icon>
                 ${i18n_close}
             </a>

--- a/src/plugins/profile/templates/profile.js
+++ b/src/plugins/profile/templates/profile.js
@@ -31,7 +31,9 @@ export default (el) => {
                         nonce=${el.model.vcard?.get('vcard_updated')}
                         height="40" width="40"></converse-avatar>
                 </a>
-                <span class="username w-100 align-self-center">${el.model.getDisplayName()}</span>
+                <span class="username w-100 align-self-center" role="heading" aria-level="2">
+                    ${el.model.getDisplayName()}
+                </span>
                 <converse-controlbox-buttons></converse-controlbox-buttons>
             </div>
             <div class="d-flex xmpp-status">

--- a/src/plugins/roomslist/templates/roomslist.js
+++ b/src/plugins/roomslist/templates/roomslist.js
@@ -180,7 +180,7 @@ export default (el) => {
     return html`
         <div class="d-flex controlbox-padded">
             <span class="w-100 controlbox-heading controlbox-heading--groupchats">
-                <a class="list-toggle open-rooms-toggle"
+                <a class="list-toggle open-rooms-toggle" role="heading" aria-level="3"
                    title="${i18n_desc_rooms}"
                    @click=${ev => el.toggleRoomsList(ev)}>
 

--- a/src/plugins/roomslist/templates/roomslist.js
+++ b/src/plugins/roomslist/templates/roomslist.js
@@ -25,6 +25,7 @@ function tplBookmark (room) {
     const i18n_bookmark = __('Bookmark');
     return html`
         <a class="list-item-action add-bookmark"
+            tabindex="0"
             data-room-jid="${room.get('jid')}"
             data-bookmark-name="${room.getDisplayName()}"
             @click=${(ev) => addBookmarkViaEvent(ev)}
@@ -75,6 +76,7 @@ function tplRoomItem (el, room) {
             ${ api.settings.get('allow_bookmarks') ? tplBookmark(room) : '' }
 
             <a class="list-item-action close-room"
+                tabindex="0"
                 data-room-jid="${room.get('jid')}"
                 data-room-name="${room.getDisplayName()}"
                 title="${i18n_leave_room}"

--- a/src/plugins/roomslist/templates/roomslist.js
+++ b/src/plugins/roomslist/templates/roomslist.js
@@ -153,20 +153,20 @@ export default (el) => {
     const is_closed = el.model.get('toggle_state') === CLOSED;
 
     const btns = [
-        html`<a class="dropdown-item show-bookmark-list-modal"
+        html`<a class="dropdown-item show-bookmark-list-modal" role="button"
                 @click=${(ev) => api.modal.show('converse-bookmark-list-modal', { 'model': el.model }, ev)}
                 data-toggle="modal">
                     <converse-icon class="fa fa-bookmark" size="1em"></converse-icon>
                     ${i18n_show_bookmarks}
         </a>`,
-        html`<a class="dropdown-item show-list-muc-modal"
+        html`<a class="dropdown-item show-list-muc-modal" role="button"
                 @click=${(ev) => api.modal.show('converse-muc-list-modal', { 'model': el.model }, ev)}
                 data-toggle="modal"
                 data-target="#muc-list-modal">
                     <converse-icon class="fa fa-list-ul" size="1em"></converse-icon>
                     ${i18n_title_list_rooms}
         </a>`,
-        html`<a class="dropdown-item show-add-muc-modal"
+        html`<a class="dropdown-item show-add-muc-modal" role="button"
                 @click=${(ev) => api.modal.show('converse-add-muc-modal', { 'model': el.model }, ev)}
                 data-toggle="modal"
                 data-target="#add-chatrooms-modal">

--- a/src/plugins/rosterview/templates/roster.js
+++ b/src/plugins/rosterview/templates/roster.js
@@ -39,7 +39,7 @@ export default (el) => {
         btns.push(html`
             <a
                 href="#"
-                class="dropdown-item add-contact"
+                class="dropdown-item add-contact" role="button"
                 @click=${(/** @type {MouseEvent} */ ev) => el.showAddContactModal(ev)}
                 title="${i18n_title_add_contact}"
                 data-toggle="modal"
@@ -54,7 +54,7 @@ export default (el) => {
     if (roster.length > 5) {
         btns.push(html`
             <a href="#"
-               class="dropdown-item toggle-filter"
+               class="dropdown-item toggle-filter" role="button"
                @click=${(/** @type {MouseEvent} */ ev) => el.toggleFilter(ev)}>
                 <converse-icon size="1em" class="fa fa-filter"></converse-icon>
                 ${is_filter_visible ? i18n_hide_filter : i18n_show_filter}
@@ -67,7 +67,7 @@ export default (el) => {
         btns.push(html`
             <a
                 href="#"
-                class="dropdown-item"
+                class="dropdown-item" role="button"
                 @click=${(/** @type {MouseEvent} */ ev) => el.syncContacts(ev)}
                 title="${i18n_title_sync_contacts}"
             >

--- a/src/plugins/rosterview/templates/roster.js
+++ b/src/plugins/rosterview/templates/roster.js
@@ -80,7 +80,9 @@ export default (el) => {
     return html`
         <div class="d-flex controlbox-padded">
             <span class="w-100 controlbox-heading controlbox-heading--contacts">
-                <a class="list-toggle open-contacts-toggle" title="${i18n_toggle_contacts}" @click=${el.toggleRoster}>
+                <a class="list-toggle open-contacts-toggle" title="${i18n_toggle_contacts}"
+                    role="heading" aria-level="3"
+                    @click=${el.toggleRoster}>
                     ${i18n_heading_contacts}
 
                     ${ roster.length ? html`<converse-icon

--- a/src/shared/autocomplete/autocomplete.js
+++ b/src/shared/autocomplete/autocomplete.js
@@ -253,6 +253,14 @@ export class AutoComplete extends EventEmitter(Object) {
 
         if (this.ac_triggers.includes(ev.key)) {
             if (ev.key === "Tab") {
+                if (ev.shiftKey) {
+                    // TAB + shift should give the focus to previous focusable element.
+                    return
+                }
+                // If the input is empty (and min_chars > 0), TAB should give focus to next focusable element.
+                if (this.min_chars > 0 && this.input.value === '') {
+                    return
+                }
                 ev.preventDefault();
             }
             this.auto_completing = true;

--- a/src/shared/avatar/avatar.js
+++ b/src/shared/avatar/avatar.js
@@ -41,6 +41,7 @@ export default class Avatar extends CustomElement {
                 width: this.width,
                 image: data_uri || `data:${image_type};base64,${image}`,
                 image_type,
+                alt_text: this.name
             });
         }
 
@@ -52,8 +53,9 @@ export default class Avatar extends CustomElement {
             line-height: ${this.height}px;`;
 
         const author_style = this.model.getAvatarStyle(css);
-        return html`<div class="avatar-initials" style="${until(author_style, default_bg_css + css)}">
-            ${this.getInitials(this.name)}
+        return html`<div class="avatar-initials" style="${until(author_style, default_bg_css + css)}"
+            aria-label="${this.name}">
+                ${this.getInitials(this.name)}
         </div>`;
     }
 

--- a/src/shared/avatar/templates/avatar.js
+++ b/src/shared/avatar/templates/avatar.js
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 
 /**
  * @param {string} image
@@ -15,6 +15,8 @@ export default (o) => {
             class="avatar ${o.classes}"
             width="${o.width}"
             height="${o.height}"
+            aria-label="${o.alt_text}"
+            role=${o.alt_text ? nothing : 'presentation'}
         >
             <image
                 width="${o.width}"

--- a/src/shared/chat/message-actions.js
+++ b/src/shared/chat/message-actions.js
@@ -83,7 +83,7 @@ class MessageActions extends CustomElement {
 
     static getActionsDropdownItem (o) {
         return html`
-            <button class="dropdown-item chat-msg__action ${o.button_class}" @click=${o.handler}>
+            <button type="button" class="dropdown-item chat-msg__action ${o.button_class}" @click=${o.handler}>
                 <converse-icon
                     class="${o.icon_class}"
                     color="var(--inverse-link-color)"

--- a/src/shared/chat/styles/message-actions.scss
+++ b/src/shared/chat/styles/message-actions.scss
@@ -18,6 +18,9 @@ converse-message-actions {
         .btn--standalone {
             opacity: 0;
             margin-top: -0.2em;
+            &:focus {
+                opacity: 1;
+            }
         }
         .chat-msg__action {
             width: 100%;

--- a/src/shared/chat/utils.js
+++ b/src/shared/chat/utils.js
@@ -15,7 +15,9 @@ export async function getHeadingDropdownItem (promise_or_data) {
     const data = await promise_or_data;
     return data
         ? html`
-              <a href="#" class="dropdown-item ${data.a_class}" @click=${data.handler} title="${data.i18n_title}">
+              <a href="#" role="button"
+                class="dropdown-item ${data.a_class}"
+                @click=${data.handler} title="${data.i18n_title}">
                   <converse-icon
                       size="1em"
                       class="fa ${data.icon_class}"

--- a/src/shared/components/dropdown.js
+++ b/src/shared/components/dropdown.js
@@ -7,6 +7,7 @@ import { api, constants, u } from "@converse/headless";
 import DOMNavigator from "shared/dom-navigator.js";
 import DropdownBase from 'shared/components/dropdownbase.js';
 import 'shared/components/icons.js';
+import { __ } from 'i18n';
 
 import './styles/dropdown.scss';
 
@@ -38,8 +39,9 @@ export default class Dropdown extends DropdownBase {
                     type="button"
                     data-bs-toggle="dropdown"
                     aria-haspopup="true"
-                    aria-expanded="false">
-                <converse-icon size="1em" class="${ this.icon_classes }">
+                    aria-expanded="false"
+                    aria-label=${ __('Menu') }>
+                <converse-icon aria-hidden="true" size="1em" class="${ this.icon_classes }">
             </button>
             <ul class="dropdown-menu" aria-labelledby="${this.id}">
                 ${ this.items.map(b => html`<li>${until(b, '')}</li>`) }

--- a/src/shared/styles/lists.scss
+++ b/src/shared/styles/lists.scss
@@ -91,6 +91,9 @@
                     color: var(--list-toggle-hover-color);
                     opacity: 1;
                 }
+                &:focus {
+                    opacity: 1;
+                }
             }
 
             .list-item-action--visible {

--- a/src/templates/form_input.js
+++ b/src/templates/form_input.js
@@ -8,7 +8,8 @@ export default  (o) => html`
         <!-- This is a hack to prevent Chrome from auto-filling the username in
              any of the other input fields in the MUC configuration form. -->
         ${ (o.type === 'password' && o.fixed_username) ? html`
-            <input class="hidden-username" type="text" autocomplete="username" value="${o.fixed_username}"></input>
+            <input class="hidden-username" aria-hidden="true" type="text"
+                autocomplete="username" value="${o.fixed_username}"></input>
         ` : '' }
         <input
             autocomplete="${o.autocomplete || ''}"


### PR DESCRIPTION
I made an accessibility audit on my project. Part of the issues concern Converse.
Here are the required fixes. I have separated them in different commits, so we can discuss if necessary.

Here is the list of changes:
* adding role=button attribute on dropdown actions, for better
  accessibility with screen readers.
* Autocomplete fields: shift+tab should always give focus to previous
  focusable element, and tab should give the focus to next focusable
  element if the input is empty.
* dropdown buttons: adding a "Menu" aria-label, and adding aria-hidden on icon.
* message actions: opacity:1 on focus.
* list-item-action: opacity:1 on focus, tabindex=0 to be focusable.
* adding aria-hidden="true" on fields with hidden-username class.
* Adding role="heading", aria-level="2" on userinfo, MUC title and
  chatbox titles, to improve navigation with screen readers.
* Adding role="heading", aria-level="3" on controlbox-heading elements.
* converse-avatar:
  * Fix alt_text parameter that was ignored
  * using aria-label instead of alt attribute on svg (alt is not valid)
  * if no alt_text, adding role="presentation" so that screen readers
    ignores the image
  * when fallbacking on initials, adding a aria-label with the full name

As my project only uses Converse in singleton mode to display one MUC, the audit is incomplete.
I tried to fix some of the issues more widely than what was required for my project, but i can have missed some points.

- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
