### PR TITLE
Allow plain text paste by holding shift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- #3829: Rich text from LibreOffice Calc is sent as screenshots
 - #3830: The message textarea blocks undo of the pasted text
 
 ## 12.0.0 (2025-08-28)

--- a/src/plugins/chatview/message-form.js
+++ b/src/plugins/chatview/message-form.js
@@ -20,6 +20,7 @@ export default class MessageForm extends CustomElement {
     constructor() {
         super();
         this.model = null;
+        this.shiftDown = false;
     }
 
     async initialize() {
@@ -102,6 +103,10 @@ export default class MessageForm extends CustomElement {
      * @param {ClipboardEvent} ev
      */
     onPaste(ev) {
+        if (this.shiftDown) {
+            return;
+        }
+
         if (ev.clipboardData.files.length !== 0) {
             ev.stopPropagation();
             ev.preventDefault();
@@ -125,6 +130,11 @@ export default class MessageForm extends CustomElement {
      * @param {KeyboardEvent} ev
      */
     onKeyUp(ev) {
+        const { keycodes } = converse;
+        if (ev.key === keycodes.SHIFT) {
+            this.shiftDown = false;
+        }
+
         // Trigger an event, for `<converse-message-limit-indicator/>`
         this.model.trigger('event:keyup', { ev });
     }
@@ -134,6 +144,10 @@ export default class MessageForm extends CustomElement {
      */
     onKeyDown(ev) {
         const { keycodes } = converse;
+        if (ev.key === keycodes.SHIFT) {
+            this.shiftDown = true;
+        }
+
         if (
             ev.ctrlKey ||
             (ev.shiftKey && ev.key === keycodes.ENTER) ||

--- a/src/plugins/chatview/tests/message-form.js
+++ b/src/plugins/chatview/tests/message-form.js
@@ -3,6 +3,69 @@ const { sizzle, u } = converse.env;
 
 describe('A message form', function () {
     it(
+        'pastes files.',
+        mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+            const textarea = view.querySelector('textarea.chat-textarea');
+
+            const clipboardData = new DataTransfer();
+            clipboardData.items.add(new File(['test'], 'test.txt', { type: 'text/plain' }));
+
+            // Create a paste event with clipboard data
+            const pasteEvent = new ClipboardEvent('paste', {
+                bubbles: true,
+                cancelable: true,
+                clipboardData,
+            });
+
+            // Dispatch the paste event
+            textarea.dispatchEvent(pasteEvent);
+            expect(pasteEvent.defaultPrevented).toBe(true);
+        }),
+    );
+
+    it(
+        'does not paste file if shift is pressed',
+        mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+            const textarea = view.querySelector('textarea.chat-textarea');
+
+            const keyDownEvent = new KeyboardEvent('keydown', {
+                key: 'Shift',
+            });
+
+            textarea.dispatchEvent(keyDownEvent);
+
+            const clipboardData = new DataTransfer();
+            clipboardData.items.add(new File(['test'], 'test.txt', { type: 'text/plain' }));
+
+            // Create a paste event with clipboard data
+            const pasteEvent = new ClipboardEvent('paste', {
+                bubbles: true,
+                cancelable: true,
+                clipboardData,
+            });
+
+            // Dispatch the paste event
+            textarea.dispatchEvent(pasteEvent);
+
+            const keyUpEvent = new KeyboardEvent('keyup', {
+                key: 'Shift',
+            });
+
+            textarea.dispatchEvent(keyUpEvent);
+
+            expect(pasteEvent.defaultPrevented).toBe(false);
+        }),
+    );
+
+    it(
         'allows native paste if no files',
         mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
             await mock.waitForRoster(_converse, 'current', 1);


### PR DESCRIPTION
This provides a possible fix for #3829 by skipping the check for files when pasting if the shift key was pressed prior to the paste event.

- [x] Add a changelog entry for your change in `CHANGES.md`
- [x] Please add a test for your change. 