### PR TITLE
Domain group disco button

### DIFF
--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -111,7 +111,7 @@ export default class MUCListModal extends BaseModal {
     }
 
     onDomainChange () {
-        this.getElementsByClassName('form-control')[0].value = this.model.get('muc_domain');
+        this.querySelector('form-control').value = this.model.get('muc_domain');
         this.items = [];
         this.model.save('feedback_text', '');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -111,6 +111,7 @@ export default class MUCListModal extends BaseModal {
     }
 
     onDomainChange () {
+        this.getElementsByClassName('form-control')[0].value = this.model.get('muc_domain');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();
     }
 

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -112,6 +112,7 @@ export default class MUCListModal extends BaseModal {
 
     onDomainChange () {
         this.getElementsByClassName('form-control')[0].value = this.model.get('muc_domain');
+        this.items = [];
         api.settings.get('auto_list_rooms') && this.updateRoomsList();
     }
 

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -111,7 +111,10 @@ export default class MUCListModal extends BaseModal {
     }
 
     onDomainChange () {
-        this.querySelector('form-control').value = this.model.get('muc_domain');
+        const domain_input = this.querySelector('form-control');
+        if (domain_input) {
+            /** @type {HTMLInputElement} */(domain_input).value = this.model.get('muc_domain');
+        }
         this.items = [];
         this.model.save('feedback_text', '');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -113,6 +113,7 @@ export default class MUCListModal extends BaseModal {
     onDomainChange () {
         this.getElementsByClassName('form-control')[0].value = this.model.get('muc_domain');
         this.items = [];
+        this.model.save('feedback_text', '');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();
     }
 

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -111,7 +111,7 @@ export default class MUCListModal extends BaseModal {
     }
 
     onDomainChange () {
-        this.querySelector('form-control').value = this.model.get('muc_domain');
+        this.querySelector('.form-control').value = this.model.get('muc_domain');
         this.items = [];
         this.model.save('feedback_text', '');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();

--- a/src/plugins/muc-views/modals/muc-list.js
+++ b/src/plugins/muc-views/modals/muc-list.js
@@ -111,10 +111,7 @@ export default class MUCListModal extends BaseModal {
     }
 
     onDomainChange () {
-        const domain_input = this.querySelector('form-control');
-        if (domain_input) {
-            /** @type {HTMLInputElement} */(domain_input).value = this.model.get('muc_domain');
-        }
+        this.querySelector('form-control').value = this.model.get('muc_domain');
         this.items = [];
         this.model.save('feedback_text', '');
         api.settings.get('auto_list_rooms') && this.updateRoomsList();

--- a/src/plugins/muc-views/templates/muc-list.js
+++ b/src/plugins/muc-views/templates/muc-list.js
@@ -34,7 +34,7 @@ const tplItem = (o, item) => {
         <li class="room-item list-group-item">
             <div class="available-chatroom d-flex flex-row">
                 <a class="open-room available-room w-100"
-                    @click=${o.openRoom}
+                    @click=${o.openItem}
                     data-room-jid="${item.jid}"
                     data-room-name="${item.name}"
                     title="${i18n_open_title}"

--- a/src/plugins/roomslist/templates/roomslist.js
+++ b/src/plugins/roomslist/templates/roomslist.js
@@ -77,21 +77,34 @@ function tplRoomItem (el, room) {
  */
 function tplRoomDomainGroup (el, domain, rooms) {
     const i18n_title = __('Click to hide these rooms');
+    const i18n_title_list_rooms = __('Query server');
     const collapsed = el.model.get('collapsed_domains');
     const is_collapsed = collapsed.includes(domain);
+    const btns = [
+        html`<a class="dropdown-item show-list-muc-modal" role="button"
+                @click="${(ev) => {el.model.setDomain(domain); api.modal.show('converse-muc-list-modal', { 'model': el.model }, ev)}}"
+                data-toggle="modal"
+                data-target="#muc-list-modal">
+                    <converse-icon class="fa fa-list-ul" size="1em"></converse-icon>
+                    ${i18n_title_list_rooms}
+        </a>`,
+    ];
     return html`
     <div class="muc-domain-group" data-domain="${domain}">
-        <a href="#"
-           class="list-toggle muc-domain-group-toggle controlbox-padded"
-           title="${i18n_title}"
-           @click=${ev => el.toggleDomainList(ev, domain)}>
+        <div class="d-flex controlbox-padded">
+            <a href="#"
+               class="list-toggle muc-domain-group-toggle w-100"
+               title="${i18n_title}"
+               @click=${ev => el.toggleDomainList(ev, domain)}>
 
-            <converse-icon
-                class="fa ${ is_collapsed ? 'fa-caret-right' : 'fa-caret-down' }"
-                size="1em"
-                color="var(--muc-color)"></converse-icon>
-            ${domain}
-        </a>
+                <converse-icon
+                    class="fa ${ is_collapsed ? 'fa-caret-right' : 'fa-caret-down' }"
+                    size="1em"
+                    color="var(--muc-color)"></converse-icon>
+                ${domain}
+            </a>
+            <converse-dropdown class="btn-group dropstart" .items=${btns}></converse-dropdown>
+        </div>
         <ul class="items-list muc-domain-group-rooms ${ is_collapsed ? 'collapsed' : '' }" data-domain="${domain}">
             ${ rooms.map(room => tplRoomItem(el, room)) }
         </ul>


### PR DESCRIPTION
This adds the ability to do MUC channel search for domain groups when using `muc_grouped_by_domain`.

![Screenshot: adds a dropdown menu for each domain group with a "Query server" option](https://github.com/user-attachments/assets/52d0d6a8-2dea-4ac9-a368-cdd25404a41f)

As this is currently implemented, using one of these buttons will set the default MUC domain globally, which can affect later uses of the global "Query for Groupchats" feature: I don’t know if this can have any unwanted effects yet (it doesn’t seem to be saved after logging out at least).

Before submitting your request, please make sure the following conditions are met:

- ~~[ ] Add a changelog entry for your change in `CHANGES.md`~~ `muc_grouped_by_domain` is only in 11, which is not yet released, so that might not be necessary.
- ~~[ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`~~ not applicable
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
