### PR TITLE
Fix avatars not showing when not using HTTPS

### DIFF
--- a/src/headless/plugins/vcard/api.js
+++ b/src/headless/plugins/vcard/api.js
@@ -50,11 +50,19 @@ export default {
                 // Optimistically update the vcard with image data. Otherwise some servers (e.g. Ejabberd)
                 // could send a XEP-0153 vcard:update presence which would cause us to refetch the vcard again.
                 const buffer = u.base64ToArrayBuffer(data.image);
-                const hash_ab = await crypto.subtle.digest('SHA-1', buffer);
+                // Check if crypto.subtle is available (requires secure context/HTTPS)
+                let image_hash;
+                if (window.isSecureContext) {
+                    const hash_ab = await crypto.subtle.digest('SHA-1', buffer);
+                    image_hash = u.arrayBufferToHex(hash_ab);
+                } else {
+                    // Fallback for non-HTTPS contexts: use base64 as pseudo-hash
+                    image_hash = data.image.substring(0, 32);
+                }
                 vcard.save({
                     image: data.image,
                     image_type: data.image_type,
-                    image_hash: u.arrayBufferToHex(hash_ab),
+                    image_hash: image_hash,
                 });
             }
 

--- a/src/headless/plugins/vcard/parsers.js
+++ b/src/headless/plugins/vcard/parsers.js
@@ -23,8 +23,14 @@ export async function parseVCardResultStanza(iq) {
     };
     if (result.image) {
         const buffer = u.base64ToArrayBuffer(result.image);
-        const ab = await crypto.subtle.digest('SHA-1', buffer);
-        result['image_hash'] = u.arrayBufferToHex(ab);
+        // Check if crypto.subtle is available (requires secure context/HTTPS)
+        if (window.isSecureContext) {
+            const ab = await crypto.subtle.digest('SHA-1', buffer);
+            result['image_hash'] = u.arrayBufferToHex(ab);
+        } else {
+            // Fallback for non-HTTPS contexts: use base64 as pseudo-hash
+            result['image_hash'] = result.image.substring(0, 32);
+        }
     }
     return result;
 }

--- a/src/headless/utils/color.js
+++ b/src/headless/utils/color.js
@@ -14,13 +14,21 @@ export async function colorize(s) {
     const v = cache.get(s);
     if (v) return v;
 
-    // Run the input through SHA-1
-    const digest = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-1', new TextEncoder().encode(s))));
-
-    // Treat the output as little endian and extract the least-significant 16 bits.
-    // (These are the first two bytes of the output, with the second byte being the most significant one.)
-    // Divide the value by 65536 (use float division) and multiply it by 360 (to map it to degrees in a full circle).
-    const angle = ((digest[0] + digest[1] * 256) / 65536.0) * 360;
+    // Run the input through SHA-1 (only available in secure context/HTTPS)
+    let angle;
+    if (window.isSecureContext) {
+        const digest = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-1', new TextEncoder().encode(s))));
+        // Treat the output as little endian and extract the least-significant 16 bits.
+        angle = ((digest[0] + digest[1] * 256) / 65536.0) * 360;
+    } else {
+        // Fallback for non-HTTPS contexts: use a simple hash based on string characters
+        let hash = 0;
+        for (let i = 0; i < s.length; i++) {
+            hash = ((hash << 5) - hash) + s.charCodeAt(i);
+            hash = hash & hash; // Convert to 32bit integer
+        }
+        angle = Math.abs(hash % 360);
+    }
 
     // Convert HSLuv angle to RGB Hex notation
     const hsluv = new Hsluv();


### PR DESCRIPTION
## Summary
Fixes the issue where avatars are not showing when Converse.js is opened on a non-secure context (non-HTTPS).

## Problem
The rendering of avatars from vCards uses `crypto.subtle`, which is only available in secure contexts (HTTPS). This causes avatars to not be displayed in non-HTTPS environments.

## Solution
Check for `window.isSecureContext` before using the `crypto.subtle` API, and provide a fallback for non-HTTPS environments.

## Files Changed
- `src/headless/plugins/vcard/parsers.js` - Check secure context before SHA-1 hash
- `src/headless/plugins/vcard/api.js` - Check secure context when setting avatar
- `src/headless/utils/color.js` - Check secure context in colorize function

## Testing
The fallback uses base64 substring or simple string hash as pseudo-hash when `crypto.subtle` is unavailable, allowing avatars to display in non-HTTPS contexts.

Fixes #2374