### PR TITLE
index.js: change link to list of pulic XMPP providers for registrations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add approval banner in chats with requesting contacts or unsaved contacts
 - Some fixes regarding manually resized chats in `overlayed` view mode.
 - Replace webpack with [rspack](https://rspack.rs)
+- Registration: Use https://providers.xmpp.net instead of https://compliance.conversations.im
 
 ## 11.0.1 (2025-06-09)
 

--- a/index.html
+++ b/index.html
@@ -228,8 +228,8 @@
                 <div class="h-100 p-3 rounded-3 text-center">
                     <h2>Get Started in Minutes 🚀</h2>
                     <p>Use our <a href="/fullscreen.html">web app</a> to connect to any XMPP server. You can log in with your existing XMPP account.</p>
-                    <p>No account? No problem! With Converse you can register an account on any public XMPP server that allows in-band registration.
-                        Have a look at the <a href="https://compliance.conversations.im/" target="_blank" rel="noopener">Conversations compliance page</a> for public XMPP servers that allow registrations.</p>
+                    <p>No account? No problem! With Converse you can register an account on our <em>conversejs.org</em> XMPP server any other public server that allows in-band registration.
+                        Have a look at the <a href="https://https://providers.xmpp.net//" target="_blank" rel="noopener">list of public XMPP providers</a> that allow registrations.</p>
                     <p>Come and chat with us at <a href="https://inverse.chat/#converse/room?jid=discuss@conference.conversejs.org" class="xmpp JSnocheck" title="Converse chat room">discuss@conference.conversejs.org</a>.</p>
                 </div>
             </div>

--- a/src/plugins/register/index.js
+++ b/src/plugins/register/index.js
@@ -42,7 +42,7 @@ converse.plugins.add('converse-register', {
         api.settings.extend({
             allow_registration: true,
             domain_placeholder: __(' e.g. conversejs.org'), // Placeholder text shown in the domain input on the registration form
-            providers_link: 'https://compliance.conversations.im/', // Link to XMPP providers shown on registration page
+            providers_link: 'https://providers.xmpp.net/', // Link to XMPP providers shown on registration page
             registration_domain: ''
         });
 


### PR DESCRIPTION
The registration process is the main pain for regular users (just imagine explaining this to your relatives). 
The old compliance.conversations.im is not intended for users to pick a server. But this can be added to it with low efforts but this may be difficult to negotiate.
The Kaidan client uses the https://providers.xmpp.net/ as a categorized list of providers.
According to changelog the Converse used before some list of providers from the site #1206: 

> v4.0.1 (2018-09-19) Use https://compliance.conversations.im instead of dead link tot st https://xmpp.net

Unfortunately from the recommended A category only three servers doesn't require for a CAPTCHA which is annoying: https://jabber.fr, https://yax.im, https://xmpp.eath. And the BOSH is supported only by the jabber.fr. Basically we can just add it to the text. 

We should ask other servers to enable the BOSH (and maybe disable the CAPTCHA). Anyway, it would be really good to put the `conversejs.org` as a default value (not just a placeholder) but also it's possible to add other domains into auto-completion to make it easier for user to type them (#2986). Can we add the `conversejs.org` to the list of public providers or you don't want to have many registrations from side clients?

BTW the conversations.im server has BOSH and is working but in the rating it has a low category because it has something disabled. I remember that asked its owner to fix that but he is too busy but also he wasn't happy to be used by anyone as a general server.

The compliance test checks if a server has XEP-0156: Discovering Alternative XMPP Connection Methods (HTTP)
https://compliance.conversations.im/test/xep0156/
So some of this servers with green check potentially may allow BOSH and allow registrations. If found a few from the list:
agnos.is
ari.lt 
asozial.org

Ideally we need to have the list of such servers.

There are some other places that use the Compliance page that I didn't changed:
https://github.com/search?q=repo%3Aconversejs%2Fconverse.js%20compliance.conversations.im&type=code

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [x] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
