### PR TITLE
fix: strip trailing slash from assets_path to prevent double-slash URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 14.0.0 (Unreleased)
 
+- Fix: Strip trailing slash from `assets_path` to prevent double-slash asset URLs (fixes #4041)
+
 ### Backwards incompatible changes
 
 - `api.modal.show` no longer takes a modal instance as first parameter

--- a/src/headless/plugins/emoji/api.js
+++ b/src/headless/plugins/emoji/api.js
@@ -17,7 +17,7 @@ const emojis = {
 
             let json;
             try {
-                const path = api.settings.get('assets_path');
+                const path = api.settings.get('assets_path').replace(/\/$/, '');
                 const response = await fetch(`${path}/emoji.json`);
                 if (!response.ok) throw new Error('Failed to fetch emoji.json');
                 json = await response.json();

--- a/src/plugins/chatview/tests/emojis.js
+++ b/src/plugins/chatview/tests/emojis.js
@@ -464,5 +464,14 @@ describe('Emojis', function () {
                 },
             ),
         );
+        it(
+            'does not produce double slashes in asset URLs when assets_path ends with /',
+            mock.initConverse(converse, ['chatBoxesFetched'], { 'assets_path': '/dist/' }, async function (_converse) {
+                const path = _converse.api.settings.get('assets_path').replace(/\/$/, '');
+                expect(path).toBe('/dist');
+                expect(path.endsWith('/')).toBe(false);
+                expect(`${path}/emoji.json`).toBe('/dist/emoji.json');
+            }),
+        );
     });
 });

--- a/src/plugins/notifications/index.js
+++ b/src/plugins/notifications/index.js
@@ -29,7 +29,7 @@ converse.plugins.add('converse-notification', {
             show_chat_state_notifications: false,
             show_desktop_notifications: true,
             show_tab_notifications: true,
-            sounds_path: api.settings.get('assets_path') + '/sounds/'
+            sounds_path: api.settings.get('assets_path').replace(/\/$/, '') + '/sounds/'
         });
 
         /************************ Event Handlers ************************/

--- a/src/shared/chat/utils.js
+++ b/src/shared/chat/utils.js
@@ -208,7 +208,7 @@ export function getEmojiMarkup(data, options = { unicode_only: false, add_title_
             draggable="false"
             title="${shortname}"
             alt="${shortname}"
-            src="${url.startsWith('.') ? `${api.settings.get('assets_path')}/${url}` : url}"
+            src="${url.startsWith('.') ? `${api.settings.get('assets_path').replace(/\/$/, '')}/${url}` : url}"
         />`;
     }
 }


### PR DESCRIPTION
Fixes #4041

## Problem
When `assets_path` ends with `/` (e.g. `/dist/`), Converse generates 
double-slash URLs like `/dist//emoji.json` causing HTTP 400 errors.

## Fix
Strip trailing slash from `assets_path` before building asset URLs in:
- src/headless/plugins/emoji/api.js
- src/plugins/notifications/index.js
- src/shared/chat/utils.js

## Checklist
- [x] Added changelog entry in CHANGES.md
- [x] Added a test in src/plugins/chatview/tests/emojis.js
