### PR TITLE
feat: Add send current location button to chat toolbar

### DIFF
--- a/src/plugins/chatview/index.js
+++ b/src/plugins/chatview/index.js
@@ -52,6 +52,7 @@ converse.plugins.add('converse-chatview', {
                 'call': false,
                 'clear': true,
                 'emoji': true,
+                'location': true,
                 'spoiler': false
             }
         });

--- a/src/plugins/chatview/templates/message-form.js
+++ b/src/plugins/chatview/templates/message-form.js
@@ -12,10 +12,9 @@ export default (el) => {
     const label_message = composing_spoiler ? __("Hidden message") : __("Message");
     const label_spoiler_hint = __("Optional hint");
     const message_limit = api.settings.get("message_limit");
-    const show_call_button = api.settings.get("visible_toolbar_buttons").call;
-    const show_emoji_button = api.settings.get("visible_toolbar_buttons").emoji;
+    const toolbar_buttons = api.settings.get("visible_toolbar_buttons");
+    const { call: show_call_button, emoji: show_emoji_button, location: show_location_button, spoiler: show_spoiler_button } = toolbar_buttons;
     const show_send_button = api.settings.get("show_send_button");
-    const show_spoiler_button = api.settings.get("visible_toolbar_buttons").spoiler;
     const show_toolbar = api.settings.get("show_toolbar");
 
     return html`
@@ -31,6 +30,7 @@ export default (el) => {
                   ?composing_spoiler="${composing_spoiler}"
                   ?show_call_button="${show_call_button}"
                   ?show_emoji_button="${show_emoji_button}"
+                  ?show_location_button="${show_location_button}"
                   ?show_send_button="${show_send_button}"
                   ?show_spoiler_button="${show_spoiler_button}"
                   ?show_toolbar="${show_toolbar}"

--- a/src/plugins/chatview/tests/location.js
+++ b/src/plugins/chatview/tests/location.js
@@ -1,0 +1,46 @@
+/*global mock, converse */
+
+const { u } = converse.env;
+
+describe("The Location Button", function () {
+
+    it("shows a confirmation prompt and sends the geo URI in a one-on-one chat",
+        mock.initConverse(['chatBoxesFetched'], { 'view_mode': 'fullscreen' }, async function (_converse) {
+
+            await mock.waitForRoster(_converse, 'current', 1);
+            await mock.openControlBox(_converse);
+
+            const contact_jid = mock.cur_names[0].replace(/ /g,'.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            spyOn(_converse.api, 'confirm').and.callFake(() => Promise.resolve(true));
+            spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake((success) => {
+                success({ coords: { latitude: 51.5074, longitude: -0.1278 } });
+            });
+
+            const toolbar = view.querySelector('.chat-toolbar');
+            const location_button = toolbar.querySelector('converse-location-button');
+            expect(location_button).not.toBeNull();
+
+            const button = location_button.querySelector('.toggle-location');
+            button.click();
+
+            await u.waitUntil(() => _converse.api.confirm.calls.count() === 1);
+            expect(_converse.api.confirm).toHaveBeenCalledWith(
+                'Confirm',
+                ['Are you sure you\'d like to share your location in the chat?']
+            );
+
+            await u.waitUntil(
+                () => _converse.api.connection.get().sent_stanzas.filter(
+                    s => s.nodeName === 'message' && s.querySelector('body')
+                ).length
+            );
+
+            const sent = _converse.api.connection.get().sent_stanzas.filter(
+                s => s.nodeName === 'message' && s.querySelector('body')
+            ).pop();
+            expect(sent.querySelector('body').textContent).toBe('geo:51.507400,-0.127800');
+        }));
+});

--- a/src/plugins/muc-views/templates/message-form.js
+++ b/src/plugins/muc-views/templates/message-form.js
@@ -12,10 +12,9 @@ export default (el) => {
     const label_message = composing_spoiler ? __("Hidden message") : __("Message");
     const label_spoiler_hint = __("Optional hint");
     const message_limit = api.settings.get("message_limit");
-    const show_call_button = api.settings.get("visible_toolbar_buttons").call;
-    const show_emoji_button = api.settings.get("visible_toolbar_buttons").emoji;
+    const toolbar_buttons = api.settings.get("visible_toolbar_buttons");
+    const { call: show_call_button, emoji: show_emoji_button, location: show_location_button, spoiler: show_spoiler_button } = toolbar_buttons;
     const show_send_button = api.settings.get("show_send_button");
-    const show_spoiler_button = api.settings.get("visible_toolbar_buttons").spoiler;
     const show_toolbar = api.settings.get("show_toolbar");
     return html`
         <converse-reply-preview .model=${el.model}></converse-reply-preview>
@@ -31,6 +30,7 @@ export default (el) => {
                       ?is_groupchat="${el.model.get("message_type") === "groupchat"}"
                       ?show_call_button="${show_call_button}"
                       ?show_emoji_button="${show_emoji_button}"
+                      ?show_location_button="${show_location_button}"
                       ?show_send_button="${show_send_button}"
                       ?show_spoiler_button="${show_spoiler_button}"
                       ?show_toolbar="${show_toolbar}"

--- a/src/plugins/muc-views/tests/location.js
+++ b/src/plugins/muc-views/tests/location.js
@@ -1,0 +1,96 @@
+/*global mock, converse */
+
+const { stx, u } = converse.env;
+
+describe("The Location Button", function () {
+
+    it("shows a confirmation prompt and sends the geo URI as a message in a MUC",
+        mock.initConverse(['discoInitialized'], { 'view_mode': 'fullscreen' }, async function (_converse) {
+
+            const muc_jid = 'lounge@montague.lit';
+            const nick = 'romeo';
+
+            spyOn(_converse.api, 'confirm').and.callFake(() => Promise.resolve(true));
+            spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake((success) => {
+                success({ coords: { latitude: 51.5074, longitude: -0.1278 } });
+            });
+
+            await mock.openAndEnterMUC(_converse, muc_jid, nick);
+            const view = _converse.chatboxviews.get(muc_jid);
+            const toolbar = view.querySelector('.chat-toolbar');
+
+            const location_button = toolbar.querySelector('converse-location-button');
+            expect(location_button).not.toBeNull();
+
+            const button = location_button.querySelector('.toggle-location');
+            button.click();
+
+            await u.waitUntil(() => _converse.api.confirm.calls.count() === 1);
+            expect(_converse.api.confirm).toHaveBeenCalledWith(
+                'Confirm',
+                ['Are you sure you\'d like to share your location in the chat?']
+            );
+
+            await u.waitUntil(
+                () => _converse.api.connection.get().sent_stanzas.filter(s => s.nodeName === 'message').length
+            );
+
+            const sent = _converse.api.connection.get().sent_stanzas.filter(s => s.nodeName === 'message').pop();
+            expect(sent.querySelector('body').textContent).toBe('geo:51.507400,-0.127800');
+        }));
+
+    it("shows a confirmation prompt and sends the geo URI in a MUC private message",
+        mock.initConverse(['chatBoxesFetched'], { 'view_mode': 'fullscreen' }, async function (_converse) {
+
+            const muc_jid = 'coven@chat.shakespeare.lit';
+            const nick = 'romeo';
+
+            spyOn(_converse.api, 'confirm').and.callFake(() => Promise.resolve(true));
+            spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake((success) => {
+                success({ coords: { latitude: 40.7128, longitude: -74.0060 } });
+            });
+
+            await mock.openAndEnterMUC(_converse, muc_jid, nick);
+            const view = _converse.chatboxviews.get(muc_jid);
+
+            // Simulate another occupant joining
+            _converse.api.connection.get()._dataRecv(
+                mock.createRequest(stx`
+                    <presence
+                        from="${muc_jid}/firstwitch"
+                        id="${u.getUniqueId()}"
+                        to="${_converse.jid}"
+                        xmlns="jabber:client">
+                    <x xmlns="http://jabber.org/protocol/muc#user">
+                        <item affiliation="owner" role="moderator"/>
+                    </x>
+                    </presence>`)
+            );
+            await u.waitUntil(() => view.querySelectorAll('.occupant-list converse-avatar').length === 2);
+
+            // Click the occupant avatar to open the PM panel in the sidebar
+            view.querySelector('.occupant-list converse-avatar[name="firstwitch"]').click();
+
+            // Wait for the occupant panel to render with toolbar
+            const location_button = await u.waitUntil(
+                () => view.querySelector('converse-muc-occupant converse-location-button')
+            );
+            expect(location_button).not.toBeNull();
+
+            const button = location_button.querySelector('.toggle-location');
+            button.click();
+
+            await u.waitUntil(() => _converse.api.confirm.calls.count() === 1);
+            expect(_converse.api.confirm).toHaveBeenCalledWith(
+                'Confirm',
+                ['Are you sure you\'d like to share your location in the chat?']
+            );
+
+            await u.waitUntil(
+                () => _converse.api.connection.get().sent_stanzas.filter(s => s.nodeName === 'message').length
+            );
+
+            const sent = _converse.api.connection.get().sent_stanzas.filter(s => s.nodeName === 'message').pop();
+            expect(sent.querySelector('body').textContent).toBe('geo:40.712800,-74.006000');
+        }));
+});

--- a/src/shared/chat/location-button.js
+++ b/src/shared/chat/location-button.js
@@ -1,0 +1,93 @@
+import { html } from 'lit';
+import { api } from '@converse/headless';
+import { CustomElement } from 'shared/components/element.js';
+import { __ } from 'i18n';
+
+
+export class LocationButton extends CustomElement {
+
+    static get properties () {
+        return {
+            model: { type: Object },
+            is_groupchat: { type: Boolean },
+            fetching_location: { type: Boolean, state: true },
+        }
+    }
+
+    constructor () {
+        super();
+        this.model = null;
+        this.is_groupchat = false;
+        this.fetching_location = false;
+    }
+
+    render () {
+        const color = this.is_groupchat ? '--muc-color' : '--chat-color';
+        const title = this.fetching_location
+            ? __('Getting location...')
+            : __('Share current location');
+
+        return html`
+            <button type="button"
+                    class="btn toggle-location"
+                    title="${title}"
+                    ?disabled=${this.fetching_location}
+                    @click=${this.shareLocation}>
+                <converse-icon
+                    color="var(${color})"
+                    class="fa fa-globe"
+                    size="1em"></converse-icon>
+            </button>`;
+    }
+
+    /** @param {MouseEvent} ev */
+    async shareLocation (ev) {
+        ev?.preventDefault?.();
+        ev?.stopPropagation?.();
+
+        if (!navigator.geolocation) {
+            api.alert('error', __('Location Error'), [
+                __('Your browser does not support sharing your location. Please try a different browser.')
+            ]);
+            return;
+        }
+
+        const result = await api.confirm(
+            __('Confirm'),
+            [__('Are you sure you\'d like to share your location in the chat?')]
+        );
+        if (!result) return;
+
+        this.fetching_location = true;
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const { latitude, longitude } = position.coords;
+                const geo_uri = `geo:${latitude.toFixed(6)},${longitude.toFixed(6)}`;
+                this.model.sendMessage({ body: geo_uri });
+                this.fetching_location = false;
+            },
+            (error) => {
+                let error_message;
+                switch (error.code) {
+                    case error.PERMISSION_DENIED:
+                        error_message = __('Location access was denied. Please allow location permissions in your browser settings and try again.');
+                        break;
+                    case error.POSITION_UNAVAILABLE:
+                        error_message = __('Your current location could not be determined. Please check your device\'s location services and try again.');
+                        break;
+                    case error.TIMEOUT:
+                        error_message = __('The request to get your location timed out. Please check your connection and try again.');
+                        break;
+                    default:
+                        error_message = __('An unexpected error occurred while trying to retrieve your location. Please try again.');
+                }
+                api.alert('error', __('Location Error'), [error_message]);
+                this.fetching_location = false;
+            },
+            { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+        );
+    }
+}
+
+api.elements.define('converse-location-button', LocationButton);

--- a/src/shared/chat/toolbar.js
+++ b/src/shared/chat/toolbar.js
@@ -2,6 +2,7 @@ import { html } from 'lit';
 import { until } from 'lit/directives/until.js';
 import { _converse, api, converse } from '@converse/headless';
 import './emoji-picker.js';
+import './location-button.js';
 import 'shared/chat/message-limit.js';
 import tplToolbar from './templates/toolbar.js';
 import { CustomElement } from 'shared/components/element.js';
@@ -22,6 +23,7 @@ export class ChatToolbar extends CustomElement {
             model: { type: Object },
             show_call_button: { type: Boolean },
             show_emoji_button: { type: Boolean },
+            show_location_button: { type: Boolean },
             show_send_button: { type: Boolean },
             show_spoiler_button: { type: Boolean },
         }
@@ -36,6 +38,7 @@ export class ChatToolbar extends CustomElement {
         this.show_spoiler_button = false;
         this.show_call_button = false;
         this.show_emoji_button = false;
+        this.show_location_button = false;
     }
 
     connectedCallback () {
@@ -81,6 +84,13 @@ export class ChatToolbar extends CustomElement {
 
         if (this.show_spoiler_button) {
             buttons.push(this.getSpoilerButton());
+        }
+
+        if (this.show_location_button) {
+            buttons.push(html`<converse-location-button
+                .model=${this.model}
+                ?is_groupchat=${this.is_groupchat}>
+            </converse-location-button>`);
         }
 
         const domain = _converse.session.get('domain');
@@ -161,6 +171,7 @@ export class ChatToolbar extends CustomElement {
             return html`${until(spoilers_promise.then(() => markup), '')}`;
         }
     }
+
 
     /** @param {MouseEvent} ev */
     toggleFileUpload (ev) {

--- a/src/types/shared/chat/location-button.d.ts
+++ b/src/types/shared/chat/location-button.d.ts
@@ -1,0 +1,22 @@
+export class LocationButton extends CustomElement {
+    static get properties(): {
+        model: {
+            type: ObjectConstructor;
+        };
+        is_groupchat: {
+            type: BooleanConstructor;
+        };
+        fetching_location: {
+            type: BooleanConstructor;
+            state: boolean;
+        };
+    };
+    model: any;
+    is_groupchat: boolean;
+    fetching_location: boolean;
+    render(): import("lit-html").TemplateResult<1>;
+    /** @param {MouseEvent} ev */
+    shareLocation(ev: MouseEvent): Promise<void>;
+}
+import { CustomElement } from 'shared/components/element.js';
+//# sourceMappingURL=location-button.d.ts.map

--- a/src/types/shared/chat/toolbar.d.ts
+++ b/src/types/shared/chat/toolbar.d.ts
@@ -18,6 +18,9 @@ export class ChatToolbar extends CustomElement {
         show_emoji_button: {
             type: BooleanConstructor;
         };
+        show_location_button: {
+            type: BooleanConstructor;
+        };
         show_send_button: {
             type: BooleanConstructor;
         };
@@ -32,6 +35,7 @@ export class ChatToolbar extends CustomElement {
     show_spoiler_button: boolean;
     show_call_button: boolean;
     show_emoji_button: boolean;
+    show_location_button: boolean;
     connectedCallback(): void;
     render(): import("lit-html").TemplateResult<1>;
     firstUpdated(): void;

--- a/src/utils/form.js
+++ b/src/utils/form.js
@@ -107,3 +107,4 @@ export function replaceCurrentWord(input, new_value) {
     const selection_end = caret - current_word.length + new_value.length + 1;
     input.selectionEnd = mention_boundary ? selection_end + 1 : selection_end;
 }
+


### PR DESCRIPTION
> [!NOTE]
> This PR was **merged manually** into `conversejs:master` by @jcbrand (commit `8aff910`).

## Summary
Adds a toolbar button to insert the user's current location as a `geo:` URI into the message compose box, allowing users to share their location in chat.

## Related Issue
Closes #1559

## What does this PR do?
- Adds a globe (🌐) icon button to the chat toolbar
- Uses the browser's Geolocation API to get user coordinates
- Inserts a `geo:latitude,longitude` URI into the message textarea
- User can review/edit before sending
- Coordinates are rounded to 6 decimal places for readability

## Changes

### New Configuration Option
| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `visible_toolbar_buttons.location` | Boolean | `false` | Show/hide the location button |

### Files Modified
| File | Description |
|------|-------------|
| [src/plugins/chatview/index.js](cci:7://file:///Users/somasreeshanth/converse.js/src/plugins/chatview/index.js:0:0-0:0) | Added `location` to `visible_toolbar_buttons` setting |
| [src/plugins/chatview/templates/message-form.js](cci:7://file:///Users/somasreeshanth/converse.js/src/plugins/chatview/templates/message-form.js:0:0-0:0) | Pass `show_location_button` prop to toolbar |
| [src/plugins/muc-views/templates/message-form.js](cci:7://file:///Users/somasreeshanth/converse.js/src/plugins/muc-views/templates/message-form.js:0:0-0:0) | Pass `show_location_button` prop for MUC support |
| [src/shared/chat/toolbar.js](cci:7://file:///Users/somasreeshanth/converse.js/src/shared/chat/toolbar.js:0:0-0:0) | Added [getLocationButton()](cci:1://file:///Users/somasreeshanth/converse.js/src/types/shared/chat/toolbar.d.ts:47:4-47:58) and [insertLocation()](cci:1://file:///Users/somasreeshanth/converse.js/src/shared/chat/toolbar.js:185:4-252:5) methods |
| [src/types/shared/chat/toolbar.d.ts](cci:7://file:///Users/somasreeshanth/converse.js/src/types/shared/chat/toolbar.d.ts:0:0-0:0) | Updated TypeScript definitions |

## Screenshots & Demo

<!-- Add your screenshot here -->

### 1. Location Permission Request
When clicking the location button for the first time, the browser prompts for geolocation access.

<img width="801" height="460" alt="Screenshot 2026-01-27 at 9 18 12 PM" src="https://github.com/user-attachments/assets/67b27aa2-9b73-4d0f-beb3-c3c72355f94e" />

### 2. Location Inserted into Message Composer
After granting permission, the `geo:` URI is inserted into the message textarea, allowing the user to review or edit before sending.

<img width="1484" height="824" alt="Screenshot 2026-01-27 at 9 17 47 PM" src="https://github.com/user-attachments/assets/1f115fc9-4c09-4cca-966b-d025fe604ecd" />

### 3. Sent Location Message (Optional - if you have one)
The sent location is automatically rendered as a clickable OpenStreetMap link by Converse.js.

<img width="1493" height="833" alt="Screenshot 2026-01-27 at 9 23 44 PM" src="https://github.com/user-attachments/assets/3c010bba-56b3-4686-9267-d140fde33487" />



## Testing

### Manual Testing
1. Enable location button: set `visible_toolbar_buttons: { location: true }`
2. Open a chat conversation
3. Click the globe (🌐) icon in the toolbar
4. Allow browser location permission
5. Verify `geo:lat,lon` appears in the message box
6. Press Enter to send

### Automated Tests
- All 556 existing tests pass
- No breaking changes to existing functionality

## Implementation Notes
- Uses the standard `geo:` URI format per [RFC 5870](https://tools.ietf.org/html/rfc5870)
- Converse.js automatically renders `geo:` URIs as clickable OpenStreetMap links
- Error handling for: permission denied, position unavailable, timeout
- Works in both 1:1 chats and MUCs (group chats)

## Checklist
- [x] Code follows the project's coding style
- [x] Changes don't break existing functionality
- [x] TypeScript definitions updated
- [x] Tested manually in browser
- [x] All existing tests pass
