### PR TITLE
Fix regression:

### DIFF
--- a/src/plugins/muc-views/templates/message-form.js
+++ b/src/plugins/muc-views/templates/message-form.js
@@ -29,7 +29,7 @@ export default (el) => {
                     class="btn-toolbar chat-toolbar no-text-select"
                     .model=${el.model}
                     ?hidden_occupants="${el.model.get('hidden_occupants')}"
-                    ?is_groupchat="${el.model.get('is_groupchat')}"
+                    ?is_groupchat="${el.model.get('message_type') === 'groupchat'}"
                     ?show_call_button="${show_call_button}"
                     ?show_emoji_button="${show_emoji_button}"
                     ?show_send_button="${show_send_button}"


### PR DESCRIPTION
When the toolbar was moved (commit f91d5e2c146b3d13e599c46b07ed1971cf94494e), the is_groupchat attribute was wronly computed.
