### PR TITLE
Hide reset password tab when authentication is external (Fixes #3719)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - Some fixes regarding manually resized chats in `overlayed` view mode.
 - Replace webpack with [rspack](https://rspack.rs)
 - Registration: Use https://providers.xmpp.net instead of https://compliance.conversations.im
+- Hide password reset tab when external authentication is enabled. (Fixes #3719)
+
 
 ## 11.0.1 (2025-06-09)
 

--- a/src/plugins/profile/templates/password-reset.js
+++ b/src/plugins/profile/templates/password-reset.js
@@ -2,6 +2,10 @@ import { __ } from 'i18n';
 import { html } from 'lit';
 
 export default el => {
+
+      if (el._converse?.authentication === 'external') {
+        return html``;
+    }
     const i18n_submit = __('Submit');
     const i18n_passwords_must_match = __('The new passwords must match');
     const i18n_new_password = __('New password');


### PR DESCRIPTION
Title:
Hide Password Reset tab when external auth is used