### PR TITLE
feat: Add XEP-0231 Bits of Binary support

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1144,6 +1144,18 @@ Set this option to ``true`` to request all pages of archived messages, but be
 aware that this can have performance implications.
 
 
+max_bob_size
+------------
+
+* Default: ``8192``
+
+The maximum size (in bytes) of Base64-encoded data that may be stored via
+`XEP-0231: Bits of Binary <https://xmpp.org/extensions/xep-0231.html>`_.
+
+Any received BOB data that exceeds this limit will be discarded.
+This helps prevent excessive memory usage from large inline binary objects.
+
+
 muc_hats
 --------
 

--- a/src/headless/index.js
+++ b/src/headless/index.js
@@ -24,6 +24,7 @@ export { ChatBox, Message, Messages } from './plugins/chat/index.js'; // RFC-612
 import './plugins/chatboxes/index.js';
 import './plugins/disco/index.js'; // XEP-0030 Service discovery
 import './plugins/adhoc/index.js'; // XEP-0050 Ad Hoc Commands
+import './plugins/bob/index.js'; // XEP-0231 Bits of Binary
 import './plugins/headlines/index.js'; // Support for headline messages
 export { Device, Devices, DeviceList, DeviceLists } from './plugins/omemo/index.js'; // Support for headline messages
 

--- a/src/headless/karma.conf.js
+++ b/src/headless/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
       { pattern: "tests/*.js", type: 'module' },
       { pattern: "shared/settings/tests/settings.js", type: 'module' },
       { pattern: "plugins/blocklist/tests/*.js", type: 'module' },
+      { pattern: "plugins/bob/tests/*.js", type: 'module' },
       { pattern: "plugins/caps/tests/*.js", type: 'module' },
       { pattern: "plugins/bookmarks/tests/*.js", type: 'module' },
       { pattern: "plugins/chat/tests/*.js", type: 'module' },

--- a/src/headless/plugins/bob/api.js
+++ b/src/headless/plugins/bob/api.js
@@ -1,0 +1,125 @@
+import log from '@converse/log';
+import _converse from '../../shared/_converse.js';
+import api from '../../shared/api/index.js';
+import converse from '../../shared/api/public.js';
+import sizzle from 'sizzle';
+
+const { Strophe, stx } = converse.env;
+
+export default {
+    /**
+     * BOB (Bits of Binary) API
+     * @namespace _converse.api.bob
+     * @memberOf _converse.api
+     */
+    bob: {
+        /**
+         * Check if CID is cached
+         * @param {string} cid
+         * @returns {Promise<boolean>}
+         */
+        async has(cid) {
+            await api.waitUntil('BOBsInitialized');
+            const bobs = _converse.state.bobs;
+            if (!bobs) return false;
+            const bob = bobs.get(cid);
+            if (!bob) return false;
+            return !bob.isExpired();
+        },
+
+        /**
+         * Store BOB data in persistent cache
+         * @param {string} cid
+         * @param {string} data - Base64 encoded data
+         * @param {string} type - MIME type
+         * @param {number} [max_age=86400] - Max age in seconds
+         */
+        async store(cid, data, type, max_age = 86400) {
+            await api.waitUntil('BOBsInitialized');
+            const bobs = _converse.state.bobs;
+
+            if (bobs.get(cid)) {
+                return;
+            }
+
+            try {
+                const size = atob(data).length;
+                if (size > api.settings.get('max_bob_size')) {
+                    log.warn(`BOB data for ${cid} exceeds max size (${size} > ${api.settings.get('max_bob_size')})`);
+                    return;
+                }
+            } catch {
+                log.warn(`Invalid base64 data for BOB ${cid}`);
+                return;
+            }
+
+            if (!type.startsWith('image/')) {
+                log.warn(`BOB data for ${cid} has unsupported MIME type: ${type}`);
+                return;
+            }
+
+            bobs.create({
+                cid,
+                data,
+                type,
+                max_age,
+                timestamp: Date.now(),
+            });
+        },
+
+        /**
+         * Get BOB data as Blob URL
+         * @param {string} cid
+         * @param {string} [from_jid] - JID to request from if not cached
+         * @returns {Promise<string|null>} - Blob URL or null
+         */
+        async get(cid, from_jid) {
+            await api.waitUntil('BOBsInitialized');
+            const bobs = _converse.state.bobs;
+
+            if (await this.has(cid)) {
+                const bob = bobs.get(cid);
+                return bob.getBlobURL();
+            }
+
+            if (from_jid) {
+                try {
+                    await this.fetch(cid, from_jid);
+                } catch (e) {
+                    log.error(`Failed to fetch BOB data for ${cid}:`, e);
+                    return null;
+                }
+                return this.get(cid);
+            }
+
+            return null;
+        },
+
+        /**
+         * Fetch BOB data via IQ-get
+         * @param {string} cid
+         * @param {string} from_jid
+         * @returns {Promise<void>}
+         */
+        async fetch(cid, from_jid) {
+            const iq = stx`<iq type="get" to="${from_jid}" xmlns="jabber:client">
+                <data xmlns="${Strophe.NS.BOB}" cid="${cid}"/>
+            </iq>`;
+
+            const result = await api.sendIQ(iq);
+            const selector = `data[xmlns="${Strophe.NS.BOB}"]`;
+            const data_el = result.querySelector?.(selector) || sizzle(selector, result)[0];
+
+            if (!data_el) {
+                log.error('No BOB data in response stanza:', result);
+                throw new Error('No BOB data in response');
+            }
+
+            const data = data_el.textContent.trim();
+            const type = data_el.getAttribute('type');
+            const max_age = parseInt(data_el.getAttribute('max-age') || '86400', 10);
+
+            this.store(cid, data, type, max_age);
+        },
+    },
+};

--- a/src/headless/plugins/bob/bob.js
+++ b/src/headless/plugins/bob/bob.js
@@ -1,0 +1,47 @@
+import { Model } from '@converse/skeletor';
+import log from '@converse/log';
+
+/**
+ * @class BOB
+ * Represents a single Bits of Binary (XEP-0231) cache entry
+ */
+class BOB extends Model {
+    get idAttribute() {
+        return 'cid';
+    }
+
+    /**
+     * Check if this BOB entry has expired based on max_age
+     * @returns {boolean}
+     */
+    isExpired() {
+        const max_age = this.get('max_age');
+        if (!max_age) return max_age === 0 ? true : false;
+
+        const timestamp = this.get('timestamp');
+        const age = (Date.now() - timestamp) / 1000;
+        return age > max_age;
+    }
+
+    /**
+     * Get the BOB data as a Blob URL
+     * @returns {string|null}
+     */
+    getBlobURL() {
+        const data = this.get('data');
+        const type = this.get('type');
+
+        if (!data || !type) return null;
+
+        try {
+            const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
+            const blob = new Blob([bytes], { type });
+            return URL.createObjectURL(blob);
+        } catch (e) {
+            log.error(`Failed to create Blob URL for BOB ${this.get('cid')}:`, e);
+            return null;
+        }
+    }
+}
+
+export default BOB;

--- a/src/headless/plugins/bob/bobs.js
+++ b/src/headless/plugins/bob/bobs.js
@@ -1,0 +1,56 @@
+import { Collection } from '@converse/skeletor';
+import { getOpenPromise } from '@converse/openpromise';
+import api from '../../shared/api/index.js';
+import _converse from '../../shared/_converse.js';
+import { initStorage } from '../../utils/storage.js';
+import BOB from './bob.js';
+
+/**
+ * @class BOBs
+ * Collection of BOB (Bits of Binary) cache entries with persistent storage
+ * @extends {Collection<BOB>}
+ */
+class BOBs extends Collection {
+    constructor() {
+        super();
+        this.model = BOB;
+    }
+
+    async initialize() {
+        const { session } = _converse;
+        const bare_jid = session.get('bare_jid');
+        const cache_key = `${bare_jid}-converse.bobs`;
+        initStorage(this, cache_key);
+
+        await this.fetchBOBs();
+
+        this.cleanupExpired();
+
+        /**
+         * Triggered as soon as the `_converse.state.bobs` collection has
+         * been initialized and populated from cache.
+         * @event _converse#BOBsInitialized
+         */
+        api.trigger('BOBsInitialized');
+    }
+
+    fetchBOBs() {
+        const deferred = getOpenPromise();
+        this.fetch({
+            success: () => deferred.resolve(),
+            error: () => deferred.resolve(),
+        });
+        return deferred;
+    }
+
+    /**
+     * Remove expired BOB entries from the collection
+     */
+    cleanupExpired() {
+        this.forEach((bob) => {
+            if (bob.isExpired()) bob.destroy();
+        });
+    }
+}
+
+export default BOBs;

--- a/src/headless/plugins/bob/index.js
+++ b/src/headless/plugins/bob/index.js
@@ -1,0 +1,1 @@
+import './plugin.js';

--- a/src/headless/plugins/bob/plugin.js
+++ b/src/headless/plugins/bob/plugin.js
@@ -1,0 +1,161 @@
+/**
+ * @module converse-bob
+ * @description
+ * XEP-0231: Bits of Binary
+ * Handles receiving and caching small binary data (custom smileys, CAPTCHAs)
+ */
+import sizzle from 'sizzle';
+import converse from '../../shared/api/public.js';
+import _converse from '../../shared/_converse.js';
+import log from '@converse/log';
+import BOB from './bob.js';
+import BOBs from './bobs.js';
+import bob_api from './api.js';
+
+const { Strophe } = converse.env;
+
+Strophe.addNamespace('BOB', 'urn:xmpp:bob');
+
+converse.plugins.add('converse-bob', {
+    dependencies: [],
+
+    initialize() {
+        const { api } = this._converse;
+
+        api.promises.add('BOBsInitialized');
+
+        api.settings.extend({
+            max_bob_size: 8192,
+        });
+
+        const exports = { BOB, BOBs };
+        Object.assign(_converse.exports, exports);
+
+        api.listen.on('addClientFeatures', () => {
+            api.disco.own.features.add(Strophe.NS.BOB);
+            api.disco.own.features.add('http://jabber.org/protocol/xhtml-im');
+        });
+
+        api.listen.on('connected', async () => {
+            const bobs = new _converse.exports.BOBs();
+            _converse.state.bobs = bobs;
+            await bobs.initialize();
+
+            _converse.state.bobs_cleanup_interval = setInterval(() => {
+                if (_converse.state.bobs) {
+                    _converse.state.bobs.cleanupExpired();
+                }
+            }, 600000);
+        });
+
+        api.listen.on('clearSession', () => {
+            if (_converse.state.bobs_cleanup_interval) {
+                clearInterval(_converse.state.bobs_cleanup_interval);
+                delete _converse.state.bobs_cleanup_interval;
+            }
+            if (_converse.state.bobs) {
+                _converse.state.bobs.clearStore();
+                delete _converse.state.bobs;
+            }
+        });
+
+        Object.assign(api, bob_api);
+
+        api.listen.on('parseMessage', (stanza, attrs) => {
+            const bob_data = [];
+            const data_els = sizzle(`data[xmlns="${Strophe.NS.BOB}"]`, stanza);
+
+            data_els.forEach((el) => {
+                const cid = el.getAttribute('cid');
+                const type = el.getAttribute('type');
+                const max_age = parseInt(el.getAttribute('max-age') || '86400', 10);
+                const data = el.textContent.trim();
+
+                if (cid && data) {
+                    bob_data.push({ cid, data, type, max_age });
+                    api.bob?.store(cid, data, type, max_age);
+                }
+            });
+
+            if (bob_data.length > 0) {
+                attrs.bob_data = bob_data;
+            }
+
+            // Extract cid: URIs from XHTML-IM <img> tags (e.g. Pidgin custom smileys).
+            // When a client sends a custom smiley, the plain <body> only contains
+            // fallback text. The cid: URI is only in the XHTML-IM <img src="cid:..."/>.
+            //
+            // Converse extracts attrs.body from the XHTML body's textContent, which
+            // drops <img> elements entirely. So we walk the XHTML body DOM to
+            // reconstruct the text with cid: URIs in place of <img> elements.
+            const xhtml_body = stanza.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'body')[0];
+            if (xhtml_body) {
+                const cid_imgs = Array.from(
+                    xhtml_body.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'img')
+                ).filter((img) => img.getAttribute('src')?.startsWith('cid:'));
+
+                if (cid_imgs.length > 0) {
+                    // Walk all nodes in the XHTML body and build text, replacing
+                    // <img src="cid:..."> with the cid: URI string.
+                    const walker = xhtml_body.ownerDocument.createTreeWalker(
+                        xhtml_body,
+                        4 | 1, // NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT
+                        null
+                    );
+                    const parts = [];
+                    let node;
+                    while ((node = walker.nextNode())) {
+                        if (node.nodeType === 3) {
+                            // Text node
+                            parts.push(node.textContent);
+                        } else if (
+                            node.nodeType === 1 &&
+                            node.localName === 'img' &&
+                            node.getAttribute('src')?.startsWith('cid:')
+                        ) {
+                            parts.push(node.getAttribute('src'));
+                        }
+                    }
+                    const body = parts.join('').trim();
+                    if (body) {
+                        attrs.body = body;
+                        attrs.message = body;
+                    }
+
+                    // Fetch BOB data via IQ for any CIDs not included inline
+                    // (e.g. Pidgin sends <img src="cid:..."> without inline <data>)
+                    const from_jid = attrs.from || stanza.getAttribute('from');
+                    const bare_from = Strophe.getBareJidFromJid(from_jid);
+                    const stored_cids = new Set((attrs.bob_data || []).map((b) => b.cid));
+                    for (const img of cid_imgs) {
+                        const src = img.getAttribute('src');
+                        const cid = src.slice(4); // strip "cid:" prefix
+                        if (!stored_cids.has(cid)) {
+                            log.info(`BOB: Fetching missing CID via IQ: ${cid}`);
+                            api.bob
+                                .fetch(cid, from_jid)
+                                .then(() => {
+                                    // Re-render messages containing this CID
+                                    const chatbox = _converse.chatboxes.get(bare_from);
+                                    if (chatbox) {
+                                        chatbox.messages.forEach((msg) => {
+                                            const body = msg.get('body') || '';
+                                            if (body.includes(cid)) {
+                                                // Force a real model change to trigger view re-render
+                                                msg.save('bob_updated', Date.now());
+                                            }
+                                        });
+                                    }
+                                })
+                                .catch((e) => log.error(`BOB: IQ fetch failed for ${cid}:`, e));
+                        }
+                    }
+                }
+            }
+
+            return attrs;
+        });
+
+        log.info('XEP-0231: Bits of Binary plugin initialized');
+    },
+});

--- a/src/headless/plugins/bob/tests/bob.js
+++ b/src/headless/plugins/bob/tests/bob.js
@@ -1,0 +1,188 @@
+/* global converse */
+import mock from '../../../tests/mock.js';
+const { u, Strophe, stx, sizzle } = converse.env;
+
+describe('XEP-0231: Bits of Binary', function () {
+    describe('BOB Cache', function () {
+        it(
+            'stores and retrieves BOB data',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const cid = 'cid:sha1+8f35fef110ffc5df08d579a50083ff9308fb6242@bob.xmpp.org';
+                const data = 'iVBORw0KGgoAAAANSUhEUg==';
+                const type = 'image/png';
+
+                // Store data
+                await api.bob.store(cid, data, type, 86400);
+
+                // Verify it's cached
+                expect(await api.bob.has(cid)).toBe(true);
+
+                // Retrieve as Blob URL
+                const blobUrl = await api.bob.get(cid);
+                expect(blobUrl).toBeTruthy();
+                expect(blobUrl.startsWith('blob:')).toBe(true);
+            }),
+        );
+
+        it(
+            'respects max-age expiration',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const cid = 'cid:sha1+test@bob.xmpp.org';
+                const data = 'iVBORw0KGgoAAAANSUhEUg==';
+
+                // Store with 1 second max-age
+                await api.bob.store(cid, data, 'image/png', 1);
+                expect(await api.bob.has(cid)).toBe(true);
+
+                // Wait 2 seconds
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+
+                // Should be expired
+                expect(await api.bob.has(cid)).toBe(false);
+            }),
+        );
+
+        it(
+            'rejects oversized data',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const cid = 'cid:sha1+large@bob.xmpp.org';
+                // Create valid base64 that decodes to >8KB (need ~12KB base64 for 9KB decoded)
+                const largeData = btoa('A'.repeat(9000));
+
+                await api.bob.store(cid, largeData, 'image/png', 86400);
+
+                // Should not be cached
+                expect(await api.bob.has(cid)).toBe(false);
+            }),
+        );
+
+        it(
+            'rejects non-image MIME types',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const cid = 'cid:sha1+pdf@bob.xmpp.org';
+                const data = 'JVBERi0xLjQK';
+
+                await api.bob.store(cid, data, 'application/pdf', 86400);
+
+                // Should not be cached
+                expect(await api.bob.has(cid)).toBe(false);
+            }),
+        );
+    });
+
+    describe('Message Parsing', function () {
+        it(
+            'extracts BOB data from incoming messages',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                await mock.waitForRoster(_converse, 'current', 1);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+
+                const cid = 'cid:sha1+abc123@bob.xmpp.org';
+                const bobData = 'iVBORw0KGgoAAAANSUhEUg==';
+
+                const stanza = stx`<message from="${contact_jid}" to="${_converse.bare_jid}" type="chat" xmlns="jabber:client">
+                    <body>Check this out! ${cid}</body>
+                    <data xmlns="urn:xmpp:bob" cid="${cid}" type="image/png" max-age="3600">${bobData}</data>
+                </message>`;
+
+                await _converse.handleMessageStanza(stanza.tree());
+
+                // Verify data was cached
+                expect(await _converse.api.bob.has(cid)).toBe(true);
+            }),
+        );
+
+        it(
+            'extracts BOB cid from XHTML-IM img tags (Pidgin-style custom smileys)',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                await mock.waitForRoster(_converse, 'current', 1);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+
+                const cid = 'sha1+8f35fef110ffc5df08d579a50083ff9308fb6242@bob.xmpp.org';
+                const bobData = 'iVBORw0KGgoAAAANSUhEUg==';
+
+                // Pidgin-style stanza: body has only the alt/shortname text,
+                // the cid: URI is only in the XHTML-IM <img> tag.
+                // Based on XEP-0231 Example 1.
+                // Note: Using raw XML string because stx template doesn't
+                // properly handle XHTML namespace on nested elements.
+                const xml =
+                    `<message from="${contact_jid}" to="${_converse.bare_jid}" type="chat" xmlns="jabber:client">` +
+                    `<body>Here is a smiley: myemoji</body>` +
+                    `<html xmlns="http://jabber.org/protocol/xhtml-im">` +
+                    `<body xmlns="http://www.w3.org/1999/xhtml">` +
+                    `<p>Here is a smiley: <img alt="myemoji" src="cid:${cid}"/></p>` +
+                    `</body>` +
+                    `</html>` +
+                    `<data xmlns="urn:xmpp:bob" cid="cid:${cid}" type="image/png" max-age="86400">${bobData}</data>` +
+                    `</message>`;
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(xml, 'application/xml');
+                const stanza = doc.documentElement;
+
+                await _converse.handleMessageStanza(stanza);
+
+                // Verify the BOB data was cached
+                expect(await _converse.api.bob.has(`cid:${cid}`)).toBe(true);
+
+                // Verify the message body was updated to include the cid: URI
+                const msg = await _converse.api.chats.get(contact_jid);
+                const messages = msg.messages;
+                const last_msg = messages.at(-1);
+                expect(last_msg.get('body')).toContain(`cid:${cid}`);
+                expect(last_msg.get('body')).not.toContain('myemoji');
+            }),
+        );
+    });
+
+    describe('IQ Requests', function () {
+        it(
+            'fetches uncached BOB data via IQ-get',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const contact_jid = 'romeo@montague.lit';
+                const cid = 'cid:sha1+fetch@bob.xmpp.org';
+                const bobData = 'iVBORw0KGgoAAAANSUhEUg==';
+
+                // Mock IQ response
+                const response = stx`<iq type="result" xmlns="jabber:client">
+                    <data xmlns="urn:xmpp:bob" cid="${cid}" type="image/png" max-age="3600">${bobData}</data>
+                </iq>`;
+                spyOn(api, 'sendIQ').and.returnValue(Promise.resolve(response.tree()));
+
+                // Fetch data
+                const blobUrl = await api.bob.get(cid, contact_jid);
+
+                // Verify IQ was sent
+                expect(api.sendIQ).toHaveBeenCalled();
+
+                // Verify data was cached
+                expect(await api.bob.has(cid)).toBe(true);
+                expect(blobUrl).toBeTruthy();
+            }),
+        );
+
+        it(
+            'handles IQ errors gracefully',
+            mock.initConverse(['chatBoxesInitialized', 'BOBsInitialized'], {}, async (_converse) => {
+                const { api } = _converse;
+                const contact_jid = 'romeo@montague.lit';
+                const cid = 'cid:sha1+notfound@bob.xmpp.org';
+
+                // Mock IQ error
+                spyOn(api, 'sendIQ').and.returnValue(Promise.reject(new Error('item-not-found')));
+
+                // Attempt to fetch
+                const blobUrl = await api.bob.get(cid, contact_jid);
+
+                // Should return null on error
+                expect(blobUrl).toBeNull();
+                expect(await api.bob.has(cid)).toBe(false);
+            }),
+        );
+    });
+});

