### PR TITLE
feat(rosterview): autocomplete XMPP providers when adding contacts

### DIFF
--- a/src/plugins/rosterview/modals/templates/add-contact.js
+++ b/src/plugins/rosterview/modals/templates/add-contact.js
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { api } from '@converse/headless';
 import { __ } from 'i18n';
-import { getGroupsAutoCompleteList, getJIDsAutoCompleteList, getNamesAutoCompleteList } from '../../utils.js';
+import { getGroupsAutoCompleteList, getNamesAutoCompleteList } from '../../utils.js';
 import 'shared/autocomplete/index.js';
 
 /**
@@ -35,7 +35,7 @@ export default (el) => {
                                 name="jid"
                             ></converse-autocomplete>`
                           : html`<converse-autocomplete
-                                .list="${getJIDsAutoCompleteList()}"
+                                .list="${el.getJIDDomainAutoCompleteList()}"
                                 .data="${(text, input) => `${input.slice(0, input.indexOf('@'))}@${text}`}"
                                 position="below"
                                 min_chars="2"


### PR DESCRIPTION
## Summary
- load public provider domains from `providers_data_url` in the Add Contact modal
- merge fetched provider domains with known roster domains for autocomplete suggestions
- keep existing username+domain insertion flow (`user@domain`) while broadening available domain matches

## Why
Issue #2929 asks for provider autocomplete support while adding contacts. This patch extends the current domain suggestions beyond already-known roster domains to include public XMPP providers.

## Testing
- `npx eslint src/plugins/rosterview/modals/add-contact.js src/plugins/rosterview/modals/templates/add-contact.js` *(fails on existing `require-await` rules in unchanged async methods in `add-contact.js`)*
