### PR TITLE
Fix auto zoom in in ios safari fullpage view mode when input message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fix login form style for `classic` theme
 - Properly handle OGP metadata that doesn't have an image
 - Fix TypeError which prevents logging out
+- Fix auto zoom in when input message in ios safari
 
 ## 11.0.0 (2025-05-21)
 

--- a/src/shared/styles/_core.scss
+++ b/src/shared/styles/_core.scss
@@ -149,7 +149,11 @@
     input[type='submit'],
     input[type='button'],
     input[type='text'],
-    input[type='password'],
+    input[type='password'] {
+        font-size: var(--font-size-large);
+        min-height: 0;
+    }
+    
     button {
         font-size: var(--font-size);
         min-height: 0;


### PR DESCRIPTION
Fix auto zoom in  page in ios safari fullpage view mode when input message, it will result in a scroll bar present in x and y. 