--- a/src/headless/plugins/caps/tests/caps.js
+++ b/src/headless/plugins/caps/tests/caps.js
@@ -46,7 +46,7 @@ describe('A sent presence stanza', function () {
                 <status>Hello world</status>
                 <priority>0</priority>
                 <x xmlns="vcard-temp:x:update"/>
-                <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
 
 
@@ -58,7 +58,7 @@ describe('A sent presence stanza', function () {
                 <status>Going jogging</status>
                 <priority>2</priority>
                 <x xmlns="vcard-temp:x:update"/>
-                <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
 
             api.settings.set('priority', undefined);
@@ -69,7 +69,7 @@ describe('A sent presence stanza', function () {
                 <status>Doing taxes</status>
                 <priority>0</priority>
                 <x xmlns="vcard-temp:x:update"/>
-                <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
         })
     );

--- a/src/headless/plugins/muc/tests/muc.js
+++ b/src/headless/plugins/muc/tests/muc.js
@@ -59,7 +59,7 @@ describe("Groupchats", function () {
                 <presence from="${_converse.jid}" id="${pres.getAttribute('id')}" to="${muc_jid}/romeo" xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <show>away</show>
-                    <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
             expect(muc.getOwnOccupant().get('show')).toBe('away');
@@ -74,7 +74,7 @@ describe("Groupchats", function () {
                     <show>xa</show>
                     <priority>0</priority>
                     <x xmlns="vcard-temp:x:update"/>
-                    <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`)
 
             profile.set({ show: 'dnd', status_message: 'Do not disturb' });
@@ -89,7 +89,7 @@ describe("Groupchats", function () {
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <show>dnd</show>
                     <status>Do not disturb</status>
-                    <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
             expect(muc2.getOwnOccupant().get('show')).toBe('dnd');
@@ -145,7 +145,7 @@ describe("Groupchats", function () {
             expect(pres).toEqualStanza(stx`
                 <presence from="${_converse.jid}" id="${pres.getAttribute('id')}" to="coven@chat.shakespeare.lit/romeo" xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
         }));
     });

--- a/src/headless/plugins/muc/tests/presence.js
+++ b/src/headless/plugins/muc/tests/presence.js
@@ -26,7 +26,7 @@ describe('MUC presence history element', function () {
                 <x xmlns="http://jabber.org/protocol/muc">
                   <history maxstanzas="5"/>
                 </x>
-                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0="/>
+                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920="/>
               </presence>`);
 
             api.settings.set('muc_history_max_stanzas', 0);
@@ -41,7 +41,7 @@ describe('MUC presence history element', function () {
             expect(sent_stanza).toEqualStanza(stx`
               <presence to="${muc2_jid}/${nick}" xmlns="jabber:client" id="${sent_stanza.getAttribute('id')}" from="${jid}">
                 <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
-                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0="/>
+                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920="/>
               </presence>`);
         })
     );

--- a/src/headless/plugins/smacks/tests/smacks.js
+++ b/src/headless/plugins/smacks/tests/smacks.js
@@ -94,7 +94,7 @@ describe("XEP-0198 Stream Management", function () {
         expect(_converse.session.get('unacked_stanzas')[1]).toBe(Strophe.serialize(IQ_stanzas[3]));
         expect(_converse.session.get('unacked_stanzas')[2]).toBe(
             `<presence xmlns="jabber:client"><priority>0</priority><x xmlns="vcard-temp:x:update"/>`+
-                `<c hash="sha-1" node="https://conversejs.org" ver="5xpk8wyeMSdAjnSeIv3fwIjd1r0=" xmlns="http://jabber.org/protocol/caps"/>`+
+                `<c hash="sha-1" node="https://conversejs.org" ver="KVNJ9gqHYdyeIi4pySOVMTuG920=" xmlns="http://jabber.org/protocol/caps"/>`+
             `</presence>`);
 
         r = stx`<r xmlns="urn:xmpp:sm:3"/>`;

--- a/src/headless/shared/constants.js
+++ b/src/headless/shared/constants.js
@@ -127,6 +127,7 @@ Strophe.addNamespace('XHTML', 'http://www.w3.org/1999/xhtml');
 // the other plugins are whitelisted in src/consts.js
 export const CORE_PLUGINS = [
     'converse-adhoc',
+    'converse-bob',
     'converse-bookmarks',
     'converse-blocklist',
     'converse-bosh',

--- a/src/headless/types/plugins/bob/api.d.ts
+++ b/src/headless/types/plugins/bob/api.d.ts
@@ -1,0 +1,34 @@
+declare namespace _default {
+    namespace bob {
+        /**
+         * Check if CID is cached
+         * @param {string} cid
+         * @returns {Promise<boolean>}
+         */
+        function has(cid: string): Promise<boolean>;
+        /**
+         * Store BOB data in persistent cache
+         * @param {string} cid
+         * @param {string} data - Base64 encoded data
+         * @param {string} type - MIME type
+         * @param {number} [max_age=86400] - Max age in seconds
+         */
+        function store(cid: string, data: string, type: string, max_age?: number): Promise<void>;
+        /**
+         * Get BOB data as Blob URL
+         * @param {string} cid
+         * @param {string} [from_jid] - JID to request from if not cached
+         * @returns {Promise<string|null>} - Blob URL or null
+         */
+        function get(cid: string, from_jid?: string): Promise<string | null>;
+        /**
+         * Fetch BOB data via IQ-get
+         * @param {string} cid
+         * @param {string} from_jid
+         * @returns {Promise<void>}
+         */
+        function fetch(cid: string, from_jid: string): Promise<void>;
+    }
+}
+export default _default;
+//# sourceMappingURL=api.d.ts.map

--- a/src/headless/types/plugins/bob/bob.d.ts
+++ b/src/headless/types/plugins/bob/bob.d.ts
@@ -1,0 +1,20 @@
+export default BOB;
+/**
+ * @class BOB
+ * Represents a single Bits of Binary (XEP-0231) cache entry
+ */
+declare class BOB extends Model<import("@converse/skeletor").ModelAttributes> {
+    constructor(attributes?: Partial<import("@converse/skeletor").ModelAttributes>, options?: import("@converse/skeletor").ModelOptions);
+    /**
+     * Check if this BOB entry has expired based on max_age
+     * @returns {boolean}
+     */
+    isExpired(): boolean;
+    /**
+     * Get the BOB data as a Blob URL
+     * @returns {string|null}
+     */
+    getBlobURL(): string | null;
+}
+import { Model } from '@converse/skeletor';
+//# sourceMappingURL=bob.d.ts.map

--- a/src/headless/types/plugins/bob/bobs.d.ts
+++ b/src/headless/types/plugins/bob/bobs.d.ts
@@ -1,0 +1,25 @@
+export default BOBs;
+/**
+ * @class BOBs
+ * Collection of BOB (Bits of Binary) cache entries with persistent storage
+ * @extends {Collection<BOB>}
+ */
+declare class BOBs extends Collection<BOB> {
+    constructor();
+    model: typeof BOB;
+    initialize(): Promise<void>;
+    fetchBOBs(): Promise<any> & {
+        isResolved: boolean;
+        isPending: boolean;
+        isRejected: boolean;
+        resolve: (value: any) => void;
+        reject: (reason?: any) => void;
+    };
+    /**
+     * Remove expired BOB entries from the collection
+     */
+    cleanupExpired(): void;
+}
+import BOB from './bob.js';
+import { Collection } from '@converse/skeletor';
+//# sourceMappingURL=bobs.d.ts.map

--- a/src/headless/types/plugins/bob/index.d.ts
+++ b/src/headless/types/plugins/bob/index.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=index.d.ts.map

--- a/src/headless/types/plugins/bob/plugin.d.ts
+++ b/src/headless/types/plugins/bob/plugin.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=plugin.d.ts.map

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import "./plugins/muc-views/index.js";      // Views related to MUC
 import "./plugins/notifications/index.js";
 import "./plugins/profile/index.js";
 import "./plugins/omemo-views/index.js";
+import "./plugins/bob-views/index.js";     // Views for XEP-0231 Bits of Binary
 import "./plugins/push/index.js";           // XEP-0357 Push Notifications
 import "./plugins/register/index.js";       // XEP-0077 In-band registration
 import "./plugins/roomslist/index.js";      // Show currently open chat rooms

--- a/src/plugins/bob-views/index.js
+++ b/src/plugins/bob-views/index.js
@@ -1,0 +1,18 @@
+/**
+ * @copyright The Converse.js contributors
+ * @license Mozilla Public License (MPLv2)
+ * @module plugins-bob-views
+ * @description
+ * View plugin for XEP-0231 Bits of Binary
+ * Handles rendering BOB images in message bodies
+ */
+import { api, converse } from '@converse/headless';
+import { handleBOBImages } from './utils.js';
+
+converse.plugins.add('converse-bob-views', {
+    dependencies: ['converse-bob'],
+
+    initialize() {
+        api.listen.on('afterMessageBodyTransformed', handleBOBImages);
+    },
+});

--- a/src/plugins/bob-views/utils.js
+++ b/src/plugins/bob-views/utils.js
@@ -1,0 +1,33 @@
+import { api } from '@converse/headless';
+import tplImage from 'shared/texture/templates/image.js';
+
+/**
+ * Handle BOB images in message body after transformation
+ * @param {import('shared/texture/texture.js').Texture} texture
+ */
+export async function handleBOBImages(texture) {
+    if (!api.bob) return;
+
+    const text = texture.toString();
+
+    if (!text.includes('cid:')) return;
+
+    const regex = /cid:([^\s]+)/g;
+    const matches = [...text.matchAll(regex)];
+
+    for (const m of matches) {
+        const cid = m[0];
+        const cid_key = cid.startsWith('cid:') ? cid.slice(4) : cid;
+
+        const blob_url = await api.bob.get(cid_key);
+        if (blob_url) {
+            const template = tplImage({
+                src: blob_url,
+                href: null,
+                onClick: texture.onImgClick,
+                onLoad: texture.onImgLoad,
+            });
+            texture.addTemplateResult(m.index + texture.offset, m.index + m[0].length + texture.offset, template);
+        }
+    }
+}

--- a/src/plugins/bookmark-views/tests/bookmarks.js
+++ b/src/plugins/bookmark-views/tests/bookmarks.js
@@ -1,49 +1,49 @@
 /* global mock, converse */
 const { Strophe, sizzle, stx, u } = converse.env;
 
-describe("A chat room", function () {
-
+describe('A chat room', function () {
     beforeEach(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    describe("when bookmarked", function () {
-
-        it("will use the nickname from the bookmark", mock.initConverse([], {}, async function (_converse) {
-            const { u } = converse.env;
-            await mock.waitForRoster(_converse, 'current', 0);
-            await mock.waitUntilBookmarksReturned(_converse);
-            const muc_jid = 'coven@chat.shakespeare.lit';
-            const { bookmarks } = _converse.state;
-            bookmarks.create({
-                'jid': muc_jid,
-                'autojoin': false,
-                'name':  'The Play',
-                'nick': 'Othello'
-            });
-            spyOn(_converse.ChatRoom.prototype, 'getAndPersistNickname').and.callThrough();
-            _converse.api.rooms.open(muc_jid);
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
-            await mock.waitForReservedNick(_converse, muc_jid);
-            const room = await u.waitUntil(() => _converse.chatboxes.get(muc_jid));
-            expect(room.get('nick')).toBe('Othello');
-        }));
+    describe('when bookmarked', function () {
+        it(
+            'will use the nickname from the bookmark',
+            mock.initConverse([], {}, async function (_converse) {
+                const { u } = converse.env;
+                await mock.waitForRoster(_converse, 'current', 0);
+                await mock.waitUntilBookmarksReturned(_converse);
+                const muc_jid = 'coven@chat.shakespeare.lit';
+                const { bookmarks } = _converse.state;
+                bookmarks.create({
+                    'jid': muc_jid,
+                    'autojoin': false,
+                    'name': 'The Play',
+                    'nick': 'Othello',
+                });
+                spyOn(_converse.ChatRoom.prototype, 'getAndPersistNickname').and.callThrough();
+                _converse.api.rooms.open(muc_jid);
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                await mock.waitForReservedNick(_converse, muc_jid);
+                const room = await u.waitUntil(() => _converse.chatboxes.get(muc_jid));
+                expect(room.get('nick')).toBe('Othello');
+            }),
+        );
     });
 });
 
-describe("Bookmarks", function () {
-
+describe('Bookmarks', function () {
     beforeEach(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    it("can be pushed from the XMPP server", mock.initConverse(
-            ['connected', 'chatBoxesFetched'], {}, async function (_converse) {
+    it(
+        'can be pushed from the XMPP server',
+        mock.initConverse(['connected', 'chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            const { u } = converse.env;
+            await mock.waitForRoster(_converse, 'current', 0);
+            await mock.waitUntilBookmarksReturned(_converse);
 
-        const { api } = _converse;
-        const { u } = converse.env;
-        await mock.waitForRoster(_converse, 'current', 0);
-        await mock.waitUntilBookmarksReturned(_converse);
-
-        // The stored data is automatically pushed to all of the user's connected resources.
-        // Publisher receives event notification
-        let stanza = stx`<message from="romeo@montague.lit"
+            // The stored data is automatically pushed to all of the user's connected resources.
+            // Publisher receives event notification
+            let stanza = stx`<message from="romeo@montague.lit"
                             to="${_converse.jid}"
                             type="headline"
                             id="${u.getUniqueId()}"
@@ -67,16 +67,16 @@ describe("Bookmarks", function () {
                 </items>
             </event>
         </message>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-        await mock.waitForMUCDiscoInfo(_converse, 'theplay@conference.shakespeare.lit');
+            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+            await mock.waitForMUCDiscoInfo(_converse, 'theplay@conference.shakespeare.lit');
 
-        const { bookmarks } = _converse.state;
-        await u.waitUntil(() => bookmarks.length);
-        expect(bookmarks.length).toBe(2);
-        expect(bookmarks.map(b => b.get('name'))).toEqual(['Another bookmark', "The Play's the Thing"]);
-        expect(await api.rooms.get('theplay@conference.shakespeare.lit')).not.toBeUndefined();
+            const { bookmarks } = _converse.state;
+            await u.waitUntil(() => bookmarks.length);
+            expect(bookmarks.length).toBe(2);
+            expect(bookmarks.map((b) => b.get('name'))).toEqual(['Another bookmark', "The Play's the Thing"]);
+            expect(await api.rooms.get('theplay@conference.shakespeare.lit')).not.toBeUndefined();
 
-        stanza = stx`<message from="romeo@montague.lit"
+            stanza = stx`<message from="romeo@montague.lit"
                         to="${_converse.jid}"
                         type="headline"
                         id="${u.getUniqueId()}"
@@ -101,17 +101,19 @@ describe("Bookmarks", function () {
                 </items>
             </event>
         </message>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
 
-        await u.waitUntil(() => bookmarks.length === 3);
-        expect(bookmarks.map(b => b.get('name'))).toEqual(
-            ['Second bookmark', "The Play's the Thing", 'Yet another bookmark']
-        );
-        expect(_converse.chatboxviews.get('theplay@conference.shakespeare.lit')).not.toBeUndefined();
-        expect(Object.keys(_converse.chatboxviews.getAll()).length).toBe(1);
+            await u.waitUntil(() => bookmarks.length === 3);
+            expect(bookmarks.map((b) => b.get('name'))).toEqual([
+                'Second bookmark',
+                "The Play's the Thing",
+                'Yet another bookmark',
+            ]);
+            expect(_converse.chatboxviews.get('theplay@conference.shakespeare.lit')).not.toBeUndefined();
+            expect(Object.keys(_converse.chatboxviews.getAll()).length).toBe(1);
 
-        // Check that MUC is left when autojoin is set to false
-        stanza = stx`<message from="romeo@montague.lit"
+            // Check that MUC is left when autojoin is set to false
+            stanza = stx`<message from="romeo@montague.lit"
                         to="${_converse.jid}"
                         type="headline"
                         id="${u.getUniqueId()}"
@@ -136,50 +138,51 @@ describe("Bookmarks", function () {
                 </items>
             </event>
         </message>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
 
-        await u.waitUntil(() => bookmarks.filter((b) => !b.get('autojoin')).length === 3);
-        expect(bookmarks.map(b => b.get('name'))).toEqual(
-            ['Second bookmark', "The Play's the Thing", 'Yet another bookmark']
-        );
-        expect(_converse.chatboxviews.get('theplay@conference.shakespeare.lit')).toBeUndefined();
-        expect(Object.keys(_converse.chatboxviews.getAll()).length).toBe(0);
-    }));
+            await u.waitUntil(() => bookmarks.filter((b) => !b.get('autojoin')).length === 3);
+            expect(bookmarks.map((b) => b.get('name'))).toEqual([
+                'Second bookmark',
+                "The Play's the Thing",
+                'Yet another bookmark',
+            ]);
+            expect(_converse.chatboxviews.get('theplay@conference.shakespeare.lit')).toBeUndefined();
+            expect(Object.keys(_converse.chatboxviews.getAll()).length).toBe(0);
+        }),
+    );
 
-    it("can be retrieved from the XMPP server", mock.initConverse(
-            ['chatBoxesFetched'], {},
-            async function (_converse) {
+    it(
+        'can be retrieved from the XMPP server',
+        mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+            const { sizzle, u } = converse.env;
+            await mock.waitForRoster(_converse, 'current', 0);
+            await mock.waitUntilDiscoConfirmed(
+                _converse,
+                _converse.bare_jid,
+                [{ 'category': 'pubsub', 'type': 'pep' }],
+                ['http://jabber.org/protocol/pubsub#publish-options', 'urn:xmpp:bookmarks:1#compat'],
+            );
 
-        const { sizzle, u } = converse.env;
-        await mock.waitForRoster(_converse, 'current', 0);
-        await mock.waitUntilDiscoConfirmed(
-            _converse, _converse.bare_jid,
-            [{'category': 'pubsub', 'type': 'pep'}],
-            [
-                'http://jabber.org/protocol/pubsub#publish-options',
-                'urn:xmpp:bookmarks:1#compat'
-            ]
-        );
+            // Client requests all items
+            const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
+            const sent_stanza = await u.waitUntil(() =>
+                IQ_stanzas.filter((s) => sizzle('items[node="urn:xmpp:bookmarks:1"]', s).length).pop(),
+            );
 
-        // Client requests all items
-        const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
-        const sent_stanza = await u.waitUntil(
-            () => IQ_stanzas.filter(s => sizzle('items[node="urn:xmpp:bookmarks:1"]', s).length).pop());
-
-        expect(sent_stanza).toEqualStanza(
-            stx`<iq from="romeo@montague.lit/orchard" id="${sent_stanza.getAttribute('id')}" type="get" xmlns="jabber:client">
+            expect(sent_stanza).toEqualStanza(
+                stx`<iq from="romeo@montague.lit/orchard" id="${sent_stanza.getAttribute('id')}" type="get" xmlns="jabber:client">
                 <pubsub xmlns="http://jabber.org/protocol/pubsub">
                     <items node="urn:xmpp:bookmarks:1"/>
                 </pubsub>
-            </iq>`
-        );
+            </iq>`,
+            );
 
-        expect(_converse.bookmarks.models.length).toBe(0);
-        spyOn(_converse.bookmarks, 'onBookmarksReceived').and.callThrough();
+            expect(_converse.bookmarks.models.length).toBe(0);
+            spyOn(_converse.bookmarks, 'onBookmarksReceived').and.callThrough();
 
-        // Server returns all items
-        // Purposefully exclude the <nick> element to test #1043
-        const stanza = stx`
+            // Server returns all items
+            // Purposefully exclude the <nick> element to test #1043
+            const stanza = stx`
             <iq xmlns="jabber:server"
                 type="result"
                 to="${_converse.jid}"
@@ -206,66 +209,66 @@ describe("Bookmarks", function () {
             </pubsub>
             </iq>`;
 
-        _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-        await u.waitUntil(() => _converse.bookmarks.onBookmarksReceived.calls.count());
-        await _converse.api.waitUntil('bookmarksInitialized');
-        const { bookmarks } = _converse.state;
-        expect(bookmarks.models.length).toBe(2);
+            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+            await u.waitUntil(() => _converse.bookmarks.onBookmarksReceived.calls.count());
+            await _converse.api.waitUntil('bookmarksInitialized');
+            const { bookmarks } = _converse.state;
+            expect(bookmarks.models.length).toBe(2);
 
-        const theplay = bookmarks.get('theplay@conference.shakespeare.lit');
-        expect(theplay.get('autojoin')).toBe(true);
+            const theplay = bookmarks.get('theplay@conference.shakespeare.lit');
+            expect(theplay.get('autojoin')).toBe(true);
 
-        const orchard = bookmarks.get('orchard@conference.shakespeare.lit');
-        expect(orchard.get('autojoin')).toBe(true);
-        expect(orchard.get('extensions').length).toBe(1);
-        expect(orchard.get('extensions')[0]).toBe('<state xmlns="http://myclient.example/bookmark/state" minimized="true"/>');
-    }));
+            const orchard = bookmarks.get('orchard@conference.shakespeare.lit');
+            expect(orchard.get('autojoin')).toBe(true);
+            expect(orchard.get('extensions').length).toBe(1);
+            expect(orchard.get('extensions')[0]).toBe(
+                '<state xmlns="http://myclient.example/bookmark/state" minimized="true"/>',
+            );
+        }),
+    );
 
