### PR TITLE
Load/store FAST keys for auto_login.

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1887,25 +1887,26 @@ Based on the OGP metadata Converse will render a URL preview (also known as an
   the ``show_images_inline``, ``embed_audio`` and ``embed_videos`` settings.
 
 
-reuse_scram_keys
-----------------
+reuse_keys
+----------
 
 * Default: ``true``
 
 Most XMPP servers enable the Salted Challenge Response Authentication Mechanism
-or SCRAM for short. This allows the user and the server to mutually
-authenticate *without* the need to transmit the user's password in plaintext.
+or SCRAM for short. Newer servers also support Fast Authentication Streamlining Tokens.
+These allow the user and the server to mutually authenticate *without* the need
+to transmit the user's password in plaintext.
 
 Assuming the server does not alter the user's password or the
-storage parameters, we can authenticate with the same SCRAM key multiple times.
+storage parameters, we can authenticate with the same key multiple times.
 
 This opens an opportunity: we can store the user's login credentials in the
 browser without storing the sensitive plaintext password, or the
 need to set up complicated third party backends, like OAuth.
 
-Enabling this option will let Converse save a user's SCRAM keys upon successful
+Enabling this option will let Converse save a user's keys upon successful
 login, and next time Converse is loaded the user will be automatically logged in
-with those SCRAM keys.
+with those keys.
 
 
 .. _`roomconfig_whitelist`:

--- a/docs/source/session.rst
+++ b/docs/source/session.rst
@@ -196,10 +196,12 @@ We've purposefully not put this functionality in Converse.js due to the
 security implications of storing plaintext passwords in localStorage.
 
 
-Storing the SASL SCRAM-SHA1 hash in IndexedDB
----------------------------------------------
+Storing the SASL SCRAM-SHA1 hash or FAST token in IndexedDB
+-----------------------------------------------------------
 
 Another suggestion that's been suggested is to store the SCRAM-SHA1 computed
 ``clientKey`` in localStorage and to use that upon page reload to log the user in again.
 
-This has been implemented since version 10, see documentation on `reuse_scram_keys <https://conversejs.org/docs/html/configuration.html#reuse-scram-keys>`_
+In more modern terms, we can store the FAST token if supported by the server.
+
+This has been implemented since version 10, see documentation on `reuse_keys <https://conversejs.org/docs/html/configuration.html#reuse-keys>`_

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "pluggable.js": "^3.0.1",
         "prettier": "^3.2.5",
         "sizzle": "^2.3.5",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.2",
+        "strophe.js": "file:../strophejs"
       },
       "devDependencies": {
         "@converse/headless": "file:src/headless",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "^3.2.5",
         "sizzle": "^2.3.5",
         "sprintf-js": "^1.1.2",
-        "strophe.js": "file:../strophejs"
+        "strophe.js": "github:kousu/strophejs#sasl2_fast_2"
       },
       "devDependencies": {
         "@converse/headless": "file:src/headless",
@@ -8147,9 +8147,8 @@
       }
     },
     "node_modules/strophe.js": {
-      "version": "4.0.0-rc0",
-      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-4.0.0-rc0.tgz",
-      "integrity": "sha512-9j2hR/OsxFX1gmqcsxNOQySrUUju0blHAmGB5g5EcdlVjWn19u+xHKEoXt4Ft8VPBB9rQR0jvtQkAJPpqM9XTw==",
+      "version": "3.1.1",
+      "resolved": "git+ssh://git@github.com/kousu/strophejs.git#0d0c7fe3b3badfb52f190dd0b1d02e00986267b3",
       "license": "MIT",
       "peerDependencies": {
         "jsdom": ">=20.0.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "prettier": "^3.2.5",
     "sizzle": "^2.3.5",
     "sprintf-js": "^1.1.2",
-    "strophe.js": "file:../strophejs"
+    "strophe.js": "github:kousu/strophejs#sasl2_fast_2"
   },
   "resolutions": {
     "autoprefixer": "10.4.5"

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "pluggable.js": "^3.0.1",
     "prettier": "^3.2.5",
     "sizzle": "^2.3.5",
-    "sprintf-js": "^1.1.2"
+    "sprintf-js": "^1.1.2",
+    "strophe.js": "file:../strophejs"
   },
   "resolutions": {
     "autoprefixer": "10.4.5"

--- a/src/headless/shared/api/user.js
+++ b/src/headless/shared/api/user.js
@@ -5,7 +5,7 @@ import _converse from '../_converse.js';
 import presence_api from './presence.js';
 import connection_api from '../connection/api.js';
 import { replacePromise } from '../../utils/session.js';
-import { attemptNonPreboundSession, setUserJID } from '../../utils/init.js';
+import { attemptNonPreboundSession, setUserJID, savedLoginInfo } from '../../utils/init.js';
 import { getOpenPromise } from '@converse/openpromise';
 import { user_settings_api } from '../settings/user/api.js';
 import { LOGOUT } from '../constants.js';
@@ -108,8 +108,15 @@ const api = {
                 // Recreate all the promises
                 Object.keys(_converse.promises).forEach((p) => replacePromise(_converse, p));
 
-                // Remove the session JID, otherwise the user would just be logged
+                // Remove the session JID/keys, otherwise the user would just be logged
                 // in again upon reload. See #2759
+                const jid = localStorage.getItem("conversejs-session-jid");
+                if (jid) {
+                    savedLoginInfo(jid).then((login_info) => {
+                        // XXX TODO: is there a cleaner call? .remove()? .clear()?
+                        login_info.save({ fast: null, scram_keys: null });
+                    })
+                }
                 localStorage.removeItem('conversejs-session-jid');
 
                 /**

--- a/src/headless/shared/settings/constants.js
+++ b/src/headless/shared/settings/constants.js
@@ -6,7 +6,7 @@
  * @property {String} [assets_path='/dist']
  * @property {('login'|'prebind'|'anonymous'|'external')} [authentication='login']
  * @property {Boolean} [auto_login=false] - Currently only used in connection with anonymous login
- * @property {Boolean} [reuse_scram_keys=true] - Save SCRAM keys after login to allow for future auto login
+ * @property {Boolean} [reuse_keys=true] - Save SCRAM/FAST keys after login to allow for future auto login
  * @property {Boolean} [auto_reconnect=true]
  * @property {Array<String>} [blacklisted_plugins]
  * @property {Boolean} [clear_cache_on_logout=false]
@@ -50,7 +50,7 @@ export const DEFAULT_SETTINGS = {
     geouri_replacement: 'https://www.openstreetmap.org/?mlat=$1&mlon=$2#map=18/$1/$2',
     i18n: undefined,
     jid: undefined,
-    reuse_scram_keys: true,
+    reuse_keys: true,
     keepalive: true,
     loglevel: 'info',
     locales: [

--- a/src/headless/types/shared/settings/constants.d.ts
+++ b/src/headless/types/shared/settings/constants.d.ts
@@ -16,7 +16,7 @@ export namespace DEFAULT_SETTINGS {
     let geouri_replacement: string;
     let i18n: any;
     let jid: any;
-    let reuse_scram_keys: boolean;
+    let reuse_keys: boolean;
     let keepalive: boolean;
     let loglevel: string;
     let locales: string[];
@@ -46,9 +46,9 @@ export type ConfigurationSettings = {
      */
     auto_login?: boolean;
     /**
-     * - Save SCRAM keys after login to allow for future auto login
+     * - Save keys after login to allow for future auto login
      */
-    reuse_scram_keys?: boolean;
+    reuse_keys?: boolean;
     auto_reconnect?: boolean;
     blacklisted_plugins?: Array<string>;
     clear_cache_on_logout?: boolean;


### PR DESCRIPTION
Also clean up FAST *and* SCRAM keys on log out; otherwise, the credentials are still in the browser, and could be stolen, or reused simply by someone who knows to redefined conversejs-session-jid in localStorage.

Fixes https://github.com/conversejs/converse.js/issues/3144

Depends on https://github.com/strophe/strophejs/pull/840. The **bulk** of the work is in that pull.

TODO:

* [ ] This *renames* reuse_scram_keys to reuse_keys to cover both FAST and SCRAM, so it should probably get a backwards-compatibility shim for the old name.
* [ ] Drop my development environment edit to package.json (without there's no way to test because both repos need to be in sync)


---

Before submitting your request, please make sure the following conditions are met:

- [ ] Add a changelog entry for your change in `CHANGES.md`
- [x] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
