### PR TITLE
Fix checkbox styling in forms.

### DIFF
--- a/src/templates/form_checkbox.js
+++ b/src/templates/form_checkbox.js
@@ -1,10 +1,11 @@
 import { html } from "lit";
 
 export default  (o) => html`
-    <fieldset class="pb-2">
+    <fieldset class="pb-2 form-check">
         <input id="${o.id}"
                name="${o.name}"
                type="checkbox"
+               class="form-check-input"
                ?readonly=${o.readonly}
                ?checked=${o.checked}
                ?required=${o.required} />


### PR DESCRIPTION
In the ConverseJS WIP, there is a bug for checkbox fields in room configuration form: if the label + description are too long, there is an extra line break:

![image](https://github.com/user-attachments/assets/a75d017d-9c47-48fe-b2e7-1f13e4f7a214)

This PR fixes this issue:

![image](https://github.com/user-attachments/assets/ec831955-ef90-40c1-9553-d3faf7ef74ac)
