### PR TITLE
Update links to ejabberd documentation, also other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Converse integrates with popular platforms and frameworks:
 |--------|--------|
 | [Openfire](https://www.igniterealtime.org/projects/openfire/) | [inverse](https://www.igniterealtime.org/projects/openfire/plugins.jsp) |
 | [Prosody](https://prosody.im/) | [mod_conversejs](https://modules.prosody.im/mod_conversejs.html) |
-| [Ejabberd](https://ejabberd.im/) | [mod-conversejs](https://docs.ejabberd.im/admin/configuration/modules/#mod-conversejs) |
+| [ejabberd](https://ejabberd.im/) | [mod_conversejs](https://docs.ejabberd.im/admin/configuration/modules/#mod_conversejs) |
 
 ### Web Frameworks & CMS
 | Platform | Integration |

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -19,19 +19,19 @@ For example, the following XMPP servers have plugins available:
 
 * **Openfire**: `inverse plugin <https://www.igniterealtime.org/projects/openfire/plugin-archive.jsp?plugin=inverse>`_
 * **Prosody**: `mod_conversejs <https://modules.prosody.im/mod_conversejs.html>`_
-* **ejabberd**: `mod_conversejs <https://docs.ejabberd.im/admin/configuration/modules/#mod-conversejs>`_
+* **ejabberd**: `mod_conversejs <https://docs.ejabberd.im/admin/configuration/modules/#mod_conversejs>`_
 
 .. warning::
     When configuring one of these plugins in production, it's good practice to use a specific version of the Converse resources to avoid breaking changes.
 
 For instance, this will configure ejabberd's, mod-conversejs to fetch a specific version instead of whichever is the latest one.
 
-.. code-block:: yml
+.. code-block:: yaml
     
-    mod_conversejs:
-      # Replace 11.0.1 with your desired version
-      conversejs_css: https://cdn.conversejs.org/12.0.0/dist/converse.min.css
-      conversejs_script: https://cdn.conversejs.org/12.0.0/dist/converse.min.js
+    modules:
+      mod_conversejs:
+        conversejs_css: https://cdn.conversejs.org/12.0.0/dist/converse.min.css
+        conversejs_script: https://cdn.conversejs.org/12.0.0/dist/converse.min.js
 
 
 Option 2: Self-hosting

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -91,7 +91,8 @@ This is the job of a BOSH connection manager. BOSH (Bidirectional-streams Over
 Synchronous HTTP) is a protocol for allowing XMPP communication over HTTP. The
 protocol is defined in `XEP-0206: XMPP Over BOSH <https://xmpp.org/extensions/xep-0206.html>`_.
 
-Popular XMPP servers such as `Ejabberd <http://www.ejabberd.im>`_,
+Popular XMPP servers such as
+ejabberd `(mod_bosh) <https://docs.ejabberd.im/admin/configuration/modules/#mod_bosh>`_,
 Prosody `(mod_bosh) <http://prosody.im/doc/setting_up_bosh>`_ and
 `OpenFire <http://www.igniterealtime.org/projects/openfire/>`_ all include
 their own BOSH connection managers (but you usually have to enable them in the
@@ -232,7 +233,9 @@ your browser.
 Websockets provide long-lived, bidirectional connections which do not rely on
 HTTP. Therefore BOSH, which operates over HTTP, doesn't apply to websockets.
 
-`Prosody <http://prosody.im>`_ (from version 0.10) and `Ejabberd <http://www.ejabberd.im>`_ support websocket connections, as
+`Prosody <http://prosody.im>`_ (from version 0.10) and
+ejabberd `(ejabberd_http_ws) <https://docs.ejabberd.im/admin/configuration/listen/#ejabberd_http_ws>`_
+support websocket connections, as
 does the node-xmpp-bosh connection manager.
 
 Refer to the :ref:`websocket-url` configuration setting for information on how to

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
                             <p>For ease of use, Converse is available as a plugin or add-on module for the
                                 <a href="https://www.igniterealtime.org/projects/openfire/plugins.jsp" target="_blank" rel="noopener">Openfire</a>
                                 <a href="https://modules.prosody.im/mod_conversejs.html" target="_blank" rel="noopener">Prosody</a>
-                                <a href="https://docs.ejabberd.im/admin/configuration/modules/#mod-conversejs" target="_blank" rel="noopener">Ejabberd</a>
+                                <a href="https://docs.ejabberd.im/admin/configuration/modules/#mod_conversejs" target="_blank" rel="noopener">ejabberd</a>
                                 XMPP servers.
                             </p>
                         </div>


### PR DESCRIPTION
The ejabberd documentation site was migrated to another content manager in June 2024. Most content and URLs should remain valid, but a few ones changed.

This PR updates Converse documentation to link correctly to the current ejabberd documentation.

While making those changes, I noticed other minor simple fixes in the documentation related to ejabberd, and applied them too.