### PR TITLE
Load avatar data over HTTP if available in vCard EXTVAL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.1 (Unreleased)
+
+- Load avatar data over HTTP if available in vCard EXTVAL
+
 ## 12.0.0 (2025-08-28)
 
 - #3581: Don't unnecessarily regenerate pot and po files

--- a/src/headless/plugins/vcard/parsers.js
+++ b/src/headless/plugins/vcard/parsers.js
@@ -12,6 +12,7 @@ export async function parseVCardResultStanza(iq) {
         fullname: iq.querySelector(':scope > vCard FN')?.textContent,
         image: iq.querySelector(':scope > vCard PHOTO BINVAL')?.textContent,
         image_type: iq.querySelector(':scope > vCard PHOTO TYPE')?.textContent,
+        image_url: iq.querySelector(':scope > vCard PHOTO EXTVAL')?.textContent,
         nickname: iq.querySelector(':scope > vCard NICKNAME')?.textContent,
         role: iq.querySelector(':scope > vCard ROLE')?.textContent,
         stanza: iq, // TODO: remove?
@@ -21,7 +22,10 @@ export async function parseVCardResultStanza(iq) {
         vcard_error: undefined,
         image_hash: undefined,
     };
-    if (result.image) {
+    if (result.image_url) {
+        result['image_url'] = result.image_url;
+    }
+    else if (result.image) {
         const buffer = u.base64ToArrayBuffer(result.image);
         const ab = await crypto.subtle.digest('SHA-1', buffer);
         result['image_hash'] = u.arrayBufferToHex(ab);

--- a/src/headless/plugins/vcard/parsers.js
+++ b/src/headless/plugins/vcard/parsers.js
@@ -10,9 +10,6 @@ export async function parseVCardResultStanza(iq) {
     const result = {
         email: iq.querySelector(':scope > vCard EMAIL USERID')?.textContent,
         fullname: iq.querySelector(':scope > vCard FN')?.textContent,
-        image: iq.querySelector(':scope > vCard PHOTO BINVAL')?.textContent,
-        image_type: iq.querySelector(':scope > vCard PHOTO TYPE')?.textContent,
-        image_url: iq.querySelector(':scope > vCard PHOTO EXTVAL')?.textContent,
         nickname: iq.querySelector(':scope > vCard NICKNAME')?.textContent,
         role: iq.querySelector(':scope > vCard ROLE')?.textContent,
         stanza: iq, // TODO: remove?
@@ -20,15 +17,26 @@ export async function parseVCardResultStanza(iq) {
         vcard_updated: new Date().toISOString(),
         error: undefined,
         vcard_error: undefined,
-        image_hash: undefined,
     };
-    if (result.image_url) {
-        result['image_url'] = result.image_url;
-    }
-    else if (result.image) {
-        const buffer = u.base64ToArrayBuffer(result.image);
+
+    const image = iq.querySelector(':scope > vCard PHOTO BINVAL')?.textContent;
+    const image_type = iq.querySelector(':scope > vCard PHOTO TYPE')?.textContent;
+    const image_url = iq.querySelector(':scope > vCard PHOTO EXTVAL')?.textContent;
+
+    if (image) {
+        const buffer = u.base64ToArrayBuffer(image);
         const ab = await crypto.subtle.digest('SHA-1', buffer);
-        result['image_hash'] = u.arrayBufferToHex(ab);
+
+        Object.assign(result, {
+            image,
+            image_type,
+            image_hash: u.arrayBufferToHex(ab),
+        });
+    }
+    else if (image_url) {
+        Object.assign(result, {
+            image_url,
+        });
     }
     return result;
 }

--- a/src/headless/plugins/vcard/parsers.js
+++ b/src/headless/plugins/vcard/parsers.js
@@ -32,8 +32,7 @@ export async function parseVCardResultStanza(iq) {
             image_type,
             image_hash: u.arrayBufferToHex(ab),
         });
-    }
-    else if (image_url) {
+    } else if (image_url) {
         Object.assign(result, {
             image_url,
         });

--- a/src/headless/plugins/vcard/types.ts
+++ b/src/headless/plugins/vcard/types.ts
@@ -10,6 +10,7 @@ export interface VCardResult {
     image?: string;
     image_hash?: string;
     image_type?: string;
+    image_url?: string;
     nickname?: string;
     role?: string;
     stanza: Element;
@@ -25,6 +26,7 @@ export type VCardData = {
     role?: string;
     email?: string;
     url?: string;
+    image_url?: string;
     image_type?: string;
     image?: string;
 };

--- a/src/headless/plugins/vcard/utils.js
+++ b/src/headless/plugins/vcard/utils.js
@@ -46,7 +46,11 @@ export function onOccupantAvatarChanged(occupant) {
         vcards.push(_converse.state.vcards.get(occupant.get('jid')));
     }
     vcards.push(_converse.state.vcards.get(occupant.get('from')));
-    vcards.forEach((v) => (hash || url) && v && (v?.get('image_hash') !== hash || v?.get('image_url') !== url) && api.vcard.update(v, true));
+    vcards.filter((v) => v).forEach((v) => {
+        if (hash && v.get('image_hash') !== hash || url && v.get('image_url') !== url) {
+            api.vcard.update(v, true);
+        }
+    });
 }
 
 /**

--- a/src/headless/plugins/vcard/utils.js
+++ b/src/headless/plugins/vcard/utils.js
@@ -39,13 +39,14 @@ export function createStanza(type, jid, vcard_el) {
  * @param {MUCOccupant} occupant
  */
 export function onOccupantAvatarChanged(occupant) {
+    const url = occupant.get('image_url');
     const hash = occupant.get('image_hash');
     const vcards = [];
     if (occupant.get('jid')) {
         vcards.push(_converse.state.vcards.get(occupant.get('jid')));
     }
     vcards.push(_converse.state.vcards.get(occupant.get('from')));
-    vcards.forEach((v) => hash && v && v?.get('image_hash') !== hash && api.vcard.update(v, true));
+    vcards.forEach((v) => hash && v && (v?.get('image_url') !== url || v?.get('image_hash') !== hash) && api.vcard.update(v, true));
 }
 
 /**

--- a/src/headless/plugins/vcard/utils.js
+++ b/src/headless/plugins/vcard/utils.js
@@ -39,14 +39,14 @@ export function createStanza(type, jid, vcard_el) {
  * @param {MUCOccupant} occupant
  */
 export function onOccupantAvatarChanged(occupant) {
-    const url = occupant.get('image_url');
     const hash = occupant.get('image_hash');
+    const url = occupant.get('image_url');
     const vcards = [];
     if (occupant.get('jid')) {
         vcards.push(_converse.state.vcards.get(occupant.get('jid')));
     }
     vcards.push(_converse.state.vcards.get(occupant.get('from')));
-    vcards.forEach((v) => hash && v && (v?.get('image_url') !== url || v?.get('image_hash') !== hash) && api.vcard.update(v, true));
+    vcards.forEach((v) => (hash || url) && v && (v?.get('image_hash') !== hash || v?.get('image_url') !== url) && api.vcard.update(v, true));
 }
 
 /**

--- a/src/shared/avatar/avatar.js
+++ b/src/shared/avatar/avatar.js
@@ -42,7 +42,7 @@ export default class Avatar extends CustomElement {
             image = this.model?.vcard?.get('image');
         }
 
-        if (image_type && (image_url || image || data_uri)) {
+        if ((image_type && (image || data_uri)) || (image_url)) {
             return tplAvatar({
                 classes: this.getAttribute('class'),
                 height: this.height,

--- a/src/shared/avatar/avatar.js
+++ b/src/shared/avatar/avatar.js
@@ -29,6 +29,7 @@ export default class Avatar extends CustomElement {
     }
 
     render() {
+        let image_url;
         let image_type;
         let image;
         let data_uri;
@@ -36,16 +37,17 @@ export default class Avatar extends CustomElement {
             image_type = this.pickerdata.image_type;
             data_uri = this.pickerdata.data_uri;
         } else {
+            image_url = this.model?.vcard?.get('image_url');
             image_type = this.model?.vcard?.get('image_type');
             image = this.model?.vcard?.get('image');
         }
 
-        if (image_type && (image || data_uri)) {
+        if (image_type && (image_url || image || data_uri)) {
             return tplAvatar({
                 classes: this.getAttribute('class'),
                 height: this.height,
                 width: this.width,
-                image: data_uri || `data:${image_type};base64,${image}`,
+                image: image_url || data_uri || `data:${image_type};base64,${image}`,
                 image_type,
                 alt_text: __('The profile picture of %1$s', this.name),
             });

--- a/src/shared/avatar/templates/avatar.js
+++ b/src/shared/avatar/templates/avatar.js
@@ -2,9 +2,9 @@ import { html, nothing } from 'lit';
 
 /**
  * @param {string} image
- * @param {string} image_type
+ * @param {string} [image_type]
  */
-const getImgHref = (image, image_type) => {
+function getImgHref(image, image_type) {
     if (image.startsWith('https:') || image.startsWith('data:')) {
         return image;
     }

--- a/src/shared/avatar/templates/avatar.js
+++ b/src/shared/avatar/templates/avatar.js
@@ -7,8 +7,7 @@ import { html, nothing } from 'lit';
 function getImgHref(image, image_type) {
     if (image.startsWith('https:') || image.startsWith('data:')) {
         return image;
-    }
-    else {
+    } else {
         return `data:${image_type};base64,${image}`;
     }
 };

--- a/src/shared/avatar/templates/avatar.js
+++ b/src/shared/avatar/templates/avatar.js
@@ -5,7 +5,12 @@ import { html, nothing } from 'lit';
  * @param {string} image_type
  */
 const getImgHref = (image, image_type) => {
-    return image.startsWith('data:') ? image : `data:${image_type};base64,${image}`;
+    if (image.startsWith('https:') || image.startsWith('data:')) {
+        return image;
+    }
+    else {
+        return `data:${image_type};base64,${image}`;
+    }
 };
 
 export default (o) => {


### PR DESCRIPTION
Its possible to point the user avatar to a URL address and store it in PEP. It then becomes accessible from vcard-temp in the EXTVAL tag.

The same can be done with MUC avatars by setting the EXTVAL tag with the url, but this is not oficially supported by XEP-0486.

Edit: I think handleVCardUpdatePresence() in src/headless/plugins/vcard/utils.js should be modified, but i'm not sure if its only needed for the binary avatars or not since i'm not too familiar with Javascript or Sizzle. Seems to function fine without any changes to it however.