### PR TITLE
Hide reset password tab when authentication is external

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - Some fixes regarding manually resized chats in `overlayed` view mode.
 - Replace webpack with [rspack](https://rspack.rs)
 - Registration: Use https://providers.xmpp.net instead of https://compliance.conversations.im
-
+- Fix: Hide reset password tab for external authentication mechanisms. (#3779)
 ## 11.0.1 (2025-06-09)
 
 - #2938: Add a service discovery browser

--- a/src/plugins/profile/utils.js
+++ b/src/plugins/profile/utils.js
@@ -26,16 +26,18 @@ export function getPrettyStatus(stat) {
  */
 export function shouldShowPasswordResetForm() {
     const conn = _converse.api.connection.get();
-    const mechanism = conn._sasl_mechanism;
- console.log('🔍 SASL Mechanism:', mechanism?.mechname, mechanism);
-    if (
-        mechanism.mechname === 'EXTERNAL' ||
-        mechanism.mechname === 'ANONYMOUS' ||
-        mechanism.mechname === 'X-OAUTH2' ||
-        mechanism.mechname === 'OAUTHBEARER'
-    ) {
+    const mechanism = conn?._sasl_mechanism;
+
+    console.log('🔍 SASL Mechanism:', mechanism?.mechname, mechanism);
+
+    if (!mechanism?.mechname) {
+        // Fallback: no mechanism detected
         return false;
     }
-    return true;
+
+    const externalMechs = ['EXTERNAL', 'ANONYMOUS', 'X-OAUTH2', 'OAUTHBEARER'];
+
+    return !externalMechs.includes(mechanism.mechname.toUpperCase());
 }
+
 

--- a/src/plugins/profile/utils.js
+++ b/src/plugins/profile/utils.js
@@ -27,6 +27,7 @@ export function getPrettyStatus(stat) {
 export function shouldShowPasswordResetForm() {
     const conn = _converse.api.connection.get();
     const mechanism = conn._sasl_mechanism;
+ console.log('🔍 SASL Mechanism:', mechanism?.mechname, mechanism);
     if (
         mechanism.mechname === 'EXTERNAL' ||
         mechanism.mechname === 'ANONYMOUS' ||


### PR DESCRIPTION
Updated the shouldShowPasswordResetForm function to correctly hide the reset password tab for external authentication methods.

Hope this fixes the previous implementation issue.

