### PR TITLE
Adda a warning to quickstart about using version numbers when configuring xmpp server plugins.

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,7 +22,7 @@ For example, the following XMPP servers have plugins available:
 * **ejabberd**: `mod_conversejs <https://docs.ejabberd.im/admin/configuration/modules/#mod-conversejs>`_
 
 .. warning::
-    When configuring one of these plugins in production, ensure that they use a specific version of the conversjs resources to avoid breaking changes.
+    When configuring one of these plugins in production, it's good practice to use a specific version of the Converse resources to avoid breaking changes.
 
 For instance, this will configure ejabberd's, mod-conversejs to fetch a specific version instead of whichever is the latest one.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,6 +21,19 @@ For example, the following XMPP servers have plugins available:
 * **Prosody**: `mod_conversejs <https://modules.prosody.im/mod_conversejs.html>`_
 * **ejabberd**: `mod_conversejs <https://docs.ejabberd.im/admin/configuration/modules/#mod-conversejs>`_
 
+.. warning::
+    When configuring one of these plugins in production, ensure that they use a specific version of the conversjs resources to avoid breaking changes.
+
+For instance, this will configure ejabberd's, mod-conversejs to fetch a specific version instead of whichever is the latest one.
+
+.. code-block:: yml
+    
+    mod_conversejs:
+      # Replace 11.0.1 with your desired version
+      conversejs_css: https://cdn.conversejs.org/11.0.1/dist/converse.min.css
+      conversejs_script: https://cdn.conversejs.org/11.0.1/dist/converse.min.js
+
+
 Option 2: Self-hosting
 ======================
 
@@ -39,7 +52,7 @@ To use it, add these lines to your HTML page's ``<head>`` section:
 
 .. code-block:: html
 
-    <!-- Replace 10.1.5 with your desired version -->
+    <!-- Replace 11.0.1 with your desired version -->
     <link rel="stylesheet" href="https://cdn.conversejs.org/11.0.1/dist/converse.min.css">
     <script src="https://cdn.conversejs.org/11.0.1/dist/converse.min.js" charset="utf-8"></script>
 


### PR DESCRIPTION
This adds a warning to the `Host it via your XMPP Server` part of the QuickStart guide, consistent with the warning in the `Using the CDN` section. A configuration example specific to ejabberd is also added to illustrate how to satisfy that warning.

fixes: #3772 