### PR TITLE
Fix: trying to use emojis with an uppercase letter breaks the message field

### DIFF
--- a/src/headless/plugins/emoji/api.js
+++ b/src/headless/plugins/emoji/api.js
@@ -49,7 +49,7 @@ const emojis = {
             converse.emojis.shortnames = converse.emojis.list.map((m) => m.sn);
             const getShortNames = () =>
                 converse.emojis.shortnames.map((s) => s.replace(/[+]/g, '\\$&')).join('|');
-            converse.emojis.shortnames_regex = new RegExp(getShortNames(), 'gi');
+            converse.emojis.shortnames_regex = new RegExp(getShortNames(), 'g');
             converse.emojis.initialized_promise.resolve();
         }
         return converse.emojis.initialized_promise;

--- a/src/headless/plugins/emoji/utils.js
+++ b/src/headless/plugins/emoji/utils.js
@@ -108,7 +108,7 @@ export function getShortnameReferences (text) {
     }
     const references = [...text.matchAll(converse.emojis.shortnames_regex)].filter(ref => ref[0].length > 0);
     return references.map(ref => {
-        const cp = converse.emojis.by_sn[ref[0].toLowerCase()].cp;
+        const cp = converse.emojis.by_sn[ref[0]].cp;
         return {
             cp,
             'begin': ref.index,
@@ -190,7 +190,7 @@ export function isOnlyEmojis (text) {
     }
     const emojis = words.filter(text => {
         const refs = getCodePointReferences(u.shortnamesToUnicode(text));
-        return refs.length === 1 && (text.toLowerCase() === refs[0]['shortname'] || text === refs[0]['emoji']);
+        return refs.length === 1 && (text === refs[0]['shortname'] || text === refs[0]['emoji']);
     });
     return emojis.length === words.length;
 }


### PR DESCRIPTION
Previoux fix (https://github.com/conversejs/converse.js/pull/3501) was wrong and introduced other issues:
* impossible to define an emoji with uppercase letters
* possible to use an emoji :abc: by using :Abc:, but it won't display

So, the correct fix is just to remove the 'i' modifier for the shortname_regex, to always have case sensitive emojis.



## More details about this PR

Before my previous fix (https://github.com/conversejs/converse.js/pull/3501), emojis were broken if you tried to call them without beeing case sensitive.

Consider we have a ":abc:" short_name.
The shortname_regex was case insensitive, so it detected for example ":ABC:". But then, the following line was broken:
https://github.com/conversejs/converse.js/blob/f8935e0b721a08bad8e019f05607a20d5878470c/src/headless/plugins/emoji/utils.js#L102

`by_sn[ref[0]]` was undefined, and the `.cp` make it fail.

Same here:
https://github.com/conversejs/converse.js/blob/f8935e0b721a08bad8e019f05607a20d5878470c/src/headless/plugins/emoji/utils.js#L176

`text === refs[0]['shortname']` is case sensitive.

So, i added the `text.toLowerCase()`... But this is assuming that shortnames are lowercase... When you deal with custom emojis, nothing tells you have to use lowerCase.
(And `.toLowerCase()` may be inexact for some alphabets).

Moreover, this was fixing the message sending... But the message display was broken. There was a missing `toLowerCase()` here:
https://github.com/conversejs/converse.js/blob/8754f03ee6b55381c6935b28532add54bc72fcad/src/shared/chat/utils.js#L222

To resume:
* v10 is broken. If you call ":ABC:", Converse was totally broken, and you need to reload the page. And when there is such message in the chat, it was broken too if a remember well.
* my previous fix was only working if all shortnames are lowercase. It appears that in my project, some users decided to use uppercase for some custom emojis (can't blame them for that).

Trying to handle case insensivity would be difficult... And could cause some troubles if there are multiple emojis with are equals when case insensitive... (in the JSON object, you can have ":ABC" and ":abc"...).

So i think it is better to make shortnames case sensitive. In most case, it will just work.
(the only code part that was trying to make emojis shortnames case insensitive is the `i` modifier on the regex this PR changes)

The only issue i can see, is if you have some custom emoji without the ":" prefix, and when you use a mobile phone that will automatically use an uppercase for the first letter of a new sentence. This seems a reasonable assumption.
