### PR TITLE
Add reply preview UI and highlight animation

### DIFF
--- a/src/plugins/muc-views/templates/mep-message.js
+++ b/src/plugins/muc-views/templates/mep-message.js
@@ -7,6 +7,7 @@ export default (el) => {
     const isodate = dayjs(el.model.get('time')).toISOString();
     return html`
         <div class="message chat-info message--mep ${ el.getExtraMessageClasses() }"
+            data-msgid="${el.model.get('id')}"
             data-isodate="${isodate}"
             data-type="${el.data_name}"
             data-value="${el.data_value}">
@@ -14,16 +15,24 @@ export default (el) => {
             <div class="chat-msg__content">
                 <div class="chat-msg__body chat-msg__body--${el.model.get('type')} ${el.model.get('is_delayed') ? 'chat-msg__body--delayed' : '' }">
                     <div class="chat-info__message">
-                        ${ el.model.isRetracted() ? el.renderRetraction() : html`
-                            <converse-texture
-                                .mentions=${el.model.get('references')}
-                                render_styling
-                                text=${el.model.getMessageText()}>
-                            </converse-texture>
-                            ${ el.model.get('reason') ?
-                                html`<q class="reason"><converse-texture text=${el.model.get('reason')}></converse-texture></q>` : `` }
-                        `}
-                    </div>
+
+    ${ el.hasReply() ? html`
+        <div class="reply-preview" @click=${ev => el.onReplyClick(ev)}>
+            <div class="reply-author">${el.getReplyAuthorName()}</div>
+            <div class="reply-snippet">${el.getReplySnippet()}</div>
+        </div>
+    ` : `` }
+
+    ${ el.model.isRetracted() ? el.renderRetraction() : html`
+        <converse-texture
+            .mentions=${el.model.get('references')}
+            render_styling
+            text=${el.model.getMessageText()}>
+        </converse-texture>
+        ${ el.model.get('reason') ?
+            html`<q class="reason"><converse-texture text=${el.model.get('reason')}></converse-texture></q>` : `` }
+    `}
+</div>
                     <converse-message-actions
                         ?is_retracted=${el.model.isRetracted()}
                         .model=${el.model}></converse-message-actions>

--- a/src/shared/chat/message.js
+++ b/src/shared/chat/message.js
@@ -14,7 +14,8 @@ import tplMessageText from './templates/message-text.js';
 import tplRetraction from './templates/retraction.js';
 import tplSpinner from 'templates/spinner.js';
 import { ObservableElement } from 'shared/components/observable.js';
-import { __ } from 'i18n';
+import { __ } from 'i18n/index.js';
+
 
 const { Strophe } = converse.env;
 const { SUCCESS } = constants;
@@ -112,6 +113,20 @@ export default class Message extends ObservableElement {
             ['chat', 'groupchat', 'normal'].includes(this.model.get('type'));
     }
 
+    onReplyClick (ev) {
+    ev.preventDefault();
+    const reply = this.getReplyTo();
+    if (!reply || !reply.id) return;
+
+    const el = this.closest('converse-chat')
+        ?.querySelector(`[data-msgid="${reply.id}"]`);
+
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el?.classList.add('highlight-reply');
+
+    setTimeout(() => el?.classList.remove('highlight-reply'), 2000);
+}
+
     onImgClick (ev) {
         ev.preventDefault();
         api.modal.show('converse-image-modal', { src: ev.target.src }, ev);
@@ -145,6 +160,27 @@ export default class Message extends ObservableElement {
 
     getOccupantRole () {
         return this.model.occupant?.get('role');
+    }
+
+    hasReply () {
+    return !!this.model.get('reply_to');
+    }
+
+    getReplyTo () {
+    return this.model.get('reply_to');
+    }
+    getReplyAuthorName () {
+    const reply = this.getReplyTo();
+    if (!reply) return __('Unknown');
+
+    return reply.nick || reply.from || __('Unknown');
+}
+    getReplySnippet () {
+        const reply = this.getReplyTo();
+        if (!reply) return '';
+
+        const text = reply.body || reply.text || '';
+        return text.length > 60 ? text.slice(0, 60) + '…' : text;
     }
 
     getExtraMessageClasses () {

--- a/src/shared/chat/templates/message-text.js
+++ b/src/shared/chat/templates/message-text.js
@@ -57,19 +57,32 @@ export default (el) => {
     return html`
         ${el.model.get('is_spoiler') ? tplSpoilerHint : ''}
         ${el.model.get('subject') ? html`<div class="chat-msg__subject">${el.model.get('subject')}</div>` : ''}
-        <span class="chat-msg__body--wrapper ${error_text ? 'error' : ''}">
-            <converse-chat-message-body
-                class="chat-msg__text ${el.model.get('is_only_emojis')
-                    ? 'chat-msg__text--larger'
-                    : ''} ${spoiler_classes}"
-                .model="${el.model}"
-                hide_url_previews=${el.model.get('hide_url_previews')}
-                ?is_me_message=${el.model.isMeCommand()}
-                text="${text}"
-            ></converse-chat-message-body>
-            ${el.model.get('received') && !el.model.isMeCommand() && !is_groupchat_message ? tplCheckmark() : ''}
-            ${el.model.get('edited') ? tplEditedIcon(el) : ''}
-        </span>
+       <span class="chat-msg__body--wrapper ${error_text ? 'error' : ''}">
+      ${el.hasReply() ? html`
+    <div class="reply-preview" @click=${el.onReplyClick.bind(el)}>
+        <div class="reply-author">
+            ${el.getReplyAuthorName()}
+        </div>
+        <div class="reply-snippet">
+            ${el.getReplySnippet()}
+        </div>
+    </div>
+` : ''}
+
+    <converse-chat-message-body
+        class="chat-msg__text ${el.model.get('is_only_emojis')
+            ? 'chat-msg__text--larger'
+            : ''} ${spoiler_classes}"
+        .model=${el.model}
+        hide_url_previews=${el.model.get('hide_url_previews')}
+        ?is_me_message=${el.model.isMeCommand()}
+        text="${text}"
+    ></converse-chat-message-body>
+
+    ${el.model.get('received') && !el.model.isMeCommand() && !is_groupchat_message ? tplCheckmark() : ''}
+    ${el.model.get('edited') ? tplEditedIcon(el) : ''}
+</span>
+
         ${show_oob ? html`<div class="chat-msg__media">
             <converse-texture
                 text="${el.model.get('oob_url')}"

--- a/src/shared/styles/messages.scss
+++ b/src/shared/styles/messages.scss
@@ -337,6 +337,38 @@
             justify-content: space-between;
         }
     }
+        /* ===== Reply preview UI ===== */
+    .reply-preview {
+        border-left: 3px solid var(--info-color);
+        padding: 4px 8px;
+        margin-bottom: 6px;
+        background: rgba(0,0,0,0.05);
+        cursor: pointer;
+    }
+
+    .reply-preview:hover {
+        background: rgba(0,0,0,0.08);
+    }
+
+    .reply-author {
+        font-weight: bold;
+        font-size: 0.85em;
+    }
+
+    .reply-snippet {
+        font-size: 0.8em;
+        opacity: 0.8;
+    }
+
+    .highlight-reply {
+        animation: highlightFlash 2s ease;
+    }
+
+    @keyframes highlightFlash {
+        0% { background: yellow; }
+        100% { background: inherit; }
+    }
+
 
     .chatroom-body .message {
         &.onload {


### PR DESCRIPTION
#3916

This PR adds UI support for displaying reply previews in chat messages.
When a message is a reply, a small preview box is shown above the message body, containing the original author name and a short text snippet. Clicking the preview scrolls to and highlights the referenced message for easier context.

This change is UI-only and backward compatible. It does not modify any XMPP protocol logic or server behavior.