### PR TITLE
Add proper native bookmarks deletion

### DIFF
--- a/src/headless/types/plugins/bookmarks/collection.d.ts
+++ b/src/headless/types/plugins/bookmarks/collection.d.ts
@@ -25,6 +25,11 @@ declare class Bookmarks extends Collection {
      */
     setBookmark(attrs: import("./types").BookmarkAttrs, create?: boolean, options?: object): void;
     /**
+     * @param {Bookmark} bookmark
+     * @returns {Promise<void|Element>}
+     */
+    removeBookmarkStanza(bookmark: Bookmark): Promise<void | Element>;
+    /**
      * @param {'urn:xmpp:bookmarks:1'|'storage:bookmarks'} node
      * @param {Bookmark} bookmark
      * @returns {Stanza|Stanza[]}


### PR DESCRIPTION
This PR addresses an issue where the old bookmark deletion function was incorrectly adding empty bookmarks to user's PubSub service.  This was due to an invalid `item` used for deletion and a type mismatch in the `getPublishedItems` function.  This change ensures proper bookmark deletion when the server adheres to XEP-0402.

Related issue: https://github.com/conversejs/converse.js/issues/3815

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [x] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.