### PR TITLE
Shift unescapeHTML util function to headless

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - #3829: Rich text from LibreOffice Calc is sent as screenshots
 - #3830: The message textarea blocks undo of the pasted text
+- #3863: Shift `unescapeHTML` helper function (used to set `isOnlyEmoji` on a message) to converse-headless
 
 ## 12.0.0 (2025-08-28)
 

--- a/src/headless/plugins/emoji/utils.js
+++ b/src/headless/plugins/emoji/utils.js
@@ -1,4 +1,5 @@
 import { ASCII_REPLACE_REGEX, CODEPOINTS_REGEX } from './regexes.js';
+import { unescapeHTML } from '../../utils/html.js';
 import converse from '../../shared/api/public.js';
 
 const { u } = converse.env;
@@ -86,11 +87,11 @@ function convert (unicode) {
 export function convertASCII2Emoji (str) {
     // Replace ASCII smileys
     return str.replace(ASCII_REPLACE_REGEX, (entire, _, m2, m3) => {
-        if( (typeof m3 === 'undefined') || (m3 === '') || (!(u.unescapeHTML(m3) in ASCII_LIST)) ) {
+        if( (typeof m3 === 'undefined') || (m3 === '') || (!(unescapeHTML(m3) in ASCII_LIST)) ) {
             // if the ascii doesn't exist just return the entire match
             return entire;
         }
-        m3 = u.unescapeHTML(m3);
+        m3 = unescapeHTML(m3);
         const unicode = ASCII_LIST[m3].toUpperCase();
         return m2+convert(unicode);
     });

--- a/src/headless/utils/html.js
+++ b/src/headless/utils/html.js
@@ -136,3 +136,15 @@ export function decodeHTMLEntities(str) {
     }
     return str;
 }
+
+/**
+ * Helper method that replace HTML-escaped symbols with equivalent characters
+ * (e.g. transform occurrences of '&amp;' to '&')
+ * @param {string} string - a String containing the HTML-escaped symbols.
+ * @return {string}
+ */
+export function unescapeHTML (string) {
+    var div = document.createElement('div');
+    div.innerHTML = string;
+    return div.innerText;
+}

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -199,17 +199,6 @@ function nextUntil (el, selector) {
 }
 
 /**
- * Helper method that replace HTML-escaped symbols with equivalent characters
- * (e.g. transform occurrences of '&amp;' to '&')
- * @param {String} string - a String containing the HTML-escaped symbols.
- */
-function unescapeHTML (string) {
-    var div = document.createElement('div');
-    div.innerHTML = string;
-    return div.innerText;
-}
-
-/**
  * @param {string} string
  */
 function escapeHTML (string) {
@@ -486,7 +475,6 @@ Object.assign(u, {
     showElement,
     slideIn,
     slideOut,
-    unescapeHTML,
     xFormField2TemplateResult,
 });
 


### PR DESCRIPTION
The function is only used inside of there (by the emoji plugin). Fixes #3863