### PR TITLE
Fix documentation formatting in security.rst

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - #3769: Various OMEMO fixes
 - #3791: Fetching pubsub node configuration fails
 - #3792: Node reconfiguration attempt uses incorrect field names
+- Fix documentation formatting in security.rst
 - Add approval banner in chats with requesting contacts or unsaved contacts
 - Add mongolian as a language option
 - Breaking: `Strophe.shims` has been removed. Instead, just use the globals.

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -51,7 +51,7 @@ Restrict access to private code/data
     the omitted plugins should also be removed from the whitelist, otherwise
     malicious plugins could be registered under their names.
 
-Addititional measures
+Additional measures
 =====================
 
 Besides the measures mentioned above, integrators and hosts can also take

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -52,7 +52,7 @@ Restrict access to private code/data
     malicious plugins could be registered under their names.
 
 Additional measures
-=====================
+===================
 
 Besides the measures mentioned above, integrators and hosts can also take
 further security precautions.


### PR DESCRIPTION
This PR addresses a minor documentation formatting issue in the security.rst file. The change ensures proper underline length for section headers to match reStructuredText standards.

- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