-    it("can have a password which will be used to enter", mock.initConverse(
-            ['chatBoxesFetched'], {},
-            async function (_converse) {
+    it(
+        'can have a password which will be used to enter',
+        mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+            const autojoin_muc = 'theplay@conference.shakespeare.lit';
+            await mock.waitForRoster(_converse, 'current', 0);
+            await mock.waitUntilBookmarksReturned(_converse, [
+                {
+                    jid: autojoin_muc,
+                    name: "The Play's the Thing",
+                    autojoin: true,
+                    nick: 'JC',
+                    password: 'secret',
+                },
+                {
+                    jid: 'orchard@conference.shakespeare.lit',
+                    name: 'The Orchard',
+                },
+            ]);
 
-        const autojoin_muc = "theplay@conference.shakespeare.lit";
-        await mock.waitForRoster(_converse, 'current', 0);
-        await mock.waitUntilBookmarksReturned(_converse, [
-            {
-                jid: autojoin_muc,
-                name: "The Play's the Thing",
-                autojoin: true,
-                nick: 'JC',
-                password: 'secret',
-            }, {
-                jid: "orchard@conference.shakespeare.lit",
-                name: "The Orchard",
-            }
-        ]);
+            await _converse.api.waitUntil('bookmarksInitialized');
+            const { bookmarks } = _converse.state;
+            expect(bookmarks.models.length).toBe(2);
 
-        await _converse.api.waitUntil('bookmarksInitialized');
-        const { bookmarks } = _converse.state;
-        expect(bookmarks.models.length).toBe(2);
+            const theplay = bookmarks.get(autojoin_muc);
+            expect(theplay.get('autojoin')).toBe(true);
+            expect(theplay.get('name')).toBe("The Play's the Thing");
+            expect(theplay.get('nick')).toBe('JC');
+            expect(theplay.get('password')).toBe('secret');
+            expect(bookmarks.get('orchard@conference.shakespeare.lit').get('autojoin')).toBe(false);
 
-        const theplay = bookmarks.get(autojoin_muc);
-        expect(theplay.get('autojoin')).toBe(true);
-        expect(theplay.get('name')).toBe("The Play's the Thing");
-        expect(theplay.get('nick')).toBe('JC');
-        expect(theplay.get('password')).toBe('secret');
-        expect(bookmarks.get('orchard@conference.shakespeare.lit').get('autojoin')).toBe(false);
+            await mock.waitForMUCDiscoInfo(_converse, autojoin_muc);
+            await u.waitUntil(() => _converse.state.chatboxes.get(autojoin_muc));
 
-        await mock.waitForMUCDiscoInfo(_converse, autojoin_muc);
-        await u.waitUntil(() => _converse.state.chatboxes.get(autojoin_muc));
+            const features = ['http://jabber.org/protocol/muc', 'jabber:iq:register', 'muc_passwordprotected'];
+            await mock.waitForMUCDiscoInfo(_converse, autojoin_muc, features);
 
-        const features = [
-            'http://jabber.org/protocol/muc',
-            'jabber:iq:register',
-            'muc_passwordprotected',
-        ];
-        await mock.waitForMUCDiscoInfo(_converse, autojoin_muc, features);
+            const { sent_stanzas } = _converse.api.connection.get();
+            const sent_stanza = await u.waitUntil(() =>
+                sent_stanzas.filter((s) => s.getAttribute('to') === `${autojoin_muc}/JC`).pop(),
+            );
 
-        const { sent_stanzas } = _converse.api.connection.get();
-        const sent_stanza = await u.waitUntil(
-            () => sent_stanzas.filter(s => s.getAttribute('to') === `${autojoin_muc}/JC`).pop());
-
-        expect(sent_stanza).toEqualStanza(stx`
+            expect(sent_stanza).toEqualStanza(stx`
             <presence
                 xmlns="jabber:client"
                 from="${_converse.jid}"
@@ -278,7 +281,8 @@ describe("Bookmarks", function () {
             <c xmlns="http://jabber.org/protocol/caps"
                hash="sha-1"
                node="https://conversejs.org"
-               ver="H63l6q0hnLTdpFJt2JA5AOAGl/o="/>
+               ver="MGI8RlyfupY+RiLF6iOY7u36yDA="/>
             </presence>`);
-    }));
+        }),
+    );
 });

--- a/src/plugins/chatview/tests/message-images.js
+++ b/src/plugins/chatview/tests/message-images.js
@@ -47,7 +47,11 @@ describe("A Chat Message", function () {
         expect(view.querySelectorAll('.chat-content .chat-image').length).toBe(5);
 
         // Check that the Imgur URL gets a .png attached to make it render
-        await u.waitUntil(() => Array.from(view.querySelectorAll('.chat-content .chat-image')).pop().src.endsWith('png'), 1000);
+        await u.waitUntil(() => {
+            const images = Array.from(view.querySelectorAll('.chat-content .chat-image'));
+            const lastImage = images.pop();
+            return lastImage && lastImage.src && lastImage.src.endsWith('png');
+        }, 1000);
     }));
 
     it("will not render images if render_media is false",

--- a/src/plugins/muc-views/tests/nickname.js
+++ b/src/plugins/muc-views/tests/nickname.js
@@ -2,54 +2,55 @@
 
 const { Strophe, sizzle, u, stx } = converse.env;
 
-describe("A MUC", function () {
-
+describe('A MUC', function () {
     beforeAll(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    it("allows you to change your nickname via a modal",
+    it(
+        'allows you to change your nickname via a modal',
         mock.initConverse(
             [],
             { view_mode: 'fullscreen', auto_register_muc_nickname: true },
             async function (_converse) {
+                const nick = 'romeo';
+                const muc_jid = 'lounge@montague.lit';
+                const model = await mock.openAndEnterMUC(_converse, muc_jid, nick);
 
-        const nick = 'romeo';
-        const muc_jid = 'lounge@montague.lit';
-        const model = await mock.openAndEnterMUC(_converse, muc_jid, nick);
+                expect(model.get('nick')).toBe(nick);
+                expect(model.occupants.length).toBe(1);
+                expect(model.occupants.at(0).get('nick')).toBe(nick);
 
-        expect(model.get('nick')).toBe(nick);
-        expect(model.occupants.length).toBe(1);
-        expect(model.occupants.at(0).get('nick')).toBe(nick);
+                const view = _converse.chatboxviews.get(muc_jid);
+                const dropdown_item = await u.waitUntil(() => view.querySelector('.open-nickname-modal'));
+                dropdown_item.click();
 
-        const view = _converse.chatboxviews.get(muc_jid);
-        const dropdown_item = await u.waitUntil(() => view.querySelector(".open-nickname-modal"));
-        dropdown_item.click();
+                const modal = _converse.api.modal.get('converse-muc-nickname-modal');
+                await u.waitUntil(() => u.isVisible(modal));
 
-        const modal = _converse.api.modal.get('converse-muc-nickname-modal');
-        await u.waitUntil(() => u.isVisible(modal));
+                const input = modal.querySelector('input[name="nick"]');
+                expect(input.value).toBe(nick);
 
-        const input = modal.querySelector('input[name="nick"]');
-        expect(input.value).toBe(nick);
+                const newnick = 'loverboy';
+                input.value = newnick;
+                modal.querySelector('input[type="submit"]')?.click();
 
-        const newnick = 'loverboy';
-        input.value = newnick;
-        modal.querySelector('input[type="submit"]')?.click();
-
-        await u.waitUntil(() => !u.isVisible(modal));
-        const { sent_stanzas } = _converse.api.connection.get();
-        const sent_stanza = sent_stanzas.pop()
-        expect(sent_stanza).toEqualStanza(
-            stx`<presence from="${_converse.jid}"
+                await u.waitUntil(() => !u.isVisible(modal));
+                const { sent_stanzas } = _converse.api.connection.get();
+                const sent_stanza = sent_stanzas.pop();
+                expect(sent_stanza).toEqualStanza(
+                    stx`<presence from="${_converse.jid}"
                 id="${sent_stanza.getAttribute('id')}"
                 to="${muc_jid}/${newnick}"
-                xmlns="jabber:client"/>`);
+                xmlns="jabber:client"/>`,
+                );
 
-        // clear sent stanzas
-        const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
-        while (IQ_stanzas.length) IQ_stanzas.pop();
+                // clear sent stanzas
+                const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
+                while (IQ_stanzas.length) IQ_stanzas.pop();
 
-        // Two presence stanzas are received from the MUC service
-        _converse.api.connection.get()._dataRecv(mock.createRequest(
-            stx`
+                // Two presence stanzas are received from the MUC service
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`
             <presence
                 xmlns="jabber:client"
                 from='${muc_jid}/${nick}'
@@ -64,14 +65,16 @@ describe("A MUC", function () {
                 <status code='303'/>
                 <status code='110'/>
             </x>
-            </presence>`
-        ));
+            </presence>`,
+                    ),
+                );
 
-        await u.waitUntil(() => model.get('nick') === newnick);
+                await u.waitUntil(() => model.get('nick') === newnick);
 
-        // Check that the new nickname gets registered with the MUC
-        _converse.api.connection.get()._dataRecv(mock.createRequest(
-            stx`
+                // Check that the new nickname gets registered with the MUC
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`
             <presence
                 xmlns="jabber:client"
                 from='${muc_jid}/${newnick}'
@@ -83,23 +86,29 @@ describe("A MUC", function () {
                     role='participant'/>
                 <status code='110'/>
             </x>
-            </presence>`
-        ));
+            </presence>`,
+                    ),
+                );
 
-        await u.waitUntil(() => model.occupants.at(0).get('nick') === newnick);
-        expect(model.occupants.length).toBe(1);
+                await u.waitUntil(() => model.occupants.at(0).get('nick') === newnick);
+                expect(model.occupants.length).toBe(1);
 
-        let stanza = await u.waitUntil(() => IQ_stanzas.find(
-            iq => sizzle(`iq[type="get"] query[xmlns="${Strophe.NS.MUC_REGISTER}"]`, iq).length));
+                let stanza = await u.waitUntil(() =>
+                    IQ_stanzas.find(
+                        (iq) => sizzle(`iq[type="get"] query[xmlns="${Strophe.NS.MUC_REGISTER}"]`, iq).length,
+                    ),
+                );
 
-        expect(stanza).toEqualStanza(
-            stx`<iq to="lounge@montague.lit"
+                expect(stanza).toEqualStanza(
+                    stx`<iq to="lounge@montague.lit"
                     type="get"
                     xmlns="jabber:client"
-                    id="${stanza.getAttribute('id')}"><query xmlns="jabber:iq:register"/></iq>`);
+                    id="${stanza.getAttribute('id')}"><query xmlns="jabber:iq:register"/></iq>`,
+                );
 
-        _converse.api.connection.get()._dataRecv(mock.createRequest(
-            stx`<iq from="${muc_jid}"
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`<iq from="${muc_jid}"
                 id="${stanza.getAttribute('id')}"
                 to="${_converse.session.get('jid')}"
                 xmlns="jabber:client"
@@ -119,73 +128,81 @@ describe("A MUC", function () {
                 </field>
                 </x>
             </query>
-            </iq>`));
+            </iq>`,
+                    ),
+                );
 
-        stanza = await u.waitUntil(() => IQ_stanzas.find(
-            iq => sizzle(`iq[type="set"] query[xmlns="${Strophe.NS.MUC_REGISTER}"]`, iq).length));
+                stanza = await u.waitUntil(() =>
+                    IQ_stanzas.find(
+                        (iq) => sizzle(`iq[type="set"] query[xmlns="${Strophe.NS.MUC_REGISTER}"]`, iq).length,
+                    ),
+                );
 
-        expect(stanza).toEqualStanza(
-            stx`<iq xmlns="jabber:client" to="${muc_jid}" type="set" id="${stanza.getAttribute('id')}">
+                expect(stanza).toEqualStanza(
+                    stx`<iq xmlns="jabber:client" to="${muc_jid}" type="set" id="${stanza.getAttribute('id')}">
                 <query xmlns="jabber:iq:register">
                 <x xmlns="jabber:x:data" type="submit">
                     <field var="FORM_TYPE"><value>http://jabber.org/protocol/muc#register</value></field>
                     <field var="muc#register_roomnick"><value>loverboy</value></field>
                 </x>
                 </query>
-            </iq>`);
-    }));
+            </iq>`,
+                );
+            },
+        ),
+    );
 
-    it("informs users if their nicknames have been changed.",
-            mock.initConverse([], {}, async function (_converse) {
+    it(
+        'informs users if their nicknames have been changed.',
+        mock.initConverse([], {}, async function (_converse) {
+            /* The service then sends two presence stanzas to the full JID
+             * of each occupant (including the occupant who is changing his
+             * or her room nickname), one of type "unavailable" for the old
+             * nickname and one indicating availability for the new
+             * nickname.
+             *
+             * See: https://xmpp.org/extensions/xep-0045.html#changenick
+             *
+             *  <presence
+             *      from='coven@montague.lit/thirdwitch'
+             *      id='DC352437-C019-40EC-B590-AF29E879AF98'
+             *      to='hag66@shakespeare.lit/pda'
+             *      type='unavailable'>
+             *  <x xmlns='http://jabber.org/protocol/muc#user'>
+             *      <item affiliation='member'
+             *          jid='hag66@shakespeare.lit/pda'
+             *          nick='oldhag'
+             *          role='participant'/>
+             *      <status code='303'/>
+             *      <status code='110'/>
+             *  </x>
+             *  </presence>
+             *
+             *  <presence
+             *      from='coven@montague.lit/oldhag'
+             *      id='5B4F27A4-25ED-43F7-A699-382C6B4AFC67'
+             *      to='hag66@shakespeare.lit/pda'>
+             *  <x xmlns='http://jabber.org/protocol/muc#user'>
+             *      <item affiliation='member'
+             *          jid='hag66@shakespeare.lit/pda'
+             *          role='participant'/>
+             *      <status code='110'/>
+             *  </x>
+             *  </presence>
+             */
+            const { __ } = _converse;
+            await mock.openAndEnterMUC(_converse, 'lounge@montague.lit', 'oldnick');
 
-        /* The service then sends two presence stanzas to the full JID
-         * of each occupant (including the occupant who is changing his
-         * or her room nickname), one of type "unavailable" for the old
-         * nickname and one indicating availability for the new
-         * nickname.
-         *
-         * See: https://xmpp.org/extensions/xep-0045.html#changenick
-         *
-         *  <presence
-         *      from='coven@montague.lit/thirdwitch'
-         *      id='DC352437-C019-40EC-B590-AF29E879AF98'
-         *      to='hag66@shakespeare.lit/pda'
-         *      type='unavailable'>
-         *  <x xmlns='http://jabber.org/protocol/muc#user'>
-         *      <item affiliation='member'
-         *          jid='hag66@shakespeare.lit/pda'
-         *          nick='oldhag'
-         *          role='participant'/>
-         *      <status code='303'/>
-         *      <status code='110'/>
-         *  </x>
-         *  </presence>
-         *
-         *  <presence
-         *      from='coven@montague.lit/oldhag'
-         *      id='5B4F27A4-25ED-43F7-A699-382C6B4AFC67'
-         *      to='hag66@shakespeare.lit/pda'>
-         *  <x xmlns='http://jabber.org/protocol/muc#user'>
-         *      <item affiliation='member'
-         *          jid='hag66@shakespeare.lit/pda'
-         *          role='participant'/>
-         *      <status code='110'/>
-         *  </x>
-         *  </presence>
-         */
-        const { __ } = _converse;
-        await mock.openAndEnterMUC(_converse, 'lounge@montague.lit', 'oldnick');
+            const view = _converse.chatboxviews.get('lounge@montague.lit');
+            await u.waitUntil(() => view.querySelectorAll('li .occupant-nick').length, 500);
+            let occupants = view.querySelector('.occupant-list');
+            expect(occupants.querySelectorAll('.occupant-nick').length).toBe(1);
+            expect(occupants.querySelector('.occupant-nick').textContent.trim()).toBe('oldnick');
 
-        const view = _converse.chatboxviews.get('lounge@montague.lit');
-        await u.waitUntil(() => view.querySelectorAll('li .occupant-nick').length, 500);
-        let occupants = view.querySelector('.occupant-list');
-        expect(occupants.querySelectorAll('.occupant-nick').length).toBe(1);
-        expect(occupants.querySelector('.occupant-nick').textContent.trim()).toBe("oldnick");
+            const csntext = await u.waitUntil(() => view.querySelector('.chat-content__notifications').textContent);
+            expect(csntext.trim()).toEqual('oldnick has entered the groupchat');
 
-        const csntext = await u.waitUntil(() => view.querySelector('.chat-content__notifications').textContent);
-        expect(csntext.trim()).toEqual("oldnick has entered the groupchat");
-
-        let presence = stx`
+            let presence = stx`
             <presence
                     xmlns="jabber:client"
                     from='lounge@montague.lit/oldnick'
@@ -202,18 +219,18 @@ describe("A MUC", function () {
                 </x>
             </presence>`;
 
