### PR TITLE
Adding support for protocol handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,14 +102,15 @@ before the server's replay of queued stanzas is handled.
 - #3023: Fix empty roster group name treated as a valid group instead of "Ungrouped"
 - #3382: Fix audio player accessibility for screen reader users (NVDA, JAWS)
 - #3502: Fix custom emoji shortnames overlapping with built-in emoji shortnames
-- #3815: Removal of bookmark leads to new b
+- #3815: Removal of bookmark leads to new bookmark named `Symbol(lit-nothing)`
+- #3889: MUC join: Use room jids localpart as name in case name or identity not found
+- #3824: Dates and times are not translated
 - #3829: Rich text from LibreOffice Calc is sent as screenshots
 - #3830: The message textarea blocks undo of the pasted text
 - #3839: Fix contacts menu displayed off-screen in fullscreen mode
 - #3863: Shift `unescapeHTML` helper function (used to set `isOnlyEmoji` on a message) to converse-headless
 - #3885: Don't show contact approval alerts when `allow_contact_requests` is false (e.g. anonymous mode)
 - #3886: Don't show OMEMO padlock icon when libsignal is not available (e.g. anonymous mode)
-- #3889: MUC join: Use room jids localpart as name in case name or identity not found
 - #3710: Fix autocomplete adding a trailing space when selecting a group name with the mouse
 - #3916: Add support for XEP-0461 Message Replies, allowing users to reply to specific messages
 - #3939: Don't show invitations to groupchats in which the user is already present
@@ -128,6 +129,7 @@ before the server's replay of queued stanzas is handled.
 - #3769: Various OMEMO fixes
 - #3791: Fetching pubsub node configuration fails
 - #3792: Node reconfiguration attempt uses incorrect field names
+- Adds support for opening XMPP URIs in Converse and for XEP-0147 query actions
 - Fix documentation formatting in security.rst
 - Add approval banner in chats with requesting contacts or unsaved contacts
 - Add mongolian as a language option

--- a/conversejs.doap
+++ b/conversejs.doap
@@ -130,6 +130,15 @@
     </implements>
     <implements>
       <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0147.html"/>
+        <xmpp:status>partial</xmpp:status>
+        <xmpp:version>1.2</xmpp:version>
+        <xmpp:since>14.0.0</xmpp:since>
+        <xmpp:note>Supports XMPP URI scheme with query actions for message and roster management</xmpp:note>
+      </xmpp:SupportedXep>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0153.html"/>
         <xmpp:since>11.0.0</xmpp:since>
         <xmpp:status>complete</xmpp:status>

--- a/manifest.json
+++ b/manifest.json
@@ -26,5 +26,11 @@
   "background_color": "#397491",
   "display": "standalone",
   "scope": "/",
-  "theme_color": "#397491"
+  "theme_color": "#397491",
+  "protocol_handlers": [
+    {
+      "protocol": "xmpp",
+      "url": "#converse/action?uri=%s"
+    }
+  ]
 }

--- a/src/apps/chat/index.js
+++ b/src/apps/chat/index.js
@@ -6,7 +6,7 @@ import { html } from 'lit';
 import { _converse, api, constants, converse } from '@converse/headless';
 import './view.js';
 import ChatBoxViews from './container.js';
-import { calculateViewportHeightUnit } from './utils.js';
+import { calculateViewportHeightUnit, routeToQueryAction } from './utils.js';
 import 'plugins/rootview/index.js';
 
 import './styles/chats.scss';
