### PR TITLE
Fix missing room display name when a room has no specified name

### DIFF
--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -1281,6 +1281,7 @@ class MUC extends ModelWithVCard(ModelWithMessages(ColorAwareModel(ChatBoxBase))
             this.save({ name: identity.get('name') });
         } else {
             log.error(`No identity or name found for ${this.get('jid')}`);
+            this.save({ name: this.get('jid') });
         }
         await this.getDiscoInfoFields();
         await this.getDiscoInfoFeatures();


### PR DESCRIPTION
This pull request addresses a bug that occurs when a room initially lacks a name. After logging out and logging back, the room's name displayed in bookmarks will show as `nothing` due to how the bookmark data was uploaded to the server. 

The `getDisplayName` function doesn't check if the room’s name is still missing when a bookmark is created. The `get()` method always returns a string, so there's no automatic fallback to JID.

I don't think it's the only way to solve this issue, but look like the easiest one.

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [x] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.