-        _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
-        await u.waitUntil(() => view.querySelectorAll('.chat-info').length);
+            _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
+            await u.waitUntil(() => view.querySelectorAll('.chat-info').length);
 
-        expect(sizzle('div.chat-info:last').pop().textContent.trim()).toBe(
-            __(_converse.labels.muc.STATUS_CODE_MESSAGES["303"], "newnick")
-        );
-        expect(view.model.session.get('connection_status')).toBe(converse.ROOMSTATUS.ENTERED);
+            expect(sizzle('div.chat-info:last').pop().textContent.trim()).toBe(
+                __(_converse.labels.muc.STATUS_CODE_MESSAGES['303'], 'newnick'),
+            );
+            expect(view.model.session.get('connection_status')).toBe(converse.ROOMSTATUS.ENTERED);
 
-        occupants = view.querySelector('.occupant-list');
-        expect(occupants.querySelectorAll('.occupant-nick').length).toBe(1);
+            occupants = view.querySelector('.occupant-list');
+            expect(occupants.querySelectorAll('.occupant-nick').length).toBe(1);
 
-        presence = stx`
+            presence = stx`
             <presence
                     from='lounge@montague.lit/newnick'
                     id='5B4F27A4-25ED-43F7-A699-382C6B4AFC67'
@@ -227,40 +244,42 @@ describe("A MUC", function () {
                 </x>
             </presence>`;
 
-        _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
-        expect(view.model.session.get('connection_status')).toBe(converse.ROOMSTATUS.ENTERED);
-        expect(view.querySelectorAll('div.chat-info').length).toBe(1);
-        expect(sizzle('div.chat-info', view)[0].textContent.trim()).toBe(
-            __(_converse.labels.muc.STATUS_CODE_MESSAGES["303"], "newnick")
-        );
-        occupants = view.querySelector('.occupant-list');
-        await u.waitUntil(() => sizzle('.occupant-nick:first', occupants).pop().textContent.trim() === "newnick");
-        expect(view.model.occupants.length).toBe(1);
-        expect(view.model.get('nick')).toBe("newnick");
-    }));
+            _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
+            expect(view.model.session.get('connection_status')).toBe(converse.ROOMSTATUS.ENTERED);
+            expect(view.querySelectorAll('div.chat-info').length).toBe(1);
+            expect(sizzle('div.chat-info', view)[0].textContent.trim()).toBe(
+                __(_converse.labels.muc.STATUS_CODE_MESSAGES['303'], 'newnick'),
+            );
+            occupants = view.querySelector('.occupant-list');
+            await u.waitUntil(() => sizzle('.occupant-nick:first', occupants).pop().textContent.trim() === 'newnick');
+            expect(view.model.occupants.length).toBe(1);
+            expect(view.model.get('nick')).toBe('newnick');
+        }),
+    );
 
-    describe("when being entered", function () {
+    describe('when being entered', function () {
+        it(
+            "will use the user's reserved nickname, if it exists",
+            mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+                const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
+                const muc_jid = 'lounge@montague.lit';
+                _converse.api.rooms.open(muc_jid);
+                await mock.waitForNewMUCDiscoInfo(_converse, muc_jid);
 
-        it("will use the user's reserved nickname, if it exists",
-                mock.initConverse(['chatBoxesFetched'], {}, async function (_converse) {
+                const iq = await u.waitUntil(() =>
+                    IQ_stanzas.filter(
+                        (s) => sizzle(`iq[to="${muc_jid}"] query[node="x-roomuser-item"]`, s).length,
+                    ).pop(),
+                );
 
-            const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
-            const muc_jid = 'lounge@montague.lit';
-            _converse.api.rooms.open(muc_jid);
-            await mock.waitForNewMUCDiscoInfo(_converse, muc_jid);
-
-            const iq = await u.waitUntil(() => IQ_stanzas.filter(
-                    s => sizzle(`iq[to="${muc_jid}"] query[node="x-roomuser-item"]`, s).length
-                ).pop());
-
-            expect(iq).toEqualStanza(stx`
+                expect(iq).toEqualStanza(stx`
                 <iq id="${iq.getAttribute('id')}" to="${muc_jid}" type="get" xmlns="jabber:client">
                     <query node="x-roomuser-item" xmlns="http://jabber.org/protocol/disco#info"/>
                 </iq>`);
 
-            const stanza = stx`
+                const stanza = stx`
                 <iq type="result"
-                    id="${iq.getAttribute("id")}"
+                    id="${iq.getAttribute('id')}"
                     from="${muc_jid}"
                     to="${_converse.api.connection.get().jid}"
                     xmlns="jabber:client">
@@ -268,13 +287,13 @@ describe("A MUC", function () {
                         <identity category="conference" name="thirdwitch" type="text"/>
                     </query>
                 </iq>`;
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
 
-            // The user has just entered the groupchat (because join was called)
-            // and receives their own presence from the server.
-            // See example 24:
-            // https://xmpp.org/extensions/xep-0045.html#enter-pres
-            const presence = stx`
+                // The user has just entered the groupchat (because join was called)
+                // and receives their own presence from the server.
+                // See example 24:
+                // https://xmpp.org/extensions/xep-0045.html#enter-pres
+                const presence = stx`
                 <presence
                     to="romeo@montague.lit/orchard"
                     from="lounge@montague.lit/thirdwitch"
@@ -288,46 +307,53 @@ describe("A MUC", function () {
                         <status code="210"/>
                     </x>
                 </presence>`;
-            _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
 
-            // clear sent stanzas
-            while (IQ_stanzas.length) IQ_stanzas.pop();
+                // clear sent stanzas
+                while (IQ_stanzas.length) IQ_stanzas.pop();
 
-            // Now that the user has entered the groupchat, the features are requested again.
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                // Now that the user has entered the groupchat, the features are requested again.
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
-            await u.waitUntil(() => (view.model.session.get('connection_status') === converse.ROOMSTATUS.ENTERED));
-            await mock.returnMemberLists(_converse, muc_jid, [], ['member', 'admin', 'owner']);
-            await u.waitUntil(() => view.querySelectorAll('.chat-content .chat-info').length);
-            const info_text = sizzle('.chat-content .chat-info:first', view).pop().textContent.trim();
-            expect(info_text).toBe('Your nickname has been automatically set to thirdwitch');
-        }));
+                const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
+                await u.waitUntil(() => view.model.session.get('connection_status') === converse.ROOMSTATUS.ENTERED);
+                await mock.returnMemberLists(_converse, muc_jid, [], ['member', 'admin', 'owner']);
+                await u.waitUntil(() => view.querySelectorAll('.chat-content .chat-info').length);
+                const info_text = sizzle('.chat-content .chat-info:first', view).pop().textContent.trim();
+                expect(info_text).toBe('Your nickname has been automatically set to thirdwitch');
+            }),
+        );
 
-        it("will use the nickname set in the global settings if the user doesn't have a VCard nickname",
-            mock.initConverse(['chatBoxesFetched'], {
-                blacklisted_plugins: ['converse-vcard'],
-                nickname: 'Benedict-Cucumberpatch'
-            },
-        async function (_converse) {
-            const { api } = _converse;
-            const muc_jid = 'roomy@muc.montague.lit';
-            api.rooms.open(muc_jid);
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
-            await mock.waitForReservedNick(_converse, muc_jid, '');
-            const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
-            expect(view.model.get('nick')).toBe('Benedict-Cucumberpatch');
-        }));
+        it(
+            "will use the nickname set in the global settings if the user doesn't have a VCard nickname",
+            mock.initConverse(
+                ['chatBoxesFetched'],
+                {
+                    blacklisted_plugins: ['converse-vcard'],
+                    nickname: 'Benedict-Cucumberpatch',
+                },
+                async function (_converse) {
+                    const { api } = _converse;
+                    const muc_jid = 'roomy@muc.montague.lit';
+                    api.rooms.open(muc_jid);
+                    await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                    await mock.waitForReservedNick(_converse, muc_jid, '');
+                    const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
+                    expect(view.model.get('nick')).toBe('Benedict-Cucumberpatch');
+                },
+            ),
+        );
 
-        it("will render a nickname form if a nickname conflict happens and muc_nickname_from_jid=false",
-                mock.initConverse([], { vcard: { nickname: '' }}, async function (_converse) {
+        it(
+            'will render a nickname form if a nickname conflict happens and muc_nickname_from_jid=false',
+            mock.initConverse([], { vcard: { nickname: '' } }, async function (_converse) {
+                const { api } = _converse;
+                const muc_jid = 'conflicted@muc.montague.lit';
+                api.rooms.open(muc_jid, { nick: 'romeo' });
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            const { api } = _converse;
-            const muc_jid = 'conflicted@muc.montague.lit';
-            api.rooms.open(muc_jid, { nick: 'romeo' });
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
-
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stx`
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(stx`
                 <presence
                         from="${muc_jid}/romeo"
                         id="${u.getUniqueId()}"
@@ -338,35 +364,43 @@ describe("A MUC", function () {
                     <error by="${muc_jid}" type="cancel">
                         <conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
                     </error>
-                </presence>`));
+                </presence>`),
+                );
 
-            const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
-            const el = await u.waitUntil(() => view.querySelector('.muc-nickname-form .validation-message'));
-            expect(el.textContent.trim()).toBe('The nickname you chose is reserved or currently in use, please choose a different one.');
-        }));
+                const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
+                const el = await u.waitUntil(() => view.querySelector('.muc-nickname-form .validation-message'));
+                expect(el.textContent.trim()).toBe(
+                    'The nickname you chose is reserved or currently in use, please choose a different one.',
+                );
+            }),
+        );
 
