### PR TITLE
Hide trusted login option when persistent storage is unavailable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   If you include Converse via a `<script>` tag, you must add `type="module"`:
   `<script type="module" src="converse.js"></script>`.
   Any inline scripts calling `converse.initialize()` must also use `type="module"`.
+- #2405: Hide the trusted device login checkbox when persistent browser storage is unavailable.
 
 ## 13.0.1 (2026-05-27)
 

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -227,6 +227,8 @@ This setting determines whether a user may decide whether Converse is `trusted` 
 
 This is done via a _This is a trusted device_ checkbox in the login form. If this setting is set to `true` or `off`, the checkbox will be shown to the user, otherwise not.
 
+The checkbox is hidden automatically when the configured persistent browser storage backend is unavailable, for example in private browsing modes that disable IndexedDB or localStorage.
+
 When this setting is set to `true`, the checkbox will be checked by default. To not have it checked by default, set this setting to `off`.
 
 If the user indicates that this device/browser is not trusted, then effectively it's the same as setting [clear_cache_on_logout](#clear_cache_on_logout) to `true` and [persistent_store](#persistent_store) to `sessionStorage`.

--- a/src/headless/utils/storage.js
+++ b/src/headless/utils/storage.js
@@ -30,7 +30,11 @@ function storeUsesIndexedDB(type) {
 export function isPersistentStorageAvailable() {
     const store = settings.get('persistent_store');
     if (store === 'sessionStorage') {
-        return typeof window.sessionStorage !== 'undefined';
+        try {
+            return typeof globalThis.sessionStorage !== 'undefined';
+        } catch {
+            return false;
+        }
     } else if (store === 'BrowserExtLocal' || store === 'BrowserExtSync') {
         return true;
     }

--- a/src/headless/utils/storage.js
+++ b/src/headless/utils/storage.js
@@ -25,6 +25,26 @@ function storeUsesIndexedDB(type) {
 }
 
 /**
+ * @returns {boolean}
+ */
+export function isPersistentStorageAvailable() {
+    const store = settings.get('persistent_store');
+    if (store === 'sessionStorage') {
+        return typeof window.sessionStorage !== 'undefined';
+    } else if (store === 'BrowserExtLocal' || store === 'BrowserExtSync') {
+        return true;
+    }
+
+    const driver =
+        store === 'localStorage'
+            ? BrowserStorage.localForage.LOCALSTORAGE
+            : store === 'IndexedDB'
+              ? BrowserStorage.localForage.INDEXEDDB
+              : undefined;
+    return driver ? BrowserStorage.localForage.supports(driver) : true;
+}
+
+/**
  * @param {string} id
  * @param {import('./types').StorageType} type
  * @returns {BrowserStorage}

--- a/src/plugins/controlbox/templates/loginform.js
+++ b/src/plugins/controlbox/templates/loginform.js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { _converse, api, constants } from '@converse/headless';
+import { _converse, api, constants, converse } from '@converse/headless';
 import tplSpinner from 'templates/spinner.js';
 import { CONNECTION_STATUS_CSS_CLASS } from '../constants.js';
 import { __ } from 'i18n';
@@ -7,6 +7,7 @@ import 'shared/components/brand-heading.js';
 import 'shared/components/footer.js';
 
 const { ANONYMOUS, EXTERNAL, LOGIN, PREBIND, CONNECTION_STATUS } = constants;
+const { u } = converse.env;
 
 /**
  * @param {boolean} checked
@@ -83,7 +84,8 @@ function tplAuthFields() {
     const locked_domain = api.settings.get('locked_domain');
     const default_domain = api.settings.get('default_domain');
     const placeholder_username = ((locked_domain || default_domain) && __('Username')) || __('user@domain');
-    const show_trust_checkbox = api.settings.get('allow_user_trust_override');
+    const allow_user_trust_override = api.settings.get('allow_user_trust_override');
+    const show_trust_checkbox = allow_user_trust_override && u.isPersistentStorageAvailable();
 
     return html`
         <div class="mb-3">
@@ -104,7 +106,7 @@ function tplAuthFields() {
         </div>
         ${authentication !== EXTERNAL ? tplPasswordInput() : ''}
         ${api.settings.get('show_connection_url_input') ? tplConnectionURLInput() : ''}
-        ${show_trust_checkbox ? tplTrustCheckbox(show_trust_checkbox === 'off' ? false : true) : ''}
+        ${show_trust_checkbox ? tplTrustCheckbox(allow_user_trust_override === 'off' ? false : true) : ''}
         <div class="text-center mb-3">
             <button class="btn btn-primary px-5 mx-auto" type="submit">${i18n_login}</button>
         </div>

--- a/src/plugins/controlbox/templates/loginform.js
+++ b/src/plugins/controlbox/templates/loginform.js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { _converse, api, constants, converse } from '@converse/headless';
+import { _converse, api, constants, u } from '@converse/headless';
 import tplSpinner from 'templates/spinner.js';
 import { CONNECTION_STATUS_CSS_CLASS } from '../constants.js';
 import { __ } from 'i18n';
@@ -7,7 +7,6 @@ import 'shared/components/brand-heading.js';
 import 'shared/components/footer.js';
 
 const { ANONYMOUS, EXTERNAL, LOGIN, PREBIND, CONNECTION_STATUS } = constants;
-const { u } = converse.env;
 
 /**
  * @param {boolean} checked

--- a/src/plugins/controlbox/tests/login.js
+++ b/src/plugins/controlbox/tests/login.js
@@ -92,4 +92,34 @@ describe('The Login Form', function () {
             },
         ),
     );
+
+    it(
+        'does not show the trusted device checkbox when persistent storage is unavailable',
+        mock.initConverse(
+            converse,
+            ['chatBoxesInitialized'],
+            { auto_login: false, allow_registration: false },
+            async function (_converse) {
+                const is_persistent_storage_available = u.isPersistentStorageAvailable;
+                u.isPersistentStorageAvailable = () => false;
+
+                try {
+                    mock.toggleControlBox(_converse);
+                    const cbview = await u.waitUntil(() => _converse.chatboxviews.get('controlbox'));
+                    await u.waitUntil(() => cbview.querySelector('input[name="jid"]'));
+
+                    expect(cbview.querySelectorAll('input[type="checkbox"]').length).toBe(0);
+
+                    cbview.querySelector('input[name="jid"]').value = 'romeo@montague.lit';
+                    cbview.querySelector('input[name="password"]').value = 'secret';
+                    cbview.querySelector('button[type="submit"]').click();
+
+                    expect(_converse.config.get('trusted')).toBe(false);
+                    expect(u.getDefaultStorageType()).toBe('session');
+                } finally {
+                    u.isPersistentStorageAvailable = is_persistent_storage_available;
+                }
+            },
+        ),
+    );
 });


### PR DESCRIPTION
﻿## Summary
- Add a persistent storage availability check before showing the trusted-device login checkbox.
- Preserve the existing `allow_user_trust_override: 'off'` behavior so the checkbox can still be shown unchecked by default.
- Add login form coverage and document the private browsing behavior.

Fixes #2405.

## Validation
- `npm ci`
- `$env:DROP_DEBUGGER='false'; npx.cmd rspack build --config rspack/rspack.headless.js --mode=development; npx.cmd rspack build --config rspack/rspack.build.js --mode=development; npm.cmd run build:converse-min-css`
- `npx.cmd eslint src/headless/utils/storage.js src/plugins/controlbox/templates/loginform.js src/plugins/controlbox/tests/login.js`
- `npm.cmd run types:check`
- `npx.cmd karma start karma.login.conf.js --single-run` (temporary local config containing only `src/plugins/controlbox/tests/login.js`; removed before commit)

Note: `npm.cmd test -- --single-run` hit an existing unrelated timeout in `src/plugins/chatview/tests/message-images.js` before reaching the login form tests.
