### PR TITLE
MUC occupants badges: displays short labels, with full label as title.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 - Add a new theme 'Cyberpunk' and remove the old 'Concord' theme.
 - Improved accessibility.
 - New "getOccupantActionButtons" hook, so that plugins can add actions on MUC occupants.
+- MUC occupants badges: displays short labels, with full label as title.
 
 - New config option [stanza_timeout](https://conversejs.org/docs/html/configuration.html#show-background)
 

--- a/src/plugins/muc-views/tests/occupants.js
+++ b/src/plugins/muc-views/tests/occupants.js
@@ -175,8 +175,11 @@ describe("The occupants sidebar", function () {
         expect(occupants.length).toBe(1);
         expect(occupants[0].querySelector('.occupant-nick').textContent.trim()).toBe("romeo");
         expect(occupants[0].querySelectorAll('.badge').length).toBe(2);
-        expect(occupants[0].querySelectorAll('.badge')[0].textContent.trim()).toBe('Owner');
-        expect(sizzle('.badge:last', occupants[0]).pop().textContent.trim()).toBe('Moderator');
+        expect(occupants[0].querySelectorAll('.badge')[0].textContent.trim()).toBe('O');
+        expect(occupants[0].querySelectorAll('.badge')[0].getAttribute('title').trim()).toBe('Owner');
+        expect(occupants[0].querySelectorAll('.badge')[0].getAttribute('aria-label').trim()).toBe('Owner');
+        expect(sizzle('.badge:last', occupants[0]).pop().textContent.trim()).toBe('MO');
+        expect(sizzle('.badge:last', occupants[0]).pop().getAttribute('title').trim()).toBe('Moderator');
 
         var presence = $pres({
                 to:'romeo@montague.lit/pda',
@@ -199,8 +202,12 @@ describe("The occupants sidebar", function () {
         );
         expect(occupants[1].querySelector('.occupant-nick').textContent.trim()).toBe("romeo");
         expect(occupants[0].querySelectorAll('.badge').length).toBe(2);
-        expect(occupants[0].querySelectorAll('.badge')[0].textContent.trim()).toBe('Admin');
-        expect(occupants[0].querySelectorAll('.badge')[1].textContent.trim()).toBe('Moderator');
+        expect(occupants[0].querySelectorAll('.badge')[0].textContent.trim()).toBe('A');
+        expect(occupants[0].querySelectorAll('.badge')[0].getAttribute('title').trim()).toBe('Admin');
+        expect(occupants[0].querySelectorAll('.badge')[0].getAttribute('aria-label').trim()).toBe('Admin');
+        expect(occupants[0].querySelectorAll('.badge')[1].textContent.trim()).toBe('MO');
+        expect(occupants[0].querySelectorAll('.badge')[1].getAttribute('title').trim()).toBe('Moderator');
+        expect(occupants[0].querySelectorAll('.badge')[1].getAttribute('aria-label').trim()).toBe('Moderator');
 
         contact_jid = mock.cur_names[3].replace(/ /g,'.').toLowerCase() + '@montague.lit';
         presence = $pres({
@@ -222,6 +229,7 @@ describe("The occupants sidebar", function () {
             contact_jid + ' This user can NOT send messages in this groupchat. Click to mention visitorwoman in your message.'
         );
         expect(occupants[2].querySelectorAll('.badge').length).toBe(1);
-        expect(sizzle('.badge', occupants[2]).pop().textContent.trim()).toBe('Visitor');
+        expect(sizzle('.badge', occupants[2]).pop().textContent.trim()).toBe('V');
+        expect(sizzle('.badge', occupants[2]).pop().getAttribute('title').trim()).toBe('Visitor');
     }));
 });


### PR DESCRIPTION
By default, we take the first letter of all badge, and only display this letter (full badge name is set as title and aria-label for screen readers). If there is ambiguous letters, we use 2 (or 3, ... up to 4) letters.

![image](https://github.com/user-attachments/assets/d6bd390b-32d6-43b4-b099-c58d83ba7e2e)


- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [x] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
