### PR TITLE
feat(rosterview): autocomplete provider domains in add-contact

### DIFF
--- a/src/plugins/rosterview/modals/templates/add-contact.js
+++ b/src/plugins/rosterview/modals/templates/add-contact.js
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { api } from '@converse/headless';
 import { __ } from 'i18n';
-import { getGroupsAutoCompleteList, getJIDsAutoCompleteList, getNamesAutoCompleteList } from '../../utils.js';
+import { getGroupsAutoCompleteList, getNamesAutoCompleteList } from '../../utils.js';
 import 'shared/autocomplete/index.js';
 
 /**
@@ -35,7 +35,7 @@ export default (el) => {
                                 name="jid"
                             ></converse-autocomplete>`
                           : html`<converse-autocomplete
-                                .list="${getJIDsAutoCompleteList()}"
+                                .list="${el.getJIDDomainAutoCompleteList()}"
                                 .data="${(text, input) => `${input.slice(0, input.indexOf('@'))}@${text}`}"
                                 position="below"
                                 min_chars="2"


### PR DESCRIPTION
## Summary\n- fetch XMPP provider domain list from  in add-contact modal\n- merge provider domains with roster-derived domains for JID autocomplete\n- wire add-contact input to  with domain suggestions\n\n## Why\nThis implements domain suggestions in the add-contact flow and addresses #2929.\n\n## Notes\n- keeps existing roster-based completion behavior\n- provider fetch is best-effort and safely falls back when unavailable\n\nFixes #2929