### PR TITLE
feat: Add XMPP Providers API integration for contact domain autocomplete

### DIFF
--- a/src/plugins/rosterview/modals/templates/add-contact.js
+++ b/src/plugins/rosterview/modals/templates/add-contact.js
@@ -35,7 +35,7 @@ export default (el) => {
                                 name="jid"
                             ></converse-autocomplete>`
                           : html`<converse-autocomplete
-                                .list="${getJIDsAutoCompleteList()}"
+                                .getAutoCompleteList="${getJIDsAutoCompleteList}"
                                 .data="${(text, input) => `${input.slice(0, input.indexOf('@'))}@${text}`}"
                                 position="below"
                                 min_chars="2"

--- a/src/plugins/rosterview/tests/add-contact-modal.js
+++ b/src/plugins/rosterview/tests/add-contact-modal.js
@@ -97,4 +97,51 @@ describe("The 'Add Contact' widget", function () {
                 <query xmlns="jabber:iq:roster"><item jid="marty@mcfly.net" name="Marty McFly"/></query>
             </iq>`);
     }));
+
+    it("fetches XMPP providers from the XMPP Providers API for autocompletion",
+            mock.initConverse([], {}, async function (_converse) {
+
+        await mock.waitForRoster(_converse, 'all');
+        await mock.openControlBox(_converse);
+
+        // Mock the fetch API to return XMPP providers
+        spyOn(window, 'fetch').and.callFake((url) => {
+            if (url === 'https://data.xmpp.net/providers.json') {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve([
+                        { domain: 'example.com' },
+                        { domain: 'jabber.org' },
+                        { domain: 'xmpp.net' }
+                    ])
+                });
+            }
+            return Promise.reject(new Error('Unexpected URL: ' + url));
+        });
+
+        const cbview = _converse.chatboxviews.get('controlbox');
+
+        const dropdown = await u.waitUntil(
+            () => cbview.querySelector('.dropdown--contacts')
+        );
+        dropdown.querySelector('.add-contact').click()
+
+        const modal = _converse.api.modal.get('converse-add-contact-modal');
+        await u.waitUntil(() => u.isVisible(modal), 1000);
+
+        const input_jid = modal.querySelector('input[name="jid"]');
+        input_jid.value = 'test@exam';
+
+        const evt = new Event('input');
+        input_jid.dispatchEvent(evt);
+
+        // Wait for the suggestion box to show providers from the API
+        await u.waitUntil(() => modal.querySelector('.suggestion-box li'), 2000);
+        const suggestions = modal.querySelectorAll('.suggestion-box li');
+        expect(suggestions.length).toBeGreaterThan(0);
+
+        // Check that one of the suggestions is from the mocked providers
+        const suggestionTexts = Array.from(suggestions).map(li => li.textContent);
+        expect(suggestionTexts).toContain('example.com');
+    }));
 });

--- a/src/plugins/rosterview/utils.js
+++ b/src/plugins/rosterview/utils.js
@@ -341,17 +341,79 @@ export function getGroupsAutoCompleteList() {
     return [...new Set(groups.filter((i) => i))];
 }
 
+let xmppProvidersCache = null;
+let xmppProvidersCacheTime = 0;
+const XMPP_PROVIDERS_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+const XMPP_PROVIDERS_URL = 'https://data.xmpp.net/providers.json';
+
 /**
- * @returns {string[]}
+ * Fetch XMPP providers from the public API
+ * @returns {Promise<string[]>}
  */
-export function getJIDsAutoCompleteList() {
+async function fetchXMPPProviders() {
+    const now = Date.now();
+    if (xmppProvidersCache && (now - xmppProvidersCacheTime) < XMPP_PROVIDERS_CACHE_DURATION) {
+        return xmppProvidersCache;
+    }
+
+    try {
+        const response = await fetch(XMPP_PROVIDERS_URL, {
+            mode: 'cors',
+            headers: {
+                'Accept': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        
+        // Extract domain names from providers data
+        // The API returns an array of provider objects with a 'domain' property
+        let providers = [];
+        if (Array.isArray(data)) {
+            providers = data.map(provider => provider.domain).filter(Boolean);
+        } else if (data && Array.isArray(data.providers)) {
+            providers = data.providers.map(provider => provider.domain).filter(Boolean);
+        }
+
+        xmppProvidersCache = providers;
+        xmppProvidersCacheTime = now;
+        return providers;
+    } catch (e) {
+        log.error('Failed to fetch XMPP providers:', e);
+        return [];
+    }
+}
+
+/**
+ * @param {string} [query]
+ * @returns {Promise<string[]>}
+ */
+export async function getJIDsAutoCompleteList(query) {
     const roster = /** @type {RosterContacts} */ (_converse.state.roster);
-    return [
+    const localDomains = [
         ...new Set([
             ...roster.map((item) => Strophe.getDomainFromJid(item.get('jid'))),
             _converse.session.get('domain'),
         ]),
-    ];
+    ].filter(Boolean);
+
+    // Fetch providers from XMPP Providers API
+    const providers = await fetchXMPPProviders();
+    
+    // Combine local domains with providers, removing duplicates
+    const allDomains = [...new Set([...localDomains, ...providers])];
+    
+    // Filter by query if provided
+    if (query) {
+        const lowerQuery = query.toLowerCase();
+        return allDomains.filter(domain => domain.toLowerCase().includes(lowerQuery));
+    }
+    
+    return allDomains;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR implements the XMPP Providers API integration for the "Add Contact" modal, as requested in #2929.

## Changes
- **Added** `fetchXMPPProviders()` function to fetch the list of XMPP servers from https://data.xmpp.net/providers.json
- **Modified** `getJIDsAutoCompleteList()` to include providers from the XMPP Providers API
- **Implemented** 24-hour caching to avoid excessive API calls
- **Updated** the add-contact modal template to use the async `getAutoCompleteList` property
- **Added** test case for the XMPP Providers API integration

## How it works
When users type in the XMPP address field when adding a contact, the autocomplete will now suggest domains from:
1. The user's existing contacts (local domains)
2. The user's current session domain
3. The XMPP Providers API (fetched once and cached for 24 hours)

## Testing
Added a new test case in `src/plugins/rosterview/tests/add-contact-modal.js` that verifies:
- The API is called correctly
- Suggestions include domains from the XMPP Providers API

## Screenshots
The autocomplete dropdown will now show domains from the XMPP Providers API when users type "username@" in the JID field.

## Bounty
This PR addresses the bounty issue #2929 (00).

---
Closes #2929