### PR TITLE
Reject non-secure WebSocket or BOSH endpoints

### DIFF
--- a/src/headless/shared/connection/index.js
+++ b/src/headless/shared/connection/index.js
@@ -60,8 +60,8 @@ export class Connection extends Strophe.Connection {
         }
         const bosh_links = sizzle(`Link[rel="urn:xmpp:alt-connections:xbosh"]`, xrd);
         const ws_links = sizzle(`Link[rel="urn:xmpp:alt-connections:websocket"]`, xrd);
-        const bosh_methods = bosh_links.map(el => el.getAttribute('href'));
-        const ws_methods = ws_links.map(el => el.getAttribute('href'));
+        const bosh_methods = bosh_links.map(el => el.getAttribute('href')).filter(uri => uri.startsWith('https:'));
+        const ws_methods = ws_links.map(el => el.getAttribute('href')).filter(uri => uri.startsWith('wss:'));
         if (bosh_methods.length === 0 && ws_methods.length === 0) {
             log.warn("Neither BOSH nor WebSocket connection methods have been specified with XEP-0156.");
         } else {


### PR DESCRIPTION
When discovering endpoints using XEP-0156, the server admin can list any kind of URL, but we want to use only secure ones using TLS.  In order to achieve that, we filter out the lists before using the first one available.

This was causing connection to fail with the step.im server, which exposes in order ws:, wss: and http:, and we were previously using only the first and third ones, instead of the second like we should.

Should fix the issue reported by @VnPower at https://misskey.pm/notes/a0v0aaw0tbknyojk