### PR TITLE
feat(register): autocomplete XMPP provider domains in signup form

### DIFF
--- a/src/plugins/register/form.js
+++ b/src/plugins/register/form.js
@@ -39,17 +39,20 @@ class RegistrationForm extends CustomElement {
         this.urls = [];
         this.fields = {};
         this.domain = null;
+        this.provider_domains = [];
         this.alert_type = 'info';
         this.setErrorMessage = /** @param {string} m */(m) => this.setMessage(m, 'danger');
         this.setFeedbackMessage = /** @param {string} m */(m) => this.setMessage(m, 'info');
     }
 
-    initialize () {
+    async initialize () {
         this.reset();
         this.listenTo(_converse, 'connectionInitialized', () => this.registerHooks());
 
         const settings = api.settings.get();
         this.listenTo(settings, 'change:show_connection_url_input', () => this.requestUpdate());
+
+        await this.fetchProviderDomains();
 
         const domain = api.settings.get('registration_domain');
         if (domain) {
@@ -70,6 +73,59 @@ class RegistrationForm extends CustomElement {
     setMessage(message, type) {
         this.alert_type = type;
         this.alert_message = message;
+    }
+
+    /**
+     * @param {unknown} payload
+     */
+    #extractProviderDomains (payload) {
+        const domains = new Set();
+        const addDomain = (value) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+            const domain = value.trim().toLowerCase();
+            if (domain && !domain.includes(' ')) {
+                domains.add(domain);
+            }
+        };
+
+        const collect = (node) => {
+            if (Array.isArray(node)) {
+                node.forEach(collect);
+                return;
+            }
+            if (!node || typeof node !== 'object') {
+                return;
+            }
+            addDomain(node.domain);
+            addDomain(node.jid);
+            collect(node.providers);
+            collect(node.items);
+            collect(node.entries);
+        };
+
+        collect(payload?.A ?? payload?.a ?? payload);
+        collect(payload?.B ?? payload?.b ?? []);
+        return Array.from(domains).sort();
+    }
+
+    async fetchProviderDomains () {
+        const url = api.settings.get('providers_data_url');
+        if (!url) {
+            return;
+        }
+
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                return;
+            }
+            const payload = await response.json();
+            this.provider_domains = this.#extractProviderDomains(payload);
+        } catch {
+            log.warn('Could not fetch XMPP provider domain list');
+        }
     }
 
     /**

--- a/src/plugins/register/index.js
+++ b/src/plugins/register/index.js
@@ -43,6 +43,7 @@ converse.plugins.add('converse-register', {
             allow_registration: true,
             domain_placeholder: __(' e.g. conversejs.org'), // Placeholder text shown in the domain input on the registration form
             providers_link: 'https://providers.xmpp.net/', // Link to XMPP providers shown on registration page
+            providers_data_url: 'https://data.xmpp.net/providers/v2/providers-A-and-B.json',
             registration_domain: ''
         });
 

--- a/src/plugins/register/templates/choose_provider.js
+++ b/src/plugins/register/templates/choose_provider.js
@@ -5,6 +5,7 @@ import { __ } from 'i18n';
 import { tplConnectionURLInput } from '../../controlbox/templates/loginform.js';
 import tplSwitchForm from './switch_form.js';
 import tplRegistrationForm from './registration_form.js';
+import 'shared/autocomplete/index.js';
 
 /**
  * @param {import('../form.js').default} el
@@ -37,15 +38,27 @@ function tplDomainInput(el) {
     const i18n_providers = __('Tip: A list of public XMPP providers is available');
     const i18n_providers_link = __('here');
     const href_providers = api.settings.get('providers_link');
+    const has_provider_suggestions = (el.provider_domains?.length ?? 0) > 0;
     return html`
-        <input
-            class="form-control"
-            required="required"
-            type="text"
-            name="domain"
-            placeholder="${domain_placeholder}"
-            value="${el.domain}"
-        />
+        ${has_provider_suggestions
+            ? html`<converse-autocomplete
+                  .list=${el.provider_domains}
+                  position="below"
+                  min_chars="1"
+                  filter="startswith"
+                  ?required=${true}
+                  value="${el.domain || ''}"
+                  placeholder="${domain_placeholder}"
+                  name="domain"
+              ></converse-autocomplete>`
+            : html`<input
+                  class="form-control"
+                  required="required"
+                  type="text"
+                  name="domain"
+                  placeholder="${domain_placeholder}"
+                  value="${el.domain || ''}"
+              />`}
         <p class="form-text text-muted">
             ${i18n_providers}
             <a href="${href_providers}" class="url" target="_blank" rel="noopener">${i18n_providers_link}</a>.


### PR DESCRIPTION
## Summary
- add provider dataset URL setting for registration (providers_data_url)
- fetch provider domains (categories A/B) on registration form init
- use converse-autocomplete for domain entry when provider data is available
- keep existing plain input fallback when provider list cannot be loaded

## Why
Issue #2740 asks for provider suggestions in the registration form so users can discover valid XMPP domains faster during onboarding.

## Notes
- suggestions are sourced from https://data.xmpp.net/providers/v2/providers-A-and-B.json
- fetch failures are non-fatal and preserve the current UX

Refs #2740