@@ -61,6 +61,14 @@ converse.plugins.add('converse-app-chat', {
         api.listen.on('cleanup', () => delete _converse.state.chatboxviews);
         api.listen.on('clearSession', () => chatboxviews.closeAllChatBoxes());
         api.listen.on('chatBoxViewsInitialized', calculateViewportHeightUnit);
+        
+        // Handle XEP-0147 query actions for chatboxes
+        api.listen.on('xmppURIAction', ({ jid, query_params, action }) => {
+            // Handle actions that apply to chatboxes (both 1:1 and MUC)
+            if (action === 'message' || !action) {
+                routeToQueryAction(jid, query_params, action);
+            }
+        });
 
         window.addEventListener('resize', calculateViewportHeightUnit);
         /************************ END Event Handlers ************************/

--- a/src/apps/chat/utils.js
+++ b/src/apps/chat/utils.js
@@ -1,5 +1,56 @@
+import { api } from '@converse/headless';
+import log from '@converse/log';
 
 export function calculateViewportHeightUnit () {
     const vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
+}
+
+/**
+ * Handle XEP-0147 "query actions" for chatboxes (both 1:1 and MUC).
+ * This function is called by the chatview plugin's routeToQueryAction.
+ * Handles:
+ *   - No action: opens a chat
+ *   - action=message: opens a chat and sends a message
+ *
+ * @param {string} jid - The JID to open a chat with
+ * @param {URLSearchParams} query_params - Query parameters from the URI
+ */
+export async function routeToQueryAction(jid, query_params, action) {
+
+    try {
+        await api.waitUntil('chatBoxesFetched');
+    } catch (e) {
+        log.error('routeToQueryAction: Timeout waiting for chatBoxesFetched');
+        return;
+    }
+
+    if (!action) {
+        // No action specified, just open the chat
+        log.debug(`routeToQueryAction (chatboxviews): Opening chat for "${jid}"`);
+        return api.chats.open(jid, {}, true);
+    }
+
+    if (action === 'message') {
+        await handleMessageAction(jid, query_params);
+    } else {
+        // Other actions are not handled by this plugin
+        log.debug(`routeToQueryAction (chatboxviews): Action "${action}" not handled`);
+    }
+}
+
+/**
+ * Handles the `action=message` case.
+ * Opens a chat and sends a message if a body is provided.
+ *
+ * @param {string} jid - The JID to send a message to
+ * @param {URLSearchParams} params - Query parameters including 'body'
+ */
+async function handleMessageAction(jid, params) {
+    const body = params.get('body') || '';
+    if (body) {
+        await api.chats.open(jid, { draft: body }, true);
+    } else {
+        await api.chats.open(jid, {}, true);
+    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { CustomElement } from 'shared/components/element.js';
 import { VIEW_PLUGINS } from './shared/constants.js';
 import { _converse, converse } from '@converse/headless';
 import './utils/index.js';
+import { routeToQueryAction } from './plugins/chatview/utils.js';
 
 _converse.__ = i18n.__; // DEPRECATED
 Object.assign(converse.env, { i18n });
@@ -55,6 +56,16 @@ import './plugins/reactions-views/index.js'; // XEP-0444 Reactions
 
 _converse.exports.CustomElement = CustomElement;
 
+// Register XMPP protocol handler for xmpp: URIs
+if ('registerProtocolHandler' in navigator) {
+    try {
+        const handlerUrl = `${window.location.origin}${window.location.pathname}#converse/action?uri=%s`;
+        navigator.registerProtocolHandler('xmpp', handlerUrl);
+    } catch (error) {
+        console.warn('Failed to register protocol handler:', error);
+    }
+}
+
 const initialize = converse.initialize;
 
 converse.initialize = function (settings, callback) {
@@ -63,7 +74,13 @@ converse.initialize = function (settings, callback) {
     } else {
         settings.whitelisted_plugins = VIEW_PLUGINS;
     }
-    return initialize(settings, callback);
+    // Handle XEP-0147 query actions after initialization
+    // This must happen after plugins are loaded and _converse.env is ready
+    const result = initialize(settings, callback);
+    if (result && result.then) {
+        result.then(() => routeToQueryAction());
+    }
+    return result;
 };
 
 window['converse'] = converse;

--- a/src/plugins/chatboxviews/tests/query-actions.js
+++ b/src/plugins/chatboxviews/tests/query-actions.js
@@ -1,0 +1,120 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
+
+describe("XMPP URI Query Actions (XEP-0147) - ChatBoxes", function () {
+
+    /**
+     * Test the core functionality: opening a chat when no action is specified
+     * This tests the basic URI parsing and chat opening behavior
+     */
+    it("opens a chat when URI has no action parameter",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        // Wait for roster to be initialized so we can open chats
+        await mock.waitForRoster(_converse, 'current', 1);
+
+        // Save original globals to restore them later
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        // Spy on history.replaceState to verify URL cleanup
+        const replaceStateSpy = jasmine.createSpy('replaceState');
+        window.history.replaceState = replaceStateSpy;
+
+        // Simulate a protocol handler URI by setting the hash
+        window.location.hash = '#converse/action?uri=xmpp%3Aromeo%40montague.lit';
+
+        try {
+            // Call the function - this should parse URI and open chat
+            await u.routeToQueryAction();
+
+            // Verify that the URL was cleaned up (protocol handler removes ?uri=...)
+            const expected_url = `${window.location.origin}${window.location.pathname}`;
+            expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, expected_url);
+
+            // Wait for and verify that a chatbox was created
+            await u.waitUntil(() => _converse.chatboxes.get('romeo@montague.lit'));
+            const chatbox = _converse.chatboxes.get('romeo@montague.lit');
+            expect(chatbox).toBeDefined();
+            expect(chatbox.get('jid')).toBe('romeo@montague.lit');
+        } finally {
+            // Restore original globals to avoid test pollution
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+
+    /**
+     * Test message sending functionality when action=message
+     * This tests URI parsing, chat opening, and message sending
+     */
+    it("sends a message when action=message with body",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        await mock.waitForRoster(_converse, 'current', 1);
+
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        window.history.replaceState = jasmine.createSpy('replaceState');
+
+        // Mock URI with message action
+        window.location.hash = '#converse/action?uri=xmpp%3Aromeo%40montague.lit%3Fmessage%3Bbody%3DHello';
+
+        try {
+            // Execute the function
+            await u.routeToQueryAction();
+
+            // Verify chat was opened
+            await u.waitUntil(() => _converse.chatboxes.get('romeo@montague.lit'));
+            const chatbox = _converse.chatboxes.get('romeo@montague.lit');
+            expect(chatbox).toBeDefined();
+
+            // Verify message body was set as a draft
+            expect(chatbox.get('draft')).toBe('Hello');
+        } finally {
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+
+    /**
+     * Test handling of invalid JIDs
+     * This ensures the function gracefully handles malformed JIDs
+     */
+    it("handles invalid JID gracefully",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        await mock.waitForRoster(_converse, 'current', 1);
+
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        window.history.replaceState = jasmine.createSpy('replaceState');
+
+        // Mock URI with invalid JID (missing domain)
+        window.location.hash = '#converse/action?uri=xmpp%3Ainvalid-jid';
+
+        try {
+            // Spy on api.chats.open to ensure it's NOT called for invalid JID
+            spyOn(api.chats, 'open');
+
+            // Execute the function
+            await u.routeToQueryAction();
+
+            // Verify that no chat was opened for the invalid JID
+            expect(api.chats.open).not.toHaveBeenCalled();
+
+            // Verify no chatbox was created
+            expect(_converse.chatboxes.get('invalid-jid')).toBeUndefined();
+        } finally {
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+});

--- a/src/plugins/chatview/tests/query-actions.js
+++ b/src/plugins/chatview/tests/query-actions.js
@@ -1,0 +1,113 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
+
+describe("XMPP URI Query Actions (XEP-0147) - URI Parsing", function () {
+
+    /**
+     * Test URI extraction and parsing functionality
+     * This tests the extractXMPPURI and parseXMPPURI functions
+     */
+    it("extracts and parses XMPP URI correctly",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        // Spy on history.replaceState to verify URL cleanup
+        const replaceStateSpy = jasmine.createSpy('replaceState');
+        window.history.replaceState = replaceStateSpy;
+
+        // Simulate a protocol handler URI by setting the hash
+        window.location.hash = '#converse/action?uri=xmpp%3Aromeo%40montague.lit%3Fmessage%3Bbody%3DHello';
+
+        try {
+            // Call the function - this should extract and parse the URI
+            await u.routeToQueryAction();
+
+            // Verify that the URL was cleaned up (protocol handler removes ?uri=...)
+            const expected_url = `${window.location.origin}${window.location.pathname}`;
+            expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, expected_url);
+        } finally {
+            // Restore original globals to avoid test pollution
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+
+    /**
+     * Test that routeToQueryAction triggers xmppURIAction event
+     * This tests the event-based delegation to plugin-specific handlers
+     */
+    it("triggers xmppURIAction event with parsed data",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        window.history.replaceState = jasmine.createSpy('replaceState');
+
+        // Track if the event was triggered with correct data
+        let eventTriggered = false;
+        let eventData = null;
+
+        api.listen.on('xmppURIAction', (data) => {
+            eventTriggered = true;
+            eventData = data;
+        });
+
+        // Mock URI with message action
+        window.location.hash = '#converse/action?uri=xmpp%3Aromeo%40montague.lit%3Fmessage%3Bbody%3DHello';
+
+        try {
+            // Execute the function
+            await u.routeToQueryAction();
+
+            // Verify that xmppURIAction event was triggered
+            expect(eventTriggered).toBe(true);
+            expect(eventData.jid).toBe('romeo@montague.lit');
+            expect(eventData.action).toBe('message');
+            expect(eventData.query_params.get('body')).toBe('Hello');
+        } finally {
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+
+    /**
+     * Test handling of invalid JIDs in URI parsing
+     * This ensures the function gracefully handles malformed JIDs
+     */
+    it("handles invalid JID gracefully and does not trigger event",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        window.history.replaceState = jasmine.createSpy('replaceState');
+
+        // Track if the event was triggered
+        let eventTriggered = false;
+
+        api.listen.on('xmppURIAction', () => {
+            eventTriggered = true;
+        });
+
+        // Mock URI with invalid JID (missing domain)
+        window.location.hash = '#converse/action?uri=xmpp%3Ainvalid-jid';
+
+        try {
+            // Execute the function
+            await u.routeToQueryAction();
+
+            // Verify that xmppURIAction event was NOT triggered for invalid JID
+            expect(eventTriggered).toBe(false);
+        } finally {
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+});

--- a/src/plugins/chatview/utils.js
+++ b/src/plugins/chatview/utils.js
@@ -1,5 +1,7 @@
 import { __ } from 'i18n';
-import { _converse, api } from '@converse/headless';
+import { _converse, api,u } from '@converse/headless';
+import log from "@converse/log";
+
 
 export function clearHistory (jid) {
     if (location.hash === `converse/chat?jid=${jid}`) {
@@ -71,3 +73,85 @@ export function resetElementHeight (ev) {
         ev.target.style = '';
     }
 }
+
+
+/**
+ * Handle XEP-0147 "query actions" invoked via xmpp: URIs.
+ * Extracts URI from window location, parses it, and triggers xmppURIAction event
+ * for plugin-specific handling via api.listen.
+ *
+ * @param {Event} [event] - Optional event object (used when called as protocol handler)
+ * @returns {Promise<void>}
+ * @example
+ * // Automatically called on initialization in src/index.js
+ * // Can be called manually after location.hash changes:
+ * window.location.hash = '#converse/action?uri=xmpp%3Auser%40example.com';
+ * await routeToQueryAction();
+ */
+export async function routeToQueryAction(event) {
+    const { u } = _converse.env;
+
+    const uri = extractXMPPURI(event);
+    if (!uri) return;
+
+    const { jid, action, query_params } = parseXMPPURI(uri);
+    if (!u.isValidJID(jid)) {
+        return log.warn(`routeToQueryAction: Invalid JID: "${jid}"`);
+    }
+    
+    // Trigger event to let specific plugins handle plugin-specific actions
+    api.trigger('xmppURIAction', { jid, query_params, action });
+}
+
+/**
+ * Extracts and decodes the xmpp: URI from the window location or hash.
+ */
+export function extractXMPPURI(event) {
+    let uri = null;
+    // hash-based (#converse/action?uri=...)
+    if (location.hash.startsWith('#converse/action?uri=')) {
+        event?.preventDefault();
+        uri = location.hash.split('#converse/action?uri=').pop();
+    }
+
+    if (!uri) return null;
+
+    // Decode URI and remove xmpp: prefix
+    uri = decodeURIComponent(uri);
+    if (uri.startsWith('xmpp:')) uri = uri.slice(5);
+
+    // Clean up URL (remove ?uri=... for a clean view)
+    const clean_url = `${window.location.origin}${window.location.pathname}`;
+    window.history.replaceState({}, document.title, clean_url);
+
+    return uri;
+}
+
+/**
+ * Splits an xmpp: URI into a JID, an action (querytype), and query parameters.
+ * XEP-0147 query parameters are separated by ';' instead of '&'.
+ */
+export function parseXMPPURI(uri) {
+    const [jid, query] = uri.split('?');
+    let action = null;
+    const query_params = new URLSearchParams();
+
+    if (query) {
+        const parts = query.split(';');
+        if (parts.length > 0) {
+            action = parts[0]; // The first part is the action (e.g., 'roster')
+            for (let i = 1; i < parts.length; i++) {
+                const [key, value] = parts[i].split('=');
+                if (key) {
+                    query_params.set(key, value ? decodeURIComponent(value) : '');
+                }
+            }
+        }
+    }
+    
+    return { jid, action, query_params };
+}
+
+Object.assign(u,{
+    routeToQueryAction,
+})

--- a/src/plugins/muc-views/index.js
+++ b/src/plugins/muc-views/index.js
@@ -4,6 +4,7 @@
  * @license Mozilla Public License (MPLv2)
  */
 import { api, converse, constants } from '@converse/headless';
+import { __ } from 'i18n';
 import './affiliation-form.js';
 import './role-form.js';
 import MUCView from './muc.js';
@@ -84,5 +85,22 @@ converse.plugins.add('converse-muc-views', {
 
         api.listen.on('parseMessageForCommands', parseMessageForMUCCommands);
         api.listen.on('confirmDirectMUCInvitation', confirmDirectMUCInvitation);
-    },
+
+        api.listen.on('xmppURIAction', async ({ jid, query_params, action }) => {
+            if (action === 'join') {
+                const attrs = {};
+                // As per XEP-0147, the 'password' parameter maps to 'password'
+                if (query_params.has('password')) {
+                    attrs.password = query_params.get('password');
+                }
+
+                try {
+                    await api.waitUntil('chatBoxesFetched');
+                    await api.rooms.open(jid, attrs, true);
+                } catch (err) {
+                    api.alert('error', __('Error'), [__('Failed to join the room %1$s', jid)]);
+                }
+            }
+        });
+    }
 });

--- a/src/plugins/muc-views/tests/query-actions.js
+++ b/src/plugins/muc-views/tests/query-actions.js
@@ -1,0 +1,27 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
+
+describe("XMPP URI Query Actions (XEP-0147) - MUC", function () {
+
+    describe("Join Action", function () {
+
+        it("triggers xmppURIAction event and opens room",
+            mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+            const { api } = _converse;
+            const jid = 'room@conference.example.com';
+            
+            // Spy on api.rooms.open
+            spyOn(api.rooms, 'open').and.callFake(() => Promise.resolve());
+
+            window.location.hash = `#converse/action?uri=xmpp:${jid}?join;password=secret`;
+
+            // Wait for routing
+            await u.routeToQueryAction();
+
+            expect(api.rooms.open).toHaveBeenCalledWith(jid, { password: 'secret' }, true);
+        }));
+    });
+});

--- a/src/plugins/rosterview/index.js
+++ b/src/plugins/rosterview/index.js
@@ -4,8 +4,8 @@
  */
 import { _converse, api, converse, RosterFilter } from '@converse/headless';
 import RosterContactView from './contactview.js';
-import { clearXMPPProvidersCache, highlightRosterItem } from './utils.js';
 import '../modal/index.js';
+import { clearXMPPProvidersCache, highlightRosterItem, handleRosterURIAction } from './utils.js';
 import AddContactModal from './modals/add-contact.js';
 import AcceptContactRequestModal from './modals/accept-contact-request.js';
 import NewChatModal from './modals/new-chat.js';
@@ -47,6 +47,15 @@ converse.plugins.add('converse-rosterview', {
         api.listen.on('chatBoxesInitialized', () => {
             _converse.state.chatboxes.on('destroy', (c) => highlightRosterItem(c.get('jid')));
             _converse.state.chatboxes.on('change:hidden', (c) => highlightRosterItem(c.get('jid')));
+        });
+        
+        // Handle XEP-0147 query actions for roster management
+        api.listen.on('xmppURIAction', ({ jid, query_params, action }) => {
+            // Handle roster and subscription actions
+            const handledActions = ['roster', 'remove', 'subscribe', 'unsubscribe'];
+            if (handledActions.includes(action)) {
+                handleRosterURIAction(action, jid, query_params);
+            }
         });
     },
 });

--- a/src/plugins/rosterview/tests/query-actions.js
+++ b/src/plugins/rosterview/tests/query-actions.js
@@ -1,0 +1,49 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
+
+describe("XMPP URI Query Actions (XEP-0147) - Roster", function () {
+
+    /**
+     * Test roster add functionality when action=roster
+     * This tests URI parsing and adding a contact to the roster
+     */
+    it("adds a contact to roster when action=roster",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+
+        const { api } = _converse;
+        await mock.waitForRoster(_converse, 'current', 1);
+
+        const originalHash = window.location.hash;
+        const originalReplaceState = window.history.replaceState;
+
+        window.history.replaceState = jasmine.createSpy('replaceState');
+
+        // Mock URI with roster action: ?roster;name=Juliet;group=Friends
+        window.location.hash = '#converse/action?uri=xmpp%3Ajuliet%40capulet.lit%3Froster%3Bname%3DJuliet%3Bgroup%3DFriends';
+
+        try {
+            // Spy on the contacts.add API method - return a resolved promise to avoid network calls
+            spyOn(api.contacts, 'add').and.returnValue(Promise.resolve());
+
+            // Execute the function
+            await u.routeToQueryAction();
+
+            // Verify that contacts.add was called with correct parameters
+            expect(api.contacts.add).toHaveBeenCalledWith(
+                {
+                    jid: 'juliet@capulet.lit',
+                    name: 'Juliet',
+                    groups: ['Friends']
+                },
+                true,  // persist on server
+                false, // subscribe to presence
+                ''     // no custom message
+            );
+        } finally {
+            window.location.hash = originalHash;
+            window.history.replaceState = originalReplaceState;
+        }
+    }));
+});

--- a/src/plugins/rosterview/utils.js
+++ b/src/plugins/rosterview/utils.js
@@ -490,3 +490,93 @@ Object.assign(u, {
         getNamesAutoCompleteList,
     },
 });
+
+/**
+ * Handle XEP-0147 "query actions" for roster management and subscription.
+ * Handles:
+ *   - action=roster: adds or edits a contact in the roster
+ *   - action=remove: removes a contact from the roster
+ *   - action=subscribe: subscribes to a contact's presence
+ *   - action=unsubscribe: unsubscribes from a contact's presence
+ *
+ * @param {string} action - The XEP-0147 querytype
+ * @param {string} jid - The JID to perform the action on
+ * @param {URLSearchParams} query_params - Additional query parameters from the URI
+ */
+export async function handleRosterURIAction(action, jid, query_params) {
+    if (action === 'roster') {
+        await handleRosterAddOrEdit(jid, query_params);
+    } else if (action === 'remove') {
+        await handleRosterRemove(jid);
+    } else if (action === 'subscribe') {
+        await handleRosterSubscribe(jid);
+    } else if (action === 'unsubscribe') {
+        await handleRosterUnsubscribe(jid);
+    } else {
+        log.debug(`handleRosterURIAction (rosterview): Action "${action}" not handled`);
+    }
+}
+
+/**
+ * Handles the `roster` action (adding or editing a contact).
+ * @param {string} jid - The JID of the contact
+ * @param {URLSearchParams} params - Query parameters including 'name' and 'group'
+ */
+async function handleRosterAddOrEdit(jid, params) {
+    const name = params.get('name') || jid.split('@')[0];
+    const group = params.get('group');
+    const groups = group ? [group] : [];
+
+    try {
+        await api.waitUntil('chatBoxesFetched');
+        await api.contacts.add({ jid, name, groups }, true, false, '');
+    } catch (err) {
+        api.alert('error', __('Error'), [__('Failed to add %1$s to your roster', jid)]);
+    }
+}
+
+/**
+ * Handles the `remove` action.
+ * @param {string} jid - The JID of the contact
+ */
+async function handleRosterRemove(jid) {
+    try {
+        await api.waitUntil('chatBoxesFetched');
+        const contact = await api.contacts.get(jid);
+        if (contact) {
+            await api.contacts.remove(jid);
+        } else {
+            log.warn(`Cannot remove ${jid} as they are not in the roster.`);
+        }
+    } catch (err) {
+        api.alert('error', __('Error'), [__('Failed to remove %1$s from your roster', jid)]);
+    }
+}
+
+/**
+ * Handles the `subscribe` action.
+ * As per XEP-0147, SHOULD add to roster first.
+ * @param {string} jid - The JID of the contact
+ */
+async function handleRosterSubscribe(jid) {
+    try {
+        await api.waitUntil('chatBoxesFetched');
+        await api.contacts.add({ jid }, true, true, '');
+    } catch (err) {
+        api.alert('error', __('Error'), [__('Failed to subscribe to %1$s', jid)]);
+    }
+}
+
+/**
+ * Handles the `unsubscribe` action.
+ * @param {string} jid - The JID of the contact
+ */
+async function handleRosterUnsubscribe(jid) {
+    try {
+        await api.waitUntil('chatBoxesFetched');
+        const { converse } = _converse;
+        api.send(converse.env.$pres({ type: 'unsubscribe', to: jid }));
+    } catch (err) {
+        api.alert('error', __('Error'), [__('Failed to unsubscribe from %1$s', jid)]);
+    }
+}


### PR DESCRIPTION
Here's a draft for this issue : #1247 
This merge request adds support for handling xmpp: protocol links in Converse.js, allowing users to click links like xmpp:user@example.com to automatically open a chat with the specified JID if logged in. This enhances user experience by enabling seamless integration with external XMPP links (e.g., from emails, websites, or other apps).

Before submitting your request, please make sure the following conditions are met:

- [x] Add a changelog entry for your change in `CHANGES.md`
- [ ] When adding a configuration variable, please make sure to
      document it in `docs/source/configuration.rst`
- [ ] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
