### PR TITLE
Update doap with support for XEP:0483 - HTTP Online Meetings via olme…

### DIFF
--- a/conversejs.doap
+++ b/conversejs.doap
@@ -318,12 +318,12 @@
         <xmpp:since>8.0.0</xmpp:since>
       </xmpp:SupportedXep>
     </implements>
-	<implements>
-		<xmpp:SupportedXep>
-			<xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0483.html"/>
-			<xmpp:since>11.0.1</xmpp:since>			
-			<xmpp:note xml:lang='en'>Provided by the 'Online Meetings (olmeet)' plugin</xmpp:note>
-		</xmpp:SupportedXep>
-	</implements>	
+    <implements>
+      <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0483.html"/>
+        <xmpp:since>11.0.1</xmpp:since>			
+        <xmpp:note xml:lang='en'>Provided by the 'Online Meetings (olmeet)' plugin</xmpp:note>
+      </xmpp:SupportedXep>
+    </implements>	
   </Project>
 </rdf:RDF>


### PR DESCRIPTION
Update doap with support for XEP:0483 - HTTP Online Meetings via olmeet plugin

conversejs can now:

auto-discover what audio/video conferencing service is available and configured in XMPP server
request for a web app URL and use it to
invite others to the meeting. If their client supports XEP-0483, the web app can be opened in the chatbox otherwise, it will be opened in the desktop web browser.
fallback on a static base URL configured in config if their XMPP server does not yet support xep-0483.