-        it("will automatically choose a new nickname if a nickname conflict happens and muc_nickname_from_jid=true",
-                mock.initConverse(['chatBoxesFetched'], {vcard: { nickname: '' }}, async function (_converse) {
+        it(
+            'will automatically choose a new nickname if a nickname conflict happens and muc_nickname_from_jid=true',
+            mock.initConverse(['chatBoxesFetched'], { vcard: { nickname: '' } }, async function (_converse) {
+                const { api } = _converse;
+                const muc_jid = 'conflicting@muc.montague.lit';
 
-            const { api } = _converse;
-            const muc_jid = 'conflicting@muc.montague.lit'
+                api.settings.set('muc_nickname_from_jid', true);
+                api.rooms.open(muc_jid, { nick: 'romeo' });
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            api.settings.set('muc_nickname_from_jid', true);
-            api.rooms.open(muc_jid, { nick: 'romeo' });
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                const connection = api.connection.get();
+                const sent_stanzas = connection.sent_stanzas;
+                await u.waitUntil(() =>
+                    sent_stanzas
+                        .filter((s) => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid))
+                        .pop(),
+                );
 
-            const connection = api.connection.get();
-            const sent_stanzas = connection.sent_stanzas;
-            await u.waitUntil(() => sent_stanzas.filter(s => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid)).pop());
+                const { IQ_stanzas } = api.connection.get();
 
-            const { IQ_stanzas } = api.connection.get();
+                while (IQ_stanzas.length) IQ_stanzas.pop();
+                while (sent_stanzas.length) sent_stanzas.pop();
 
-            while (IQ_stanzas.length) IQ_stanzas.pop();
-            while (sent_stanzas.length) sent_stanzas.pop();
-
-            // Simulate repeatedly that there's already someone in the groupchat
-            // with that nickname
-            let presence = stx`
+                // Simulate repeatedly that there's already someone in the groupchat
+                // with that nickname
+                let presence = stx`
                 <presence xmlns="jabber:client"
                         from='${muc_jid}/romeo'
                         id='${u.getUniqueId()}'
@@ -377,25 +411,29 @@ describe("A MUC", function () {
                         <conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
                     </error>
                 </presence>`;
-            api.connection.get()._dataRecv(mock.createRequest(presence));
+                api.connection.get()._dataRecv(mock.createRequest(presence));
 
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            let sent_stanza = await u.waitUntil(() => sent_stanzas.filter(s => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid)).pop());
-            expect(sent_stanza).toEqualStanza(stx`
+                let sent_stanza = await u.waitUntil(() =>
+                    sent_stanzas
+                        .filter((s) => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid))
+                        .pop(),
+                );
+                expect(sent_stanza).toEqualStanza(stx`
                 <presence id="${sent_stanza.getAttribute('id')}"
                         from="${connection.jid}"
                         to="${muc_jid}/romeo-2"
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="H63l6q0hnLTdpFJt2JA5AOAGl/o="/>
+                        ver="MGI8RlyfupY+RiLF6iOY7u36yDA="/>
                 </presence>`);
 
-            while (IQ_stanzas.length) IQ_stanzas.pop();
-            while (sent_stanzas.length) sent_stanzas.pop();
+                while (IQ_stanzas.length) IQ_stanzas.pop();
+                while (sent_stanzas.length) sent_stanzas.pop();
 
-            presence = stx`
+                presence = stx`
                 <presence
                         xmlns="jabber:client"
                         from="${muc_jid}/romeo-2"
@@ -407,25 +445,29 @@ describe("A MUC", function () {
                         <conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
                     </error>
                 </presence>`;
-            _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
 
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            sent_stanza = await u.waitUntil(() => sent_stanzas.filter(s => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid)).pop());
-            expect(sent_stanza).toEqualStanza(stx`
+                sent_stanza = await u.waitUntil(() =>
+                    sent_stanzas
+                        .filter((s) => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid))
+                        .pop(),
+                );
+                expect(sent_stanza).toEqualStanza(stx`
                 <presence id="${sent_stanza.getAttribute('id')}"
                         from="${connection.jid}"
                         to="${muc_jid}/romeo-3"
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="H63l6q0hnLTdpFJt2JA5AOAGl/o="/>
+                        ver="MGI8RlyfupY+RiLF6iOY7u36yDA="/>
                 </presence>`);
 
-            while (IQ_stanzas.length) IQ_stanzas.pop();
-            while (sent_stanzas.length) sent_stanzas.pop();
+                while (IQ_stanzas.length) IQ_stanzas.pop();
+                while (sent_stanzas.length) sent_stanzas.pop();
 
-            presence = stx`
+                presence = stx`
                 <presence
                         xmlns="jabber:client"
                         from="${muc_jid}/romeo-3"
@@ -437,31 +479,36 @@ describe("A MUC", function () {
                         <conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
                     </error>
                 </presence>`;
-            _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(presence));
 
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            sent_stanza = await u.waitUntil(() => sent_stanzas.filter(s => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid)).pop());
-            expect(sent_stanza).toEqualStanza(stx`
+                sent_stanza = await u.waitUntil(() =>
+                    sent_stanzas
+                        .filter((s) => s.nodeName === 'presence' && s.getAttribute('to').startsWith(muc_jid))
+                        .pop(),
+                );
+                expect(sent_stanza).toEqualStanza(stx`
                 <presence id="${sent_stanza.getAttribute('id')}"
                         from="${connection.jid}"
                         to="${muc_jid}/romeo-4"
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="H63l6q0hnLTdpFJt2JA5AOAGl/o="/>
+                        ver="MGI8RlyfupY+RiLF6iOY7u36yDA="/>
                 </presence>`);
-        }));
+            }),
+        );
 
-        it("will show an error message if the user's nickname doesn't conform to groupchat policy",
-                mock.initConverse([], {}, async function (_converse) {
+        it(
+            "will show an error message if the user's nickname doesn't conform to groupchat policy",
+            mock.initConverse([], {}, async function (_converse) {
+                const { api } = _converse;
+                const muc_jid = 'conformist@muc.montague.lit';
+                api.rooms.open(muc_jid, { nick: 'romeo' });
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
-            const { api } = _converse;
-            const muc_jid = 'conformist@muc.montague.lit'
-            api.rooms.open(muc_jid, { nick: 'romeo' });
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
-
-            const presence = stx`
+                const presence = stx`
                 <presence
                     xmlns="jabber:client"
                     from='${muc_jid}/romeo'
@@ -473,59 +520,70 @@ describe("A MUC", function () {
                         <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
                     </error>
                 </presence>`;
-            api.connection.get()._dataRecv(mock.createRequest(presence));
+                api.connection.get()._dataRecv(mock.createRequest(presence));
 
-            const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
-            const el = await u.waitUntil(() => view.querySelector('.chatroom-body converse-muc-disconnected .disconnect-msg:last-child'));
-            expect(el.textContent.trim()).toBe("Your nickname doesn't conform to this groupchat's policies.");
-        }));
+                const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
+                const el = await u.waitUntil(() =>
+                    view.querySelector('.chatroom-body converse-muc-disconnected .disconnect-msg:last-child'),
+                );
+                expect(el.textContent.trim()).toBe("Your nickname doesn't conform to this groupchat's policies.");
+            }),
+        );
 
-        it("doesn't show the nickname field if locked_muc_nickname is true",
-            mock.initConverse(['chatBoxesFetched'], {
-                locked_muc_nickname: true,
-                muc_nickname_from_jid: true,
-                vcard: { nickname: '' },
-            }, async function (_converse) {
+        it(
+            "doesn't show the nickname field if locked_muc_nickname is true",
+            mock.initConverse(
+                ['chatBoxesFetched'],
+                {
+                    locked_muc_nickname: true,
+                    muc_nickname_from_jid: true,
+                    vcard: { nickname: '' },
+                },
+                async function (_converse) {
+                    const muc_jid = 'lounge@montague.lit';
+                    await mock.openControlBox(_converse);
+                    await mock.waitForRoster(_converse, 'current', 0);
+                    const roomspanel = _converse.chatboxviews.get('controlbox').querySelector('converse-rooms-list');
+                    roomspanel.querySelector('.show-add-muc-modal').click();
 
-            const muc_jid = 'lounge@montague.lit';
-            await mock.openControlBox(_converse);
-            await mock.waitForRoster(_converse, 'current', 0);
-            const roomspanel = _converse.chatboxviews.get('controlbox').querySelector('converse-rooms-list');
-            roomspanel.querySelector('.show-add-muc-modal').click();
+                    const modal = _converse.api.modal.get('converse-add-muc-modal');
+                    await u.waitUntil(() => u.isVisible(modal), 1000);
+                    const name_input = modal.querySelector('input[name="chatroom"]');
+                    name_input.value = muc_jid;
+                    expect(modal.querySelector('label[for="nickname"]')).toBe(null);
+                    expect(modal.querySelector('input[name="nickname"]')).toBe(null);
+                    modal.querySelector('form input[type="submit"]').click();
 
-            const modal = _converse.api.modal.get('converse-add-muc-modal');
-            await u.waitUntil(() => u.isVisible(modal), 1000)
-            const name_input = modal.querySelector('input[name="chatroom"]');
-            name_input.value = muc_jid;
-            expect(modal.querySelector('label[for="nickname"]')).toBe(null);
-            expect(modal.querySelector('input[name="nickname"]')).toBe(null);
-            modal.querySelector('form input[type="submit"]').click();
+                    await mock.waitForMUCDiscoInfo(_converse, muc_jid);
+                    await u.waitUntil(() => _converse.chatboxes.length > 1);
+                    const chatroom = _converse.chatboxes.get(muc_jid);
+                    expect(chatroom.get('nick')).toBe('romeo');
+                },
+            ),
+        );
 
-            await mock.waitForMUCDiscoInfo(_converse, muc_jid);
-            await u.waitUntil(() => _converse.chatboxes.length > 1);
-            const chatroom = _converse.chatboxes.get(muc_jid);
-            expect(chatroom.get('nick')).toBe('romeo');
-        }));
-
-        it("uses the JID node if muc_nickname_from_jid is set to true",
+        it(
+            'uses the JID node if muc_nickname_from_jid is set to true',
             mock.initConverse(
                 ['chatBoxesFetched'],
                 {
                     'muc_nickname_from_jid': true,
-                    blacklisted_plugins: ['converse-vcard']
-                }, async function (_converse) {
+                    blacklisted_plugins: ['converse-vcard'],
+                },
+                async function (_converse) {
+                    await mock.openControlBox(_converse);
+                    await mock.waitForRoster(_converse, 'current', 0);
+                    const roomspanel = _converse.chatboxviews.get('controlbox').querySelector('converse-rooms-list');
+                    roomspanel.querySelector('.show-add-muc-modal').click();
 
-            await mock.openControlBox(_converse);
-            await mock.waitForRoster(_converse, 'current', 0);
-            const roomspanel = _converse.chatboxviews.get('controlbox').querySelector('converse-rooms-list');
-            roomspanel.querySelector('.show-add-muc-modal').click();
-
-            const modal = _converse.api.modal.get('converse-add-muc-modal');
-            await u.waitUntil(() => u.isVisible(modal), 1000)
-            const label_nick = modal.querySelector('label[for="nickname"]');
-            expect(label_nick.textContent.trim()).toBe('Nickname:');
-            const nick_input = modal.querySelector('input[name="nickname"]');
-            expect(nick_input.value).toBe('romeo');
-        }));
+                    const modal = _converse.api.modal.get('converse-add-muc-modal');
+                    await u.waitUntil(() => u.isVisible(modal), 1000);
+                    const label_nick = modal.querySelector('label[for="nickname"]');
+                    expect(label_nick.textContent.trim()).toBe('Nickname:');
+                    const nick_input = modal.querySelector('input[name="nickname"]');
+                    expect(nick_input.value).toBe('romeo');
+                },
+            ),
+        );
     });
 });

--- a/src/plugins/muc-views/tests/probes.js
+++ b/src/plugins/muc-views/tests/probes.js
@@ -27,14 +27,14 @@ describe('Groupchats', function () {
 
                 const sent_stanzas = _converse.api.connection.get().sent_stanzas;
                 let probe = await u.waitUntil(() =>
-                    sent_stanzas.filter((s) => s.matches('presence[type="probe"]')).pop()
+                    sent_stanzas.filter((s) => s.matches('presence[type="probe"]')).pop(),
                 );
                 expect(probe).toEqualStanza(
                     stx`<presence to="${muc_jid}/ralphm" type="probe" xmlns="jabber:client">
                         <priority>0</priority>
                         <x xmlns="vcard-temp:x:update"/>
-                        <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
-                    </presence>`
+                        <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
+                    </presence>`,
                 );
 
                 let presence = stx`<presence xmlns="jabber:client" to="${_converse.jid}" from="${muc_jid}/ralphm">
@@ -61,14 +61,14 @@ describe('Groupchats', function () {
                 expect(occupant.get('role')).toBeUndefined();
 
                 probe = await u.waitUntil(() =>
-                    sent_stanzas.filter((s) => s.matches(`presence[to="${muc_jid}/gonePhising"]`)).pop()
+                    sent_stanzas.filter((s) => s.matches(`presence[to="${muc_jid}/gonePhising"]`)).pop(),
                 );
                 expect(probe).toEqualStanza(
                     stx`<presence to="${muc_jid}/gonePhising" type="probe" xmlns="jabber:client">
                         <priority>0</priority>
                         <x xmlns="vcard-temp:x:update"/>
-                        <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
-                    </presence>`
+                        <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
+                    </presence>`,
                 );
 
                 presence = stx`<presence xmlns="jabber:client" type="unavailable" to="${_converse.jid}" from="${muc_jid}/gonePhising">
@@ -81,7 +81,7 @@ describe('Groupchats', function () {
                 expect(view.model.occupants.length).toBe(3);
                 await u.waitUntil(() => occupant.get('affiliation') === 'member');
                 expect(occupant.get('role')).toBe('participant');
-            })
+            }),
         );
     });
 });

--- a/src/plugins/muc-views/tests/rai.js
+++ b/src/plugins/muc-views/tests/rai.js
@@ -3,31 +3,33 @@ const { Strophe, u, stx, sizzle } = converse.env;
 
 // See: https://xmpp.org/rfcs/rfc3921.html
 
-describe("XEP-0437 Room Activity Indicators", function () {
-
+describe('XEP-0437 Room Activity Indicators', function () {
     beforeAll(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    it("will be activated for a MUC that becomes hidden",
+    it(
+        'will be activated for a MUC that becomes hidden',
         mock.initConverse(
-            [], {
+            [],
+            {
                 'allow_bookmarks': false, // Hack to get the rooms list to render
                 'muc_subscribe_to_rai': true,
-                'view_mode': 'fullscreen'},
+                'view_mode': 'fullscreen',
+            },
             async function (_converse) {
+                expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
 
-        expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
+                const muc_jid = 'lounge@montague.lit';
+                await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
+                const view = _converse.chatboxviews.get(muc_jid);
+                expect(view.model.get('hidden')).toBe(false);
 
-        const muc_jid = 'lounge@montague.lit';
-        await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
-        const view = _converse.chatboxviews.get(muc_jid);
-        expect(view.model.get('hidden')).toBe(false);
-
-        const sent_IQs = _converse.api.connection.get().IQ_stanzas;
-        const iq_get = await u.waitUntil(() => sent_IQs.filter(iq => sizzle(`query[xmlns="${Strophe.NS.MAM}"]`, iq).length).pop());
-        const first_msg_id = _converse.api.connection.get().getUniqueId();
-        const last_msg_id = _converse.api.connection.get().getUniqueId();
-        let message =
-            stx`<message xmlns="jabber:client"
+                const sent_IQs = _converse.api.connection.get().IQ_stanzas;
+                const iq_get = await u.waitUntil(() =>
+                    sent_IQs.filter((iq) => sizzle(`query[xmlns="${Strophe.NS.MAM}"]`, iq).length).pop(),
+                );
+                const first_msg_id = _converse.api.connection.get().getUniqueId();
+                const last_msg_id = _converse.api.connection.get().getUniqueId();
+                let message = stx`<message xmlns="jabber:client"
                     to="romeo@montague.lit/orchard"
                     from="${muc_jid}">
                 <result xmlns="urn:xmpp:mam:2" queryid="${iq_get.querySelector('query').getAttribute('queryid')}" id="${first_msg_id}">
@@ -39,9 +41,9 @@ describe("XEP-0437 Room Activity Indicators", function () {
                     </forwarded>
                 </result>
             </message>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(message));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(message));
 
-        message = stx`<message xmlns="jabber:client"
+                message = stx`<message xmlns="jabber:client"
                     to="romeo@montague.lit/orchard"
                     from="${muc_jid}">
                 <result xmlns="urn:xmpp:mam:2" queryid="${iq_get.querySelector('query').getAttribute('queryid')}" id="${last_msg_id}">
@@ -53,11 +55,10 @@ describe("XEP-0437 Room Activity Indicators", function () {
                     </forwarded>
                 </result>
             </message>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(message));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(message));
 
-        const result =
-            stx`<iq type="result"
-                    id="${iq_get.getAttribute("id")}"
+                const result = stx`<iq type="result"
+                    id="${iq_get.getAttribute('id')}"
                     xmlns="jabber:client">
                 <fin xmlns="urn:xmpp:mam:2" complete="true">
                     <set xmlns="http://jabber.org/protocol/rsm">
@@ -67,50 +68,50 @@ describe("XEP-0437 Room Activity Indicators", function () {
                     </set>
                 </fin>
             </iq>`;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(result));
-        await u.waitUntil(() => view.model.messages.length === 2);
+                _converse.api.connection.get()._dataRecv(mock.createRequest(result));
+                await u.waitUntil(() => view.model.messages.length === 2);
 
-        const sent_stanzas = [];
-        spyOn(_converse.api.connection.get(), 'send').and.callFake(s => sent_stanzas.push(s?.nodeTree ?? s));
-        view.model.save({'hidden': true});
-        await u.waitUntil(() => sent_stanzas.length === 4);
+                const sent_stanzas = [];
+                spyOn(_converse.api.connection.get(), 'send').and.callFake((s) => sent_stanzas.push(s?.nodeTree ?? s));
+                view.model.save({ 'hidden': true });
+                await u.waitUntil(() => sent_stanzas.length === 4);
 
-        expect(sent_stanzas[0]).toEqualStanza(stx`
+                expect(sent_stanzas[0]).toEqualStanza(stx`
             <message to="lounge@montague.lit" type="groupchat" xmlns="jabber:client">
                 <inactive xmlns="http://jabber.org/protocol/chatstates"/>
                 <no-store xmlns="urn:xmpp:hints"/>
                 <no-permanent-store xmlns="urn:xmpp:hints"/>
-            </message>`
-        );
+            </message>`);
 
-        expect(sent_stanzas[1]).toEqualStanza(stx`
+                expect(sent_stanzas[1]).toEqualStanza(stx`
             <message from="${_converse.jid}" id="${sent_stanzas[1].getAttribute('id')}" to="lounge@montague.lit" type="groupchat" xmlns="jabber:client">
                 <received id="${last_msg_id}" xmlns="urn:xmpp:chat-markers:0"/>
-            </message>`
-        );
-        expect(sent_stanzas[2]).toEqualStanza(stx`
+            </message>`);
+                expect(sent_stanzas[2]).toEqualStanza(stx`
             <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
-            </presence>`
-        );
-        expect(sent_stanzas[3]).toEqualStanza(stx`
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
+            </presence>`);
+                expect(sent_stanzas[3]).toEqualStanza(stx`
             <presence to="montague.lit" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
                 <rai xmlns="urn:xmpp:rai:0"/>
-            </presence>`
-        );
+            </presence>`);
 
-        await u.waitUntil(() => view.model.session.get('connection_status') === converse.ROOMSTATUS.DISCONNECTED);
-        expect(view.model.get('has_activity')).toBe(false);
+                await u.waitUntil(
+                    () => view.model.session.get('connection_status') === converse.ROOMSTATUS.DISCONNECTED,
+                );
+                expect(view.model.get('has_activity')).toBe(false);
 
-        const room_el = await u.waitUntil(() => document.querySelector("converse-rooms-list .available-chatroom"));
-        expect(Array.from(room_el.classList).includes('unread-msgs')).toBeFalsy();
+                const room_el = await u.waitUntil(() =>
+                    document.querySelector('converse-rooms-list .available-chatroom'),
+                );
+                expect(Array.from(room_el.classList).includes('unread-msgs')).toBeFalsy();
 
-        const activity_stanza = stx`
+                const activity_stanza = stx`
             <message from="${Strophe.getDomainFromJid(muc_jid)}"
                     xmlns="jabber:client">
                 <rai xmlns="urn:xmpp:rai:0">
@@ -118,64 +119,68 @@ describe("XEP-0437 Room Activity Indicators", function () {
                 </rai>
             </message>
         `;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
 
-        await u.waitUntil(() => view.model.get('has_activity'));
-        expect(Array.from(room_el.classList).includes('unread-msgs')).toBeTruthy();
-    }));
+                await u.waitUntil(() => view.model.get('has_activity'));
+                expect(Array.from(room_el.classList).includes('unread-msgs')).toBeTruthy();
+            },
+        ),
+    );
 
-    it("will be activated for a MUC that starts out hidden",
+    it(
+        'will be activated for a MUC that starts out hidden',
         mock.initConverse(
-            [], {
+            [],
+            {
                 allow_bookmarks: false, // Hack to get the rooms list to render
                 muc_subscribe_to_rai: true,
-                view_mode: 'fullscreen'},
+                view_mode: 'fullscreen',
+            },
             async function (_converse) {
+                const { api } = _converse;
+                expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
 
-        const { api } = _converse;
-        expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
+                const muc_jid = 'lounge@montague.lit';
+                const nick = 'romeo';
+                const sent_stanzas = _converse.api.connection.get().sent_stanzas;
 
-        const muc_jid = 'lounge@montague.lit';
-        const nick = 'romeo';
-        const sent_stanzas = _converse.api.connection.get().sent_stanzas;
+                const muc_creation_promise = api.rooms.open(muc_jid, { nick }, false);
+                await mock.waitForMUCDiscoInfo(_converse, muc_jid, []);
+                await mock.receiveOwnMUCPresence(_converse, muc_jid, nick);
+                await muc_creation_promise;
 
-        const muc_creation_promise = api.rooms.open(muc_jid, { nick }, false);
-        await mock.waitForMUCDiscoInfo(_converse, muc_jid, []);
-        await mock.receiveOwnMUCPresence(_converse, muc_jid, nick);
-        await muc_creation_promise;
+                const model = _converse.chatboxes.get(muc_jid);
+                await u.waitUntil(() => model.session.get('connection_status') === converse.ROOMSTATUS.ENTERED);
 
-        const model = _converse.chatboxes.get(muc_jid);
-        await u.waitUntil(() => (model.session.get('connection_status') === converse.ROOMSTATUS.ENTERED));
+                model.set('hidden', true);
 
-        model.set('hidden', true);
+                const getSentPresences = () => sent_stanzas.filter((s) => s.nodeName === 'presence');
+                await u.waitUntil(() => getSentPresences().length === 3, 500);
+                const sent_presences = getSentPresences();
 
-        const getSentPresences = () => sent_stanzas.filter(s => s.nodeName === 'presence');
-        await u.waitUntil(() => getSentPresences().length === 3, 500);
-        const sent_presences = getSentPresences();
-
-        expect(sent_presences[1]).toEqualStanza(stx`
+                expect(sent_presences[1]).toEqualStanza(stx`
             <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
-            </presence>`
-        );
-        expect(sent_presences[2]).toEqualStanza(stx`
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
+            </presence>`);
+                expect(sent_presences[2]).toEqualStanza(stx`
             <presence to="montague.lit" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
                 <rai xmlns="urn:xmpp:rai:0"/>
-            </presence>`
-        );
+            </presence>`);
 
-        await u.waitUntil(() => model.session.get('connection_status') === converse.ROOMSTATUS.DISCONNECTED);
-        expect(model.get('has_activity')).toBe(false);
+                await u.waitUntil(() => model.session.get('connection_status') === converse.ROOMSTATUS.DISCONNECTED);
+                expect(model.get('has_activity')).toBe(false);
 
-        const room_el = await u.waitUntil(() => document.querySelector("converse-rooms-list .available-chatroom"));
-        expect(Array.from(room_el.classList).includes('unread-msgs')).toBeFalsy();
+                const room_el = await u.waitUntil(() =>
+                    document.querySelector('converse-rooms-list .available-chatroom'),
+                );
+                expect(Array.from(room_el.classList).includes('unread-msgs')).toBeFalsy();
 
-        const activity_stanza = stx`
+                const activity_stanza = stx`
             <message from="${Strophe.getDomainFromJid(muc_jid)}"
                     xmlns="jabber:client">
                 <rai xmlns="urn:xmpp:rai:0">
@@ -183,58 +188,60 @@ describe("XEP-0437 Room Activity Indicators", function () {
                 </rai>
             </message>
         `;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
 
-        await u.waitUntil(() => model.get('has_activity'));
-        expect(Array.from(room_el.classList).includes('unread-msgs')).toBeTruthy();
-    }));
+                await u.waitUntil(() => model.get('has_activity'));
+                expect(Array.from(room_el.classList).includes('unread-msgs')).toBeTruthy();
+            },
+        ),
+    );
 
-
-    it("may not be activated due to server resource constraints",
+    it(
+        'may not be activated due to server resource constraints',
         mock.initConverse(
-            [], {
+            [],
+            {
                 'allow_bookmarks': false, // Hack to get the rooms list to render
                 'muc_subscribe_to_rai': true,
-                'view_mode': 'fullscreen'},
+                'view_mode': 'fullscreen',
+            },
             async function (_converse) {
+                expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
 
-        expect(_converse.session.get('rai_enabled_domains')).toBe(undefined);
+                const muc_jid = 'lounge@montague.lit';
+                const model = await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
+                expect(model.get('hidden')).toBe(false);
+                const sent_stanzas = [];
+                spyOn(_converse.api.connection.get(), 'send').and.callFake((s) => sent_stanzas.push(s?.nodeTree ?? s));
+                model.save({ 'hidden': true });
+                await u.waitUntil(() => sent_stanzas.filter((s) => s.nodeName === 'presence').length === 2);
 
-        const muc_jid = 'lounge@montague.lit';
-        const model = await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
-        expect(model.get('hidden')).toBe(false);
-        const sent_stanzas = [];
-        spyOn(_converse.api.connection.get(), 'send').and.callFake(s => sent_stanzas.push(s?.nodeTree ?? s));
-        model.save({'hidden': true});
-        await u.waitUntil(() => sent_stanzas.filter(s => s.nodeName === 'presence').length === 2);
-
-        const sent_presences = sent_stanzas.filter(s => s.nodeName === 'presence');
-        expect(sent_presences[0]).toEqualStanza(stx`
+                const sent_presences = sent_stanzas.filter((s) => s.nodeName === 'presence');
+                expect(sent_presences[0]).toEqualStanza(stx`
             <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
-            </presence>`
-        );
-        expect(sent_presences[1]).toEqualStanza(stx`
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
+            </presence>`);
+                expect(sent_presences[1]).toEqualStanza(stx`
             <presence to="montague.lit" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="xLNm7xDIHf5niRYX69ViCnDXhb4=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="VYVxu8RLtseTvxGMkBb9cKa5yiQ=" xmlns="http://jabber.org/protocol/caps"/>
                 <rai xmlns="urn:xmpp:rai:0"/>
-            </presence>`
-        );
-        // If an error presence with "resource-constraint" is returned, we rejoin
-        const activity_stanza = stx`
+            </presence>`);
+                // If an error presence with "resource-constraint" is returned, we rejoin
+                const activity_stanza = stx`
             <presence type="error"
                     from="${Strophe.getDomainFromJid(muc_jid)}"
                     xmlns="jabber:client">
                 <error type="wait"><resource-constraint xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/></error>
             </presence>
         `;
-        _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
+                _converse.api.connection.get()._dataRecv(mock.createRequest(activity_stanza));
 
-        await u.waitUntil(() => model.session.get('connection_status') === converse.ROOMSTATUS.CONNECTING);
-    }));
-
+                await u.waitUntil(() => model.session.get('connection_status') === converse.ROOMSTATUS.CONNECTING);
+            },
+        ),
+    );
 });

--- a/src/plugins/profile/tests/status.js
+++ b/src/plugins/profile/tests/status.js
@@ -3,72 +3,78 @@
 const u = converse.env.utils;
 const Strophe = converse.env.Strophe;
 
-describe("The Controlbox", function () {
-
+describe('The Controlbox', function () {
     beforeAll(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    describe("The Status Widget", function () {
+    describe('The Status Widget', function () {
+        it(
+            "shows the user's chat status, which is online by default",
+            mock.initConverse([], {}, async function (_converse) {
+                mock.openControlBox(_converse);
+                const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
+                expect(u.hasClass('online', view.querySelector('.xmpp-status span:first-child'))).toBe(true);
+                expect(view.querySelector('.xmpp-status span.online').textContent.trim()).toBe('I am online');
+            }),
+        );
 
-        it("shows the user's chat status, which is online by default",
-                mock.initConverse([], {}, async function (_converse) {
-            mock.openControlBox(_converse);
-            const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
-            expect(u.hasClass('online', view.querySelector('.xmpp-status span:first-child'))).toBe(true);
-            expect(view.querySelector('.xmpp-status span.online').textContent.trim()).toBe('I am online');
-        }));
-
-        it("can be used to set the current user's chat status",
-                mock.initConverse([], {}, async function (_converse) {
-
-            await mock.openControlBox(_converse);
-            const cbview = _converse.chatboxviews.get('controlbox');
-            cbview.querySelector('.change-status').click()
-            const modal = _converse.api.modal.get('converse-profile-modal');
-            await u.waitUntil(() => u.isVisible(modal), 1000);
-            modal.querySelector('label[for="radio-busy"]').click(); // Change status to "dnd"
-            modal.querySelector('[type="submit"]').click();
-            const sent_stanzas = _converse.api.connection.get().sent_stanzas;
-            const sent_presence = await u.waitUntil(() => sent_stanzas.filter(s => Strophe.serialize(s).match('presence')).pop());
-            expect(sent_presence).toEqualStanza(stx`
+        it(
+            "can be used to set the current user's chat status",
+            mock.initConverse([], {}, async function (_converse) {
+                await mock.openControlBox(_converse);
+                const cbview = _converse.chatboxviews.get('controlbox');
+                cbview.querySelector('.change-status').click();
+                const modal = _converse.api.modal.get('converse-profile-modal');
+                await u.waitUntil(() => u.isVisible(modal), 1000);
+                modal.querySelector('label[for="radio-busy"]').click(); // Change status to "dnd"
+                modal.querySelector('[type="submit"]').click();
+                const sent_stanzas = _converse.api.connection.get().sent_stanzas;
+                const sent_presence = await u.waitUntil(() =>
+                    sent_stanzas.filter((s) => Strophe.serialize(s).match('presence')).pop(),
+                );
+                expect(sent_presence).toEqualStanza(stx`
                 <presence xmlns="jabber:client">
                     <show>dnd</show>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
-            const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
-            const first_child = view.querySelector('.xmpp-status span:first-child');
-            expect(u.hasClass('online', first_child)).toBe(false);
-            expect(u.hasClass('dnd', first_child)).toBe(true);
-            expect(view.querySelector('.xmpp-status span:first-child').textContent.trim()).toBe('I am busy');
-        }));
+                const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
+                const first_child = view.querySelector('.xmpp-status span:first-child');
+                expect(u.hasClass('online', first_child)).toBe(false);
+                expect(u.hasClass('dnd', first_child)).toBe(true);
+                expect(view.querySelector('.xmpp-status span:first-child').textContent.trim()).toBe('I am busy');
+            }),
+        );
 
-        it("can be used to set a custom status message",
-                mock.initConverse([], {}, async function (_converse) {
+        it(
+            'can be used to set a custom status message',
+            mock.initConverse([], {}, async function (_converse) {
+                await mock.openControlBox(_converse);
+                const cbview = _converse.chatboxviews.get('controlbox');
+                cbview.querySelector('.change-status').click();
+                const modal = _converse.api.modal.get('converse-profile-modal');
 
-            await mock.openControlBox(_converse);
-            const cbview = _converse.chatboxviews.get('controlbox');
-            cbview.querySelector('.change-status').click()
-            const modal = _converse.api.modal.get('converse-profile-modal');
-
-            await u.waitUntil(() => u.isVisible(modal), 1000);
-            const msg = 'I am happy';
-            modal.querySelector('input[name="status_message"]').value = msg;
-            modal.querySelector('[type="submit"]').click();
-            const sent_stanzas = _converse.api.connection.get().sent_stanzas;
-            const sent_presence = await u.waitUntil(() => sent_stanzas.filter(s => Strophe.serialize(s).match('presence')).pop());
-            expect(sent_presence).toEqualStanza(stx`
+                await u.waitUntil(() => u.isVisible(modal), 1000);
+                const msg = 'I am happy';
+                modal.querySelector('input[name="status_message"]').value = msg;
+                modal.querySelector('[type="submit"]').click();
+                const sent_stanzas = _converse.api.connection.get().sent_stanzas;
+                const sent_presence = await u.waitUntil(() =>
+                    sent_stanzas.filter((s) => Strophe.serialize(s).match('presence')).pop(),
+                );
+                expect(sent_presence).toEqualStanza(stx`
                 <presence xmlns="jabber:client">
                     <status>I am happy</status>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
-            const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
-            const first_child = view.querySelector('.xmpp-status span:first-child');
-            expect(u.hasClass('online', first_child)).toBe(true);
-            expect(view.querySelector('.xmpp-status span:first-child').textContent.trim()).toBe(msg);
-        }));
+                const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
+                const first_child = view.querySelector('.xmpp-status span:first-child');
+                expect(u.hasClass('online', first_child)).toBe(true);
+                expect(view.querySelector('.xmpp-status span:first-child').textContent.trim()).toBe(msg);
+            }),
+        );
     });
 });

--- a/src/plugins/rosterview/tests/presence.js
+++ b/src/plugins/rosterview/tests/presence.js
@@ -2,54 +2,55 @@
 
 const original_timeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-describe("A sent presence stanza", function () {
-
+describe('A sent presence stanza', function () {
     beforeAll(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
     beforeEach(() => (jasmine.DEFAULT_TIMEOUT_INTERVAL = 7000));
     afterEach(() => (jasmine.DEFAULT_TIMEOUT_INTERVAL = original_timeout));
 
-    it("includes the saved status message",
+    it(
+        'includes the saved status message',
         mock.initConverse([], {}, async (_converse) => {
+            const { u, Strophe } = converse.env;
+            mock.openControlBox(_converse);
+            spyOn(_converse.api.connection.get(), 'send').and.callThrough();
 
-        const { u, Strophe } = converse.env;
-        mock.openControlBox(_converse);
-        spyOn(_converse.api.connection.get(), 'send').and.callThrough();
+            const cbview = await u.waitUntil(() => _converse.api.controlbox.get());
+            const change_status_el = await u.waitUntil(() => cbview.querySelector('.change-status'));
+            change_status_el.click();
+            let modal = _converse.api.modal.get('converse-profile-modal');
+            await u.waitUntil(() => u.isVisible(modal), 1000);
+            const msg = 'My custom status';
+            modal.querySelector('input[name="status_message"]').value = msg;
+            modal.querySelector('[type="submit"]').click();
 
-        const cbview = await u.waitUntil(() => _converse.api.controlbox.get());
-        const change_status_el = await u.waitUntil(() => cbview.querySelector('.change-status'));
-        change_status_el.click()
-        let modal = _converse.api.modal.get('converse-profile-modal');
-        await u.waitUntil(() => u.isVisible(modal), 1000);
-        const msg = 'My custom status';
-        modal.querySelector('input[name="status_message"]').value = msg;
-        modal.querySelector('[type="submit"]').click();
-
-        const sent_stanzas = _converse.api.connection.get().sent_stanzas;
-        let sent_presence = await u.waitUntil(() => sent_stanzas.filter(s => Strophe.serialize(s).match('presence')).pop());
-        expect(sent_presence).toEqualStanza(stx`
+            const sent_stanzas = _converse.api.connection.get().sent_stanzas;
+            let sent_presence = await u.waitUntil(() =>
+                sent_stanzas.filter((s) => Strophe.serialize(s).match('presence')).pop(),
+            );
+            expect(sent_presence).toEqualStanza(stx`
             <presence xmlns="jabber:client">
                 <status>My custom status</status>
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
-            </presence>`)
+                <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
+            </presence>`);
 
-        cbview.querySelector('.change-status').click()
-        modal = _converse.api.modal.get('converse-profile-modal');
-        await u.waitUntil(() => modal.getAttribute('aria-hidden') === "false", 1000);
-        modal.querySelector('label[for="radio-busy"]').click(); // Change status to "dnd"
-        modal.querySelector('[type="submit"]').click();
+            cbview.querySelector('.change-status').click();
+            modal = _converse.api.modal.get('converse-profile-modal');
+            await u.waitUntil(() => modal.getAttribute('aria-hidden') === 'false', 1000);
+            modal.querySelector('label[for="radio-busy"]').click(); // Change status to "dnd"
+            modal.querySelector('[type="submit"]').click();
 
-        await u.waitUntil(() => sent_stanzas.filter(s => Strophe.serialize(s).match('presence')).length === 2);
-        sent_presence = sent_stanzas.filter(s => Strophe.serialize(s).match('presence')).pop();
-        expect(sent_presence)
-            .toEqualStanza(stx`
+            await u.waitUntil(() => sent_stanzas.filter((s) => Strophe.serialize(s).match('presence')).length === 2);
+            sent_presence = sent_stanzas.filter((s) => Strophe.serialize(s).match('presence')).pop();
+            expect(sent_presence).toEqualStanza(stx`
                 <presence xmlns="jabber:client">
                     <show>dnd</show>
                     <status>My custom status</status>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
-                </presence>`)
-    }));
+                    <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
+                </presence>`);
+        }),
+    );
 });

--- a/src/plugins/rosterview/tests/protocol.js
+++ b/src/plugins/rosterview/tests/protocol.js
@@ -4,11 +4,10 @@
 
 const { u, $iq, $pres, sizzle, Strophe, stx } = converse.env;
 
-describe("Presence subscriptions", function () {
-
+describe('Presence subscriptions', function () {
     beforeEach(() => jasmine.addMatchers({ toEqualStanza: jasmine.toEqualStanza }));
 
-    describe("Integration of Roster Items and Presence Subscriptions", function () {
+    describe('Integration of Roster Items and Presence Subscriptions', function () {
         /* Some level of integration between roster items and presence
          * subscriptions is normally expected by an instant messaging user
          * regarding the user's subscriptions to and from other contacts. This
@@ -37,430 +36,456 @@ describe("Presence subscriptions", function () {
          * that session. A client MUST acknowledge each roster push with an IQ
          * stanza of type "result".
          */
-        it("Subscribe to contact, contact accepts and subscribes back",
-                mock.initConverse([], { show_self_in_roster: false, roster_groups: false }, async function (_converse) {
+        it(
+            'Subscribe to contact, contact accepts and subscribes back',
+            mock.initConverse([], { show_self_in_roster: false, roster_groups: false }, async function (_converse) {
+                let stanza;
+                await mock.waitForRoster(_converse, 'current', 0);
+                await mock.waitUntilDiscoConfirmed(_converse, 'montague.lit', [], ['vcard-temp']);
+                await u.waitUntil(() => _converse.xmppstatus.vcard?.get('fullname'), 300);
+                /* The process by which a user subscribes to a contact, including
+                 * the interaction between roster items and subscription states.
+                 */
+                mock.openControlBox(_converse);
+                spyOn(_converse.roster, 'sendContactAddIQ').and.callThrough();
+                spyOn(_converse.api.vcard, 'get').and.callThrough();
 
-            let stanza;
-            await mock.waitForRoster(_converse, 'current', 0);
-            await mock.waitUntilDiscoConfirmed(_converse, 'montague.lit', [], ['vcard-temp']);
-            await u.waitUntil(() => _converse.xmppstatus.vcard?.get('fullname'), 300);
-            /* The process by which a user subscribes to a contact, including
-             * the interaction between roster items and subscription states.
-             */
-            mock.openControlBox(_converse);
-            spyOn(_converse.roster, "sendContactAddIQ").and.callThrough();
-            spyOn(_converse.api.vcard, "get").and.callThrough();
+                const cbview = await u.waitUntil(() => _converse.api.controlbox.get());
+                const add_contact_button = await u.waitUntil(() => cbview.querySelector('.add-contact'));
+                add_contact_button.click();
 
-            const cbview = await u.waitUntil(() => _converse.api.controlbox.get());
-            const add_contact_button = await u.waitUntil(() => cbview.querySelector('.add-contact'));
-            add_contact_button.click()
+                const modal = _converse.api.modal.get('converse-add-contact-modal');
+                await u.waitUntil(() => u.isVisible(modal), 1000);
 
-            const modal = _converse.api.modal.get('converse-add-contact-modal');
-            await u.waitUntil(() => u.isVisible(modal), 1000);
+                // Fill in the form and submit
+                const form = modal.querySelector('form.add-xmpp-contact');
+                form.querySelector('input[name="jid"]').value = 'contact@example.org';
+                form.querySelector('input[name="name"]').value = 'Chris Contact';
+                form.querySelector('input[name="groups"]').value = 'My Buddies';
+                form.querySelector('[type="submit"]').click();
 
-            // Fill in the form and submit
-            const form = modal.querySelector('form.add-xmpp-contact');
-            form.querySelector('input[name="jid"]').value = 'contact@example.org';
-            form.querySelector('input[name="name"]').value = 'Chris Contact';
-            form.querySelector('input[name="groups"]').value = 'My Buddies';
-            form.querySelector('[type="submit"]').click();
+                /* In preparation for being able to render the contact in the
+                 * user's client interface and for the server to keep track of the
+                 * subscription, the user's client SHOULD perform a "roster set"
+                 * for the new roster item.
+                 */
 
-            /* In preparation for being able to render the contact in the
-             * user's client interface and for the server to keep track of the
-             * subscription, the user's client SHOULD perform a "roster set"
-             * for the new roster item.
-             */
+                /* The request consists of sending an IQ
+                 * stanza of type='set' containing a <query/> element qualified by
+                 * the 'jabber:iq:roster' namespace, which in turn contains an
+                 * <item/> element that defines the new roster item; the <item/>
+                 * element MUST possess a 'jid' attribute, MAY possess a 'name'
+                 * attribute, MUST NOT possess a 'subscription' attribute, and MAY
+                 * contain one or more <group/> child elements:
+                 */
+                await mock.waitForRoster(_converse, 'all', 0);
+                expect(_converse.roster.sendContactAddIQ).toHaveBeenCalled();
 
-            /* The request consists of sending an IQ
-             * stanza of type='set' containing a <query/> element qualified by
-             * the 'jabber:iq:roster' namespace, which in turn contains an
-             * <item/> element that defines the new roster item; the <item/>
-             * element MUST possess a 'jid' attribute, MAY possess a 'name'
-             * attribute, MUST NOT possess a 'subscription' attribute, and MAY
-             * contain one or more <group/> child elements:
-             */
-            await mock.waitForRoster(_converse, 'all', 0);
-            expect(_converse.roster.sendContactAddIQ).toHaveBeenCalled();
+                const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
+                const roster_set_stanza = IQ_stanzas.filter((s) => sizzle('query[xmlns="jabber:iq:roster"]', s)).pop();
 
-            const IQ_stanzas = _converse.api.connection.get().IQ_stanzas;
-            const roster_set_stanza = IQ_stanzas.filter(s => sizzle('query[xmlns="jabber:iq:roster"]', s)).pop();
-
-            expect(roster_set_stanza).toEqualStanza(
-                stx`<iq id="${roster_set_stanza.getAttribute('id')}" type="set" xmlns="jabber:client">
+                expect(roster_set_stanza).toEqualStanza(
+                    stx`<iq id="${roster_set_stanza.getAttribute('id')}" type="set" xmlns="jabber:client">
                     <query xmlns="jabber:iq:roster">
                         <item jid="contact@example.org" name="Chris Contact">
                             <group>My Buddies</group>
                         </item>
                     </query>
-                </iq>`
-            );
+                </iq>`,
+                );
 
-            const sent_stanzas = [];
-            let sent_stanza;
-            spyOn(_converse.api.connection.get(), 'send').and.callFake(function (stanza) {
-                sent_stanza = stanza;
-                sent_stanzas.push(stanza);
-            });
+                const sent_stanzas = [];
+                let sent_stanza;
+                spyOn(_converse.api.connection.get(), 'send').and.callFake(function (stanza) {
+                    sent_stanza = stanza;
+                    sent_stanzas.push(stanza);
+                });
 
-            /* As a result, the user's server (1) MUST initiate a roster push
-             * for the new roster item to all available resources associated
-             * with the user that have requested the roster, setting the
-             * 'subscription' attribute to a value of "none"; and (2) MUST
-             * reply to the sending resource with an IQ result indicating the
-             * success of the roster set:
-             */
-            _converse.api.connection.get()._dataRecv(mock.createRequest(
-                stx`<iq type="set" xmlns="jabber:client">
+                /* As a result, the user's server (1) MUST initiate a roster push
+                 * for the new roster item to all available resources associated
+                 * with the user that have requested the roster, setting the
+                 * 'subscription' attribute to a value of "none"; and (2) MUST
+                 * reply to the sending resource with an IQ result indicating the
+                 * success of the roster set:
+                 */
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`<iq type="set" xmlns="jabber:client">
                     <query xmlns="jabber:iq:roster">
                         <item jid="contact@example.org" subscription="none" name="Chris Contact">
                             <group>My Buddies</group>
                         </item>
                     </query>
-                </iq>`
-            ));
+                </iq>`,
+                    ),
+                );
 
-            _converse.api.connection.get()._dataRecv(mock.createRequest(
-                $iq({'type': 'result', 'id': roster_set_stanza.getAttribute('id')})
-            ));
+                _converse.api.connection
+                    .get()
+                    ._dataRecv(
+                        mock.createRequest($iq({ 'type': 'result', 'id': roster_set_stanza.getAttribute('id') })),
+                    );
 
-            await u.waitUntil(() => _converse.roster.length === 1);
+                await u.waitUntil(() => _converse.roster.length === 1);
 
-            // A contact should now have been created
-            const contact = _converse.roster.at(0);
-            expect(contact.get('jid')).toBe('contact@example.org');
-            expect(contact.get('nickname')).toBe('Chris Contact');
-            expect(contact.get('groups')).toEqual(['My Buddies']);
-            await u.waitUntil(() => contact.initialized);
+                // A contact should now have been created
+                const contact = _converse.roster.at(0);
+                expect(contact.get('jid')).toBe('contact@example.org');
+                expect(contact.get('nickname')).toBe('Chris Contact');
+                expect(contact.get('groups')).toEqual(['My Buddies']);
+                await u.waitUntil(() => contact.initialized);
 
-            /* To subscribe to the contact's presence information,
-             * the user's client MUST send a presence stanza of
-             * type='subscribe' to the contact:
-             *
-             *  <presence to='contact@example.org' type='subscribe'/>
-             */
-            const sent_presence = await u.waitUntil(() => sent_stanzas.filter(s => s.matches('presence')).pop());
-            expect(sent_presence).toEqualStanza(stx`
+                /* To subscribe to the contact's presence information,
+                 * the user's client MUST send a presence stanza of
+                 * type='subscribe' to the contact:
+                 *
+                 *  <presence to='contact@example.org' type='subscribe'/>
+                 */
+                const sent_presence = await u.waitUntil(() => sent_stanzas.filter((s) => s.matches('presence')).pop());
+                expect(sent_presence).toEqualStanza(stx`
                 <presence to="contact@example.org" type="subscribe" xmlns="jabber:client">
                     <nick xmlns="http://jabber.org/protocol/nick">Romeo</nick>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="H63l6q0hnLTdpFJt2JA5AOAGl/o=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="MGI8RlyfupY+RiLF6iOY7u36yDA=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>
             `);
 
-            /* As a result, the user's server MUST initiate a second roster
-             * push to all of the user's available resources that have
-             * requested the roster, setting the contact to the pending
-             * sub-state of the 'none' subscription state; The pending
-             * sub-state is denoted by the inclusion of the ask='subscribe'
-             * attribute in the roster item:
-             */
-            _converse.api.connection.get()._dataRecv(mock.createRequest(
-                stx`<iq type="set" from="${_converse.bare_jid}" xmlns="jabber:client">
+                /* As a result, the user's server MUST initiate a second roster
+                 * push to all of the user's available resources that have
+                 * requested the roster, setting the contact to the pending
+                 * sub-state of the 'none' subscription state; The pending
+                 * sub-state is denoted by the inclusion of the ask='subscribe'
+                 * attribute in the roster item:
+                 */
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`<iq type="set" from="${_converse.bare_jid}" xmlns="jabber:client">
                     <query xmlns="jabber:iq:roster">
                         <item jid="contact@example.org" subscription="none" ask="subscribe" name="Chris Contact">
                             <group>My Buddies</group>
                         </item>
                     </query>
-                </iq>`
-            ));
+                </iq>`,
+                    ),
+                );
 
-            const rosterview = document.querySelector('converse-roster');
+                const rosterview = document.querySelector('converse-roster');
 
-            // Check that the user is now properly shown as a pending contact in the roster.
-            await u.waitUntil(() => {
-                const header = sizzle('a:contains("My Buddies")', rosterview).pop();
-                const contacts = Array.from(header?.parentElement.querySelectorAll('li') ?? []).filter(u.isVisible);
-                return contacts.length;
-            }, 600);
+                // Check that the user is now properly shown as a pending contact in the roster.
+                await u.waitUntil(() => {
+                    const header = sizzle('a:contains("My Buddies")', rosterview).pop();
+                    const contacts = Array.from(header?.parentElement.querySelectorAll('li') ?? []).filter(u.isVisible);
+                    return contacts.length;
+                }, 600);
 
-            let header = sizzle('a:contains("My Buddies")', rosterview).pop();
-            let contacts = header.parentElement.querySelectorAll('li .open-chat');
-            expect(contacts.length).toBe(1);
-            expect(u.isVisible(contacts[0])).toBe(true);
-            sent_stanza = ""; // Reset
+                let header = sizzle('a:contains("My Buddies")', rosterview).pop();
+                let contacts = header.parentElement.querySelectorAll('li .open-chat');
+                expect(contacts.length).toBe(1);
+                expect(u.isVisible(contacts[0])).toBe(true);
+                sent_stanza = ''; // Reset
 
-            spyOn(contact, "ackSubscribe").and.callThrough();
+                spyOn(contact, 'ackSubscribe').and.callThrough();
 
-            /* Here we assume the "happy path" that the contact
-             * approves the subscription request
-             */
-            _converse.api.connection.get()._dataRecv(mock.createRequest(
-                stanza = stx`<presence to="${_converse.bare_jid}" from="contact@example.org" type="subscribed" xmlns="jabber:client"/>`
-            ));
+                /* Here we assume the "happy path" that the contact
+                 * approves the subscription request
+                 */
+                _converse.api.connection
+                    .get()
+                    ._dataRecv(
+                        mock.createRequest(
+                            (stanza = stx`<presence to="${_converse.bare_jid}" from="contact@example.org" type="subscribed" xmlns="jabber:client"/>`),
+                        ),
+                    );
 
-            /* Upon receiving the presence stanza of type "subscribed",
-             * the user SHOULD acknowledge receipt of that
-             * subscription state notification by sending a presence
-             * stanza of type "subscribe".
-             */
-            expect(contact.ackSubscribe).toHaveBeenCalled();
-            expect(sent_stanza).toEqualStanza(
-                stx`<presence to="contact@example.org" type="subscribe" xmlns="jabber:client"/>`
-            );
+                /* Upon receiving the presence stanza of type "subscribed",
+                 * the user SHOULD acknowledge receipt of that
+                 * subscription state notification by sending a presence
+                 * stanza of type "subscribe".
+                 */
+                expect(contact.ackSubscribe).toHaveBeenCalled();
+                expect(sent_stanza).toEqualStanza(
+                    stx`<presence to="contact@example.org" type="subscribe" xmlns="jabber:client"/>`,
+                );
 
-            /* The user's server MUST initiate a roster push to all of the user's
-             * available resources that have requested the roster,
-             * containing an updated roster item for the contact with
-             * the 'subscription' attribute set to a value of "to";
-             */
-            const IQ_id = _converse.api.connection.get().getUniqueId('roster');
-            stanza = stx`<iq type="set" id="${IQ_id}" xmlns="jabber:client">
+                /* The user's server MUST initiate a roster push to all of the user's
+                 * available resources that have requested the roster,
+                 * containing an updated roster item for the contact with
+                 * the 'subscription' attribute set to a value of "to";
+                 */
+                const IQ_id = _converse.api.connection.get().getUniqueId('roster');
+                stanza = stx`<iq type="set" id="${IQ_id}" xmlns="jabber:client">
                 <query xmlns="jabber:iq:roster">
                     <item jid="contact@example.org" subscription="to" name="Nicky"/>
                 </query>
             </iq>`;
 
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            // Check that the IQ set was acknowledged.
-            expect(Strophe.serialize(sent_stanza)).toBe( // Strophe adds the xmlns attr (although not in spec)
-                `<iq from="romeo@montague.lit/orchard" id="${IQ_id}" type="result" xmlns="jabber:client"/>`
-            );
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                // Check that the IQ set was acknowledged.
+                expect(Strophe.serialize(sent_stanza)).toBe(
+                    // Strophe adds the xmlns attr (although not in spec)
+                    `<iq from="romeo@montague.lit/orchard" id="${IQ_id}" type="result" xmlns="jabber:client"/>`,
+                );
 
-            // The contact should now be visible as an existing contact (but still offline).
-            await u.waitUntil(() => {
-                const header = sizzle('a:contains("My contacts")', rosterview).pop();
-                return sizzle('li', header?.parentNode).filter(l => u.isVisible(l)).length;
-            }, 600);
-            header = sizzle('a:contains("My contacts")', rosterview);
-            expect(header.length).toBe(1);
-            expect(u.isVisible(header[0])).toBeTruthy();
-            contacts = header[0].parentNode.querySelectorAll('li.current-xmpp-contact');
-            expect(contacts.length).toBe(1);
-            // Check that it has the right classes and text
-            expect(u.hasClass('to', contacts[0])).toBeTruthy();
-            expect(u.hasClass('both', contacts[0])).toBeFalsy();
-            expect(u.hasClass('current-xmpp-contact', contacts[0])).toBeTruthy();
+                // The contact should now be visible as an existing contact (but still offline).
+                await u.waitUntil(() => {
+                    const header = sizzle('a:contains("My contacts")', rosterview).pop();
+                    return sizzle('li', header?.parentNode).filter((l) => u.isVisible(l)).length;
+                }, 600);
+                header = sizzle('a:contains("My contacts")', rosterview);
+                expect(header.length).toBe(1);
+                expect(u.isVisible(header[0])).toBeTruthy();
+                contacts = header[0].parentNode.querySelectorAll('li.current-xmpp-contact');
+                expect(contacts.length).toBe(1);
+                // Check that it has the right classes and text
+                expect(u.hasClass('to', contacts[0])).toBeTruthy();
+                expect(u.hasClass('both', contacts[0])).toBeFalsy();
+                expect(u.hasClass('current-xmpp-contact', contacts[0])).toBeTruthy();
 
-            await u.waitUntil(() => contacts[0].querySelector('.contact-name')?.textContent.trim() === 'Nicky');
+                await u.waitUntil(() => contacts[0].querySelector('.contact-name')?.textContent.trim() === 'Nicky');
 
-            expect(contact.presence.getStatus()).toBe('offline');
+                expect(contact.presence.getStatus()).toBe('offline');
 
-            /*  <presence
-             *      from='contact@example.org/resource'
-             *      to='user@example.com/resource'/>
-             */
-            stanza = $pres({'to': _converse.bare_jid, 'from': 'contact@example.org/resource'});
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            // Now the contact should also be online.
-            expect(contact.presence.getStatus()).toBe('online');
+                /*  <presence
+                 *      from='contact@example.org/resource'
+                 *      to='user@example.com/resource'/>
+                 */
+                stanza = $pres({ 'to': _converse.bare_jid, 'from': 'contact@example.org/resource' });
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                // Now the contact should also be online.
+                expect(contact.presence.getStatus()).toBe('online');
 
-            /* Section 8.3.  Creating a Mutual Subscription
-             *
-             * If the contact wants to create a mutual subscription,
-             * the contact MUST send a subscription request to the
-             * user.
-             *
-             * <presence from='contact@example.org' to='user@example.com' type='subscribe'/>
-             */
-            spyOn(contact, 'authorize').and.callThrough();
-            spyOn(_converse.roster, 'handleIncomingSubscription').and.callThrough();
-            stanza = $pres({
-                'to': _converse.bare_jid,
-                'from': 'contact@example.org/resource',
-                'type': 'subscribe'});
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            expect(_converse.roster.handleIncomingSubscription).toHaveBeenCalled();
+                /* Section 8.3.  Creating a Mutual Subscription
+                 *
+                 * If the contact wants to create a mutual subscription,
+                 * the contact MUST send a subscription request to the
+                 * user.
+                 *
+                 * <presence from='contact@example.org' to='user@example.com' type='subscribe'/>
+                 */
+                spyOn(contact, 'authorize').and.callThrough();
+                spyOn(_converse.roster, 'handleIncomingSubscription').and.callThrough();
+                stanza = $pres({
+                    'to': _converse.bare_jid,
+                    'from': 'contact@example.org/resource',
+                    'type': 'subscribe',
+                });
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                expect(_converse.roster.handleIncomingSubscription).toHaveBeenCalled();
 
-            /* The user's client MUST send a presence stanza of type
-             * "subscribed" to the contact in order to approve the
-             * subscription request.
-             *
-             *  <presence to='contact@example.org' type='subscribed'/>
-             */
-            expect(contact.authorize).toHaveBeenCalled();
-            expect(sent_stanza).toEqualStanza(
-                stx`<presence to="contact@example.org" type="subscribed" xmlns="jabber:client"/>`
-            );
+                /* The user's client MUST send a presence stanza of type
+                 * "subscribed" to the contact in order to approve the
+                 * subscription request.
+                 *
+                 *  <presence to='contact@example.org' type='subscribed'/>
+                 */
+                expect(contact.authorize).toHaveBeenCalled();
+                expect(sent_stanza).toEqualStanza(
+                    stx`<presence to="contact@example.org" type="subscribed" xmlns="jabber:client"/>`,
+                );
 
-            /* As a result, the user's server MUST initiate a
-             * roster push containing a roster item for the
-             * contact with the 'subscription' attribute set to
-             * a value of "both".
-             */
-            _converse.api.connection.get()._dataRecv(mock.createRequest(
-                stx`<iq type="set" xmlns="jabber:client">
+                /* As a result, the user's server MUST initiate a
+                 * roster push containing a roster item for the
+                 * contact with the 'subscription' attribute set to
+                 * a value of "both".
+                 */
+                _converse.api.connection.get()._dataRecv(
+                    mock.createRequest(
+                        stx`<iq type="set" xmlns="jabber:client">
                     <query xmlns="jabber:iq:roster">
                         <item jid="contact@example.org" subscription="both" name="contact@example.org"/>
                     </query>
-                </iq>`
-            ));
+                </iq>`,
+                    ),
+                );
 
-            // The class on the contact will now have switched.
-            await u.waitUntil(() => !u.hasClass('to', contacts[0]));
-            expect(u.hasClass('both', contacts[0])).toBe(true);
-        }));
+                // The class on the contact will now have switched.
+                await u.waitUntil(() => !u.hasClass('to', contacts[0]));
+                expect(u.hasClass('both', contacts[0])).toBe(true);
+            }),
+        );
 
-        it("Alternate Flow: Contact Declines Subscription Request",
-                mock.initConverse([], {}, async function (_converse) {
-
-            const { $iq, $pres } = converse.env;
-            /* The process by which a user subscribes to a contact, including
-             * the interaction between roster items and subscription states.
-             */
-            var contact, stanza, sent_stanza, sent_IQ;
-            await mock.waitForRoster(_converse, 'current', 0);
-            mock.openControlBox(_converse);
-            // Add a new roster contact via roster push
-            stanza = $iq({'type': 'set'}).c('query', {'xmlns': 'jabber:iq:roster'})
-                .c('item', {
+        it(
+            'Alternate Flow: Contact Declines Subscription Request',
+            mock.initConverse([], {}, async function (_converse) {
+                const { $iq, $pres } = converse.env;
+                /* The process by which a user subscribes to a contact, including
+                 * the interaction between roster items and subscription states.
+                 */
+                var contact, stanza, sent_stanza, sent_IQ;
+                await mock.waitForRoster(_converse, 'current', 0);
+                mock.openControlBox(_converse);
+                // Add a new roster contact via roster push
+                stanza = $iq({ 'type': 'set' }).c('query', { 'xmlns': 'jabber:iq:roster' }).c('item', {
                     'jid': 'contact@example.org',
                     'subscription': 'none',
                     'ask': 'subscribe',
-                    'name': 'contact@example.org'});
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            // A pending contact should now exist.
-            contact = _converse.roster.get('contact@example.org');
-            expect(_converse.roster.get('contact@example.org') instanceof _converse.RosterContact).toBeTruthy();
-            spyOn(contact, "ackUnsubscribe").and.callThrough();
+                    'name': 'contact@example.org',
+                });
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                // A pending contact should now exist.
+                contact = _converse.roster.get('contact@example.org');
+                expect(_converse.roster.get('contact@example.org') instanceof _converse.RosterContact).toBeTruthy();
+                spyOn(contact, 'ackUnsubscribe').and.callThrough();
 
-            spyOn(_converse.api.connection.get(), 'send').and.callFake(stanza => { sent_stanza = stanza });
-            spyOn(_converse.api.connection.get(), 'sendIQ').and.callFake(iq => { sent_IQ = iq });
-            /* We now assume the contact declines the subscription
-             * requests.
-             *
-             * Upon receiving the presence stanza of type "unsubscribed"
-             * addressed to the user, the user's server (1) MUST deliver
-             * that presence stanza to the user and (2) MUST initiate a
-             * roster push to all of the user's available resources that
-             * have requested the roster, containing an updated roster
-             * item for the contact with the 'subscription' attribute
-             * set to a value of "none" and with no 'ask' attribute:
-             *
-             *  <presence
-             *      from='contact@example.org'
-             *      to='user@example.com'
-             *      type='unsubscribed'/>
-             *
-             *  <iq type='set'>
-             *  <query xmlns='jabber:iq:roster'>
-             *      <item
-             *          jid='contact@example.org'
-             *          subscription='none'
-             *          name='MyContact'>
-             *      <group>MyBuddies</group>
-             *      </item>
-             *  </query>
-             *  </iq>
-             */
-            // FIXME: also add the <iq>
-            stanza = $pres({
-                'to': _converse.bare_jid,
-                'from': 'contact@example.org',
-                'type': 'unsubscribed'
-            });
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                spyOn(_converse.api.connection.get(), 'send').and.callFake((stanza) => {
+                    sent_stanza = stanza;
+                });
+                spyOn(_converse.api.connection.get(), 'sendIQ').and.callFake((iq) => {
+                    sent_IQ = iq;
+                });
+                /* We now assume the contact declines the subscription
+                 * requests.
+                 *
+                 * Upon receiving the presence stanza of type "unsubscribed"
+                 * addressed to the user, the user's server (1) MUST deliver
+                 * that presence stanza to the user and (2) MUST initiate a
+                 * roster push to all of the user's available resources that
+                 * have requested the roster, containing an updated roster
+                 * item for the contact with the 'subscription' attribute
+                 * set to a value of "none" and with no 'ask' attribute:
+                 *
+                 *  <presence
+                 *      from='contact@example.org'
+                 *      to='user@example.com'
+                 *      type='unsubscribed'/>
+                 *
+                 *  <iq type='set'>
+                 *  <query xmlns='jabber:iq:roster'>
+                 *      <item
+                 *          jid='contact@example.org'
+                 *          subscription='none'
+                 *          name='MyContact'>
+                 *      <group>MyBuddies</group>
+                 *      </item>
+                 *  </query>
+                 *  </iq>
+                 */
+                // FIXME: also add the <iq>
+                stanza = $pres({
+                    'to': _converse.bare_jid,
+                    'from': 'contact@example.org',
+                    'type': 'unsubscribed',
+                });
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
 
-            /* Upon receiving the presence stanza of type "unsubscribed",
-             * the user SHOULD acknowledge receipt of that subscription
-             * state notification through either "affirming" it by
-             * sending a presence stanza of type "unsubscribe
-             */
-            expect(contact.ackUnsubscribe).toHaveBeenCalled();
-            expect(Strophe.serialize(sent_stanza)).toBe(
-                `<presence to="contact@example.org" type="unsubscribe" xmlns="jabber:client"/>`
-            );
+                /* Upon receiving the presence stanza of type "unsubscribed",
+                 * the user SHOULD acknowledge receipt of that subscription
+                 * state notification through either "affirming" it by
+                 * sending a presence stanza of type "unsubscribe
+                 */
+                expect(contact.ackUnsubscribe).toHaveBeenCalled();
+                expect(Strophe.serialize(sent_stanza)).toBe(
+                    `<presence to="contact@example.org" type="unsubscribe" xmlns="jabber:client"/>`,
+                );
 
-            /* _converse.js will then also automatically remove the
-             * contact from the user's roster.
-             */
-            expect(Strophe.serialize(sent_IQ)).toBe(
-                `<iq type="set" xmlns="jabber:client">`+
-                    `<query xmlns="jabber:iq:roster">`+
-                        `<item jid="contact@example.org" subscription="remove"/>`+
-                    `</query>`+
-                `</iq>`
-            );
-        }));
+                /* _converse.js will then also automatically remove the
+                 * contact from the user's roster.
+                 */
+                expect(Strophe.serialize(sent_IQ)).toBe(
+                    `<iq type="set" xmlns="jabber:client">` +
+                        `<query xmlns="jabber:iq:roster">` +
+                        `<item jid="contact@example.org" subscription="remove"/>` +
+                        `</query>` +
+                        `</iq>`,
+                );
+            }),
+        );
 
-        it("Unsubscribe to a contact when subscription is mutual",
-                mock.initConverse([], { roster_groups: false }, async function (_converse) {
+        it(
+            'Unsubscribe to a contact when subscription is mutual',
+            mock.initConverse([], { roster_groups: false }, async function (_converse) {
+                const { u, $iq, sizzle, Strophe } = converse.env;
+                const jid = 'abram@montague.lit';
+                await mock.openControlBox(_converse);
+                await mock.waitForRoster(_converse, 'current');
+                spyOn(_converse.api, 'confirm').and.callFake(() => Promise.resolve(true));
+                // We now have a contact we want to remove
+                expect(_converse.roster.get(jid) instanceof _converse.RosterContact).toBeTruthy();
 
-            const { u, $iq, sizzle, Strophe } = converse.env;
-            const jid = 'abram@montague.lit';
-            await mock.openControlBox(_converse);
-            await mock.waitForRoster(_converse, 'current');
-            spyOn(_converse.api, 'confirm').and.callFake(() => Promise.resolve(true));
-            // We now have a contact we want to remove
-            expect(_converse.roster.get(jid) instanceof _converse.RosterContact).toBeTruthy();
+                const rosterview = document.querySelector('converse-roster');
+                const header = sizzle('a:contains("My contacts")', rosterview).pop();
+                await u.waitUntil(() => header.parentElement.querySelectorAll('li').length);
 
-            const rosterview = document.querySelector('converse-roster');
-            const header = sizzle('a:contains("My contacts")', rosterview).pop();
-            await u.waitUntil(() => header.parentElement.querySelectorAll('li').length);
+                // remove the first user
+                header.parentElement.querySelector('li .remove-xmpp-contact').click();
+                expect(_converse.api.confirm).toHaveBeenCalled();
 
-            // remove the first user
-            header.parentElement.querySelector('li .remove-xmpp-contact').click();
-            expect(_converse.api.confirm).toHaveBeenCalled();
+                /* Section 8.6 Removing a Roster Item and Cancelling All
+                 * Subscriptions
+                 *
+                 * First the user is removed from the roster
+                 * Because there may be many steps involved in completely
+                 * removing a roster item and cancelling subscriptions in
+                 * both directions, the roster management protocol includes
+                 * a "shortcut" method for doing so. The process may be
+                 * initiated no matter what the current subscription state
+                 * is by sending a roster set containing an item for the
+                 * contact with the 'subscription' attribute set to a value
+                 * of "remove":
+                 *
+                 * <iq type='set' id='remove1'>
+                 *   <query xmlns='jabber:iq:roster'>
+                 *       <item jid='contact@example.org' subscription='remove'/>
+                 *   </query>
+                 * </iq>
+                 */
+                const iq_stanzas = _converse.api.connection.get().IQ_stanzas;
+                await u.waitUntil(
+                    () =>
+                        Strophe.serialize(iq_stanzas.at(-1)) ===
+                        `<iq id="${iq_stanzas.at(-1).getAttribute('id')}" type="set" xmlns="jabber:client">` +
+                            `<query xmlns="jabber:iq:roster">` +
+                            `<item jid="abram@montague.lit" subscription="remove"/>` +
+                            `</query>` +
+                            `</iq>`,
+                );
+                const sent_iq = iq_stanzas.at(-1);
 
-            /* Section 8.6 Removing a Roster Item and Cancelling All
-             * Subscriptions
-             *
-             * First the user is removed from the roster
-             * Because there may be many steps involved in completely
-             * removing a roster item and cancelling subscriptions in
-             * both directions, the roster management protocol includes
-             * a "shortcut" method for doing so. The process may be
-             * initiated no matter what the current subscription state
-             * is by sending a roster set containing an item for the
-             * contact with the 'subscription' attribute set to a value
-             * of "remove":
-             *
-             * <iq type='set' id='remove1'>
-             *   <query xmlns='jabber:iq:roster'>
-             *       <item jid='contact@example.org' subscription='remove'/>
-             *   </query>
-             * </iq>
-             */
-            const iq_stanzas = _converse.api.connection.get().IQ_stanzas;
-            await u.waitUntil(() => Strophe.serialize(iq_stanzas.at(-1)) ===
-                `<iq id="${iq_stanzas.at(-1).getAttribute('id')}" type="set" xmlns="jabber:client">`+
-                    `<query xmlns="jabber:iq:roster">`+
-                        `<item jid="abram@montague.lit" subscription="remove"/>`+
-                    `</query>`+
-                `</iq>`);
-            const sent_iq = iq_stanzas.at(-1);
+                // Receive confirmation from the contact's server
+                // <iq type='result' id='remove1'/>
+                const stanza = $iq({ 'type': 'result', 'id': sent_iq.getAttribute('id') });
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                // Our contact has now been removed
+                await u.waitUntil(() => typeof _converse.roster.get(jid) === 'undefined');
+            }),
+        );
 
-            // Receive confirmation from the contact's server
-            // <iq type='result' id='remove1'/>
-            const stanza = $iq({'type': 'result', 'id': sent_iq.getAttribute('id')});
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            // Our contact has now been removed
-            await u.waitUntil(() => typeof _converse.roster.get(jid) === "undefined");
-        }));
+        it(
+            'Receiving a subscription request',
+            mock.initConverse([], {}, async function (_converse) {
+                const { u, $pres, sizzle, Strophe } = converse.env;
+                spyOn(_converse.api, 'trigger').and.callThrough();
+                await mock.openControlBox(_converse);
+                await mock.waitForRoster(_converse, 'current');
+                /* <presence
+                 *     from='user@example.com'
+                 *     to='contact@example.org'
+                 *     type='subscribe'/>
+                 */
+                const stanza = $pres({
+                    'to': _converse.bare_jid,
+                    'from': 'contact@example.org',
+                    'type': 'subscribe',
+                })
+                    .c('nick', {
+                        'xmlns': Strophe.NS.NICK,
+                    })
+                    .t('Clint Contact');
 
-        it("Receiving a subscription request", mock.initConverse(
-                [], {}, async function (_converse) {
+                _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
+                const rosterview = document.querySelector('converse-roster');
+                await u.waitUntil(() => {
+                    const header = sizzle('a:contains("Contact requests")', rosterview).pop();
+                    return Array.from(header?.parentElement.querySelectorAll('li') ?? []).filter(u.isVisible)?.length;
+                }, 500);
+                expect(_converse.api.trigger).toHaveBeenCalledWith('contactRequest', jasmine.any(Object));
 
-            const { u, $pres, sizzle, Strophe } = converse.env;
-            spyOn(_converse.api, "trigger").and.callThrough();
-            await mock.openControlBox(_converse);
-            await mock.waitForRoster(_converse, 'current');
-            /* <presence
-             *     from='user@example.com'
-             *     to='contact@example.org'
-             *     type='subscribe'/>
-             */
-            const stanza = $pres({
-                'to': _converse.bare_jid,
-                'from': 'contact@example.org',
-                'type': 'subscribe'
-            }).c('nick', {
-                'xmlns': Strophe.NS.NICK,
-            }).t('Clint Contact');
-
-
-            _converse.api.connection.get()._dataRecv(mock.createRequest(stanza));
-            const rosterview = document.querySelector('converse-roster');
-            await u.waitUntil(() => {
                 const header = sizzle('a:contains("Contact requests")', rosterview).pop();
-                return Array.from(header?.parentElement.querySelectorAll('li') ?? []).filter(u.isVisible)?.length;
-            }, 500);
-            expect(_converse.api.trigger).toHaveBeenCalledWith('contactRequest', jasmine.any(Object));
-
-            const header = sizzle('a:contains("Contact requests")', rosterview).pop();
-            expect(u.isVisible(header)).toBe(true);
-            const contacts = header.nextElementSibling.querySelectorAll('.open-chat');
-            expect(contacts.length).toBe(1);
-        }));
+                expect(u.isVisible(header)).toBe(true);
+                const contacts = header.nextElementSibling.querySelectorAll('.open-chat');
+                expect(contacts.length).toBe(1);
+            }),
+        );
     });
 });

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -21,6 +21,7 @@ export const VIEW_PLUGINS = [
     'converse-muc-views',
     'converse-notification',
     'converse-omemo-views',
+    'converse-bob-views',
     'converse-profile',
     'converse-push',
     'converse-register',

--- a/src/types/plugins/bob-views/index.d.ts
+++ b/src/types/plugins/bob-views/index.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=index.d.ts.map

--- a/src/types/plugins/bob-views/utils.d.ts
+++ b/src/types/plugins/bob-views/utils.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Handle BOB images in message body after transformation
+ * @param {import('shared/texture/texture.js').Texture} texture
+ */
+export function handleBOBImages(texture: import("shared/texture/texture.js").Texture): Promise<void>;
+//# sourceMappingURL=utils.d.ts.map

--- a/src/types/shared/texture/components/audio-player.d.ts
+++ b/src/types/shared/texture/components/audio-player.d.ts
@@ -1,0 +1,73 @@
+/**
+ * Accessible audio player component
+ * Provides custom controls that work with screen readers like NVDA and JAWS
+ */
+export default class AudioPlayer extends CustomElement {
+    static get properties(): {
+        src: {
+            type: StringConstructor;
+        };
+        title: {
+            type: StringConstructor;
+        };
+        hide_url: {
+            type: BooleanConstructor;
+        };
+        is_playing: {
+            state: boolean;
+        };
+        current_time: {
+            state: boolean;
+        };
+        duration: {
+            state: boolean;
+        };
+        volume: {
+            state: boolean;
+        };
+        is_muted: {
+            state: boolean;
+        };
+        is_loading: {
+            state: boolean;
+        };
+        has_error: {
+            state: boolean;
+        };
+        playback_speed: {
+            state: boolean;
+        };
+    };
+    src: string;
+    hide_url: boolean;
+    is_playing: boolean;
+    current_time: number;
+    duration: number;
+    volume: number;
+    is_muted: boolean;
+    is_loading: boolean;
+    has_error: boolean;
+    playback_speed: number;
+    /** @type {HTMLAudioElement|null} */
+    audio: HTMLAudioElement | null;
+    connectedCallback(): void;
+    /**
+     * Toggle play/pause
+     * @param {Event} [ev]
+     */
+    togglePlay(ev?: Event): void;
+    /**
+     * Toggle mute
+     * @param {Event} [ev]
+     */
+    toggleMute(ev?: Event): void;
+    /**
+     * Cycle through playback speeds
+     * @param {Event} [ev]
+     */
+    cyclePlaybackSpeed(ev?: Event): void;
+    render(): import("lit-html").TemplateResult<1>;
+    #private;
+}
+import { CustomElement } from "shared/components/element.js";
+//# sourceMappingURL=audio-player.d.ts.map


### PR DESCRIPTION
## Summary
Implements [XEP-0231: Bits of Binary](https://xmpp.org/extensions/xep-0231.html), enabling Converse.js to receive and display inline binary data such as custom smileys from clients like Pidgin.
Closes #3611
## Implementation
### New `converse-bob` Plugin
- **In-memory cache** with TTL and max-age expiration
- **API**: `api.bob.get()`, `api.bob.store()`, `api.bob.has()`  
- **IQ handling**: Fetches uncached BOB data via `<iq type="get">`
- **Message parsing**: Extracts `<data xmlns="urn:xmpp:bob">` elements
- **Disco feature**: Registers `urn:xmpp:bob`
- **Security**: Image MIME types only, 8KB size limit per spec
## Test Results
TOTAL: 94 SUCCESS

### New Tests (7)
- Cache storage, retrieval, expiration
- Size and MIME validation
- Message parsing and IQ requests
- Error handling
## Capability Hash
Adding `urn:xmpp:bob` updates XEP-0115 verification string from `1T0pIfIxYO645OaT9gpXVXOvb9s=` to `ZXDrJD54GWZYlZif9IuMxum/u+g=`