### PR TITLE
Add OMEMO 2 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 14.0.0 (Unreleased)
 
 - #4041: fix: strip trailing slashes from `assets_path` to prevent double-slash asset URLs
+- feat: add support for OMEMO 2 (`urn:xmpp:omemo:2`), using Stanza Content Encryption (XEP-0420)
 - fix: `isTrustedIdentity` in OMEMO store wasn't properly loading the identity
 - fix: broadcast presence when the chat status (`show`) is cleared
 - fix: the idle status flag could never be cleared, leaving stale idle presence after the user became active again

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## 14.0.0 (Unreleased)
 
+- #4041: fix: strip trailing slashes from `assets_path` to prevent double-slash asset URLs
 - fix: `isTrustedIdentity` in OMEMO store wasn't properly loading the identity
-- fix: strip trailing slashes from `assets_path` to prevent double-slash asset URLs (#4041)
+- fix: broadcast presence when the chat status (`show`) is cleared
+- fix: the idle status flag could never be cleared, leaving stale idle presence after the user became active again
 
 ### Backwards incompatible changes
 

--- a/Makefile
+++ b/Makefile
@@ -171,10 +171,10 @@ media:
 dist/converse-no-dependencies.js: src rspack/rspack.common.js rspack/rspack.nodeps.js @converse/headless node_modules
 	npm run nodeps
 
-dist/converse.js:: node_modules
+dist/converse.js:: src rspack/rspack.build.js rspack/rspack.common.js node_modules @converse/headless
 	npm run build
 
-dist/converse.css:: node_modules
+dist/converse.css:: src rspack/rspack.build.js rspack/rspack.common.js node_modules @converse/headless
 	npm run build
 
 dist/website.css:: node_modules src/shared/styles/website.scss

--- a/conversejs.doap
+++ b/conversejs.doap
@@ -288,6 +288,12 @@
     </implements>
     <implements>
       <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0420.html"/>
+        <xmpp:since>14.0.0</xmpp:since>
+      </xmpp:SupportedXep>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0421.html"/>
       </xmpp:SupportedXep>
     </implements>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "converse.js",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "converse.js",
-      "version": "13.0.0",
+      "version": "14.0.0",
       "license": "MPL-2.0",
       "workspaces": [
         "src/headless",
@@ -4412,9 +4412,9 @@
       }
     },
     "node_modules/libomemo.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/libomemo.js/-/libomemo.js-1.0.0.tgz",
-      "integrity": "sha512-P6G3/ZRQE9fFGnZcCfot2enjCNRPQXXjFMRvwnK//Nwj9Wm2W9taL9gW48ut55ZRtD0gLN1EU6btpu7UfRVf6w==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/libomemo.js/-/libomemo.js-2.0.0-rc.1.tgz",
+      "integrity": "sha512-OfLUZV5enor01wMvLdECzG9jL4Q5XGwhdcLz15Jaf6F7xulIS0X9BfD95HHSMVqKB6rhQ0q0ZIAqdweWcvR8nQ==",
       "license": "GPL-3.0",
       "dependencies": {
         "protobufjs": "^8.0.0"
@@ -6826,7 +6826,7 @@
         "dayjs": "^1.11.8",
         "dompurify": "^3.0.8",
         "filesize": "^11.0.13",
-        "libomemo.js": "^1.0.0",
+        "libomemo.js": "^2.0.0-rc.1",
         "localforage-webextensionstorage-driver": "^3.0.0",
         "lodash-es": "^4.17.21",
         "pluggable.js": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "converse.js",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "Browser based XMPP chat client",
   "type": "module",
   "workspaces": [

--- a/src/headless/package.json
+++ b/src/headless/package.json
@@ -9,17 +9,17 @@
   ],
   "homepage": "https://conversejs.org",
   "license": "MPL-2.0",
-"exports": {
-        ".": {
-            "import": {
-                "types": "./types/index.d.ts",
-                "default": "./dist/converse-headless.js"
-            }
-        },
-        "./dist/*": "./dist/*"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/converse-headless.js"
+      }
     },
-    "main": "./dist/converse-headless.js",
-    "types": "./types/index.d.ts",
+    "./dist/*": "./dist/*"
+  },
+  "main": "./dist/converse-headless.js",
+  "types": "./types/index.d.ts",
   "files": [
     "README.md",
     "dist/",
@@ -63,7 +63,7 @@
     "dayjs": "^1.11.8",
     "dompurify": "^3.0.8",
     "filesize": "^11.0.13",
-    "libomemo.js": "^1.0.0",
+    "libomemo.js": "^2.0.0-rc.1",
     "localforage-webextensionstorage-driver": "^3.0.0",
     "lodash-es": "^4.17.21",
     "pluggable.js": "3.0.1",

--- a/src/headless/plugins/caps/tests/caps.js
+++ b/src/headless/plugins/caps/tests/caps.js
@@ -50,7 +50,7 @@ describe('A sent presence stanza', function () {
                     <x xmlns="vcard-temp:x:update"/>
                     <c hash="sha-1"
                         node="https://conversejs.org"
-                        ver="SGYrtosGMfQo3YEEsjjM4Uea0tk="
+                        ver="VQN2NgsmAtNozeP6nd9JHH3MIuE="
                         xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
@@ -62,7 +62,7 @@ describe('A sent presence stanza', function () {
                 <status>Going jogging</status>
                 <priority>2</priority>
                 <x xmlns="vcard-temp:x:update"/>
-                <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
 
             api.settings.set('priority', undefined);
@@ -73,7 +73,7 @@ describe('A sent presence stanza', function () {
                 <status>Doing taxes</status>
                 <priority>0</priority>
                 <x xmlns="vcard-temp:x:update"/>
-                <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
         }),
     );

--- a/src/headless/plugins/muc/tests/muc.js
+++ b/src/headless/plugins/muc/tests/muc.js
@@ -14,20 +14,26 @@ describe('Groupchats', function () {
             const model = _converse.chatboxes.get(muc_jid);
 
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, stx`
+                mock.createRequest(
+                    _converse,
+                    stx`
             <message xmlns="jabber:client" type="groupchat" id="1" to="${_converse.jid}" xml:lang="en" from="${muc_jid}/juliet">
                 <body>Romeo oh romeo</body>
-            </message>`),
+            </message>`,
+                ),
             );
             await u.waitUntil(() => model.messages.length);
             expect(model.get('num_unread_general')).toBe(1);
             expect(model.get('num_unread')).toBe(1);
 
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, stx`
+                mock.createRequest(
+                    _converse,
+                    stx`
             <message xmlns="jabber:client" type="groupchat" id="2" to="${_converse.jid}" xml:lang="en" from="${muc_jid}/juliet">
                 <body>Wherefore art though?</body>
-            </message>`),
+            </message>`,
+                ),
             );
 
             await u.waitUntil(() => model.messages.length === 2);
@@ -60,7 +66,7 @@ describe('Groupchats', function () {
                 <presence from="${_converse.jid}" id="${pres.getAttribute('id')}" to="${muc_jid}/romeo" xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <show>away</show>
-                    <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
                 expect(muc.getOwnOccupant().get('show')).toBe('away');
@@ -79,7 +85,7 @@ describe('Groupchats', function () {
                     <show>xa</show>
                     <priority>0</priority>
                     <x xmlns="vcard-temp:x:update"/>
-                    <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
                 profile.set({ show: 'dnd', status_message: 'Do not disturb' });
@@ -94,7 +100,7 @@ describe('Groupchats', function () {
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <show>dnd</show>
                     <status>Do not disturb</status>
-                    <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
                 expect(muc2.getOwnOccupant().get('show')).toBe('dnd');
@@ -157,7 +163,7 @@ describe('Groupchats', function () {
                 expect(pres).toEqualStanza(stx`
                 <presence from="${_converse.jid}" id="${pres.getAttribute('id')}" to="coven@chat.shakespeare.lit/romeo" xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
             }),
         );

--- a/src/headless/plugins/muc/tests/presence.js
+++ b/src/headless/plugins/muc/tests/presence.js
@@ -29,7 +29,7 @@ describe('MUC presence history element', function () {
                 </x>
                 <c xmlns="http://jabber.org/protocol/caps"
                     hash="sha-1" node="https://conversejs.org"
-                    ver="SGYrtosGMfQo3YEEsjjM4Uea0tk="/>
+                    ver="VQN2NgsmAtNozeP6nd9JHH3MIuE="/>
               </presence>`);
 
             api.settings.set('muc_history_max_stanzas', 0);
@@ -44,7 +44,7 @@ describe('MUC presence history element', function () {
             expect(sent_stanza).toEqualStanza(stx`
               <presence to="${muc2_jid}/${nick}" xmlns="jabber:client" id="${sent_stanza.getAttribute('id')}" from="${jid}">
                 <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
-                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="SGYrtosGMfQo3YEEsjjM4Uea0tk="/>
+                <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org" ver="VQN2NgsmAtNozeP6nd9JHH3MIuE="/>
               </presence>`);
         }),
     );

--- a/src/headless/plugins/omemo/api.js
+++ b/src/headless/plugins/omemo/api.js
@@ -1,8 +1,11 @@
 import { initStorage } from '../../utils/storage.js';
 import _converse from '../../shared/_converse.js';
 import api from '../../shared/api/index.js';
+import converse from '../../shared/api/public.js';
 import OMEMOStore from './store.js';
 import { generateFingerprint, getDeviceList } from './utils.js';
+
+const { Strophe } = converse.env;
 
 export default {
     /**
@@ -47,11 +50,13 @@ export default {
              * The device list will be created if it doesn't exist already.
              * @method _converse.api.omemo.devicelists.get
              * @param {String} jid - The Jabber ID for which the device list will be returned.
-             * @param {boolean} create=false - Set to `true` if the device list
+             * @param {boolean} [create=false] - Set to `true` if the device list
              *      should be created if it cannot be found.
+             * @param {import('./types').OMEMOVersion} [version] - The OMEMO version.
+             *      Defaults to the legacy version.
              */
-            async get(jid, create = false) {
-                return await getDeviceList(jid, create);
+            async get(jid, create = false, version = Strophe.NS.OMEMO) {
+                return await getDeviceList(jid, create, version);
             },
         },
 

--- a/src/headless/plugins/omemo/device.js
+++ b/src/headless/plugins/omemo/device.js
@@ -1,18 +1,18 @@
-import { Model } from '@converse/skeletor';
 import log from '@converse/log';
 import _converse from '../../shared/_converse.js';
 import api from '../../shared/api/index.js';
 import converse from '../../shared/api/public.js';
 import { IQError } from '../../shared/errors.js';
 import { UNDECIDED } from './constants.js';
-import { parseBundle } from './parsers.js';
+import { parseBundle, parseBundleV2 } from './parsers.js';
+import { OMEMOVersionAwareModel } from './profiles.js';
 
 const { Strophe, sizzle, stx, u } = converse.env;
 
 /**
- * @extends {Model<import('./types').DeviceAttributes>}
+ * @extends {OMEMOVersionAwareModel<import('./types').DeviceAttributes>}
  */
-class Device extends Model {
+class Device extends OMEMOVersionAwareModel {
     defaults() {
         return {
             trusted: UNDECIDED,
@@ -38,10 +38,15 @@ class Device extends Model {
      */
     async fetchBundleFromServer() {
         const bare_jid = _converse.session.get('bare_jid');
+        const device_id = this.get('id');
+        const is_v2 = this.isV2();
+        const bundle_node_prefix = is_v2 ? Strophe.NS.OMEMO2_BUNDLES : Strophe.NS.OMEMO_BUNDLES;
+        const bundle_xmlns = is_v2 ? Strophe.NS.OMEMO2 : Strophe.NS.OMEMO;
+
         const stanza = stx`
             <iq type="get" from="${bare_jid}" to="${this.get('jid')}" xmlns="jabber:client">
                 <pubsub xmlns="${Strophe.NS.PUBSUB}">
-                    <items node="${Strophe.NS.OMEMO_BUNDLES}:${this.get('id')}"/>
+                    <items node="${bundle_node_prefix}:${device_id}"/>
                 </pubsub>
             </iq>`;
 
@@ -49,7 +54,7 @@ class Device extends Model {
         try {
             iq = await api.sendIQ(stanza);
         } catch (iq) {
-            log.error(`Could not fetch bundle for device ${this.get('id')} from ${this.get('jid')}`);
+            log.error(`Could not fetch bundle for device ${device_id} from ${this.get('jid')}`);
             log.error(iq);
             if (iq && iq.querySelector('error')) {
                 throw new IQError('Could not fetch bundle', iq);
@@ -59,9 +64,10 @@ class Device extends Model {
         if (iq.querySelector('error')) {
             throw new IQError('Could not fetch bundle', iq);
         }
-        const publish_el = sizzle(`items[node="${Strophe.NS.OMEMO_BUNDLES}:${this.get('id')}"]`, iq).pop();
-        const bundle_el = sizzle(`bundle[xmlns="${Strophe.NS.OMEMO}"]`, publish_el).pop();
-        const bundle = parseBundle(bundle_el);
+
+        const publish_el = sizzle(`items[node="${bundle_node_prefix}:${device_id}"]`, iq).pop();
+        const bundle_el = sizzle(`bundle[xmlns="${bundle_xmlns}"]`, publish_el).pop();
+        const bundle = is_v2 ? parseBundleV2(bundle_el) : parseBundle(bundle_el);
         this.save('bundle', bundle);
         return bundle;
     }

--- a/src/headless/plugins/omemo/devicelist.js
+++ b/src/headless/plugins/omemo/devicelist.js
@@ -1,17 +1,27 @@
-import { getOpenPromise } from "@converse/openpromise";
-import { Model } from '@converse/skeletor';
+import { getOpenPromise } from '@converse/openpromise';
 import log from '@converse/log';
 import * as errors from '../../shared/errors.js';
-import { parsers } from "../../shared/index.js";
+import { parsers } from '../../shared/index.js';
 import _converse from '../../shared/_converse.js';
 import api from '../../shared/api/index.js';
 import converse from '../../shared/api/public.js';
+import { OMEMOVersionAwareModel } from './profiles.js';
 
 const { Strophe, stx, sizzle, u } = converse.env;
 
-class DeviceList extends Model {
+/**
+ * @extends {OMEMOVersionAwareModel<import('../../shared/types').JIDModelAttributes>}
+ */
+class DeviceList extends OMEMOVersionAwareModel {
+    /**
+     * Whether the most recent server fetch for this device list failed
+     * (timeout/error) rather than authoritatively returning no devices.
+     * @type {boolean}
+     */
+    #last_fetch_failed = false;
+
     get idAttribute() {
-        return "jid";
+        return 'jid';
     }
 
     async initialize() {
@@ -22,9 +32,10 @@ class DeviceList extends Model {
     }
 
     initDevices() {
-        this.devices = new _converse.exports.Devices();
-        const bare_jid = _converse.session.get("bare_jid");
-        const id = `converse.devicelist-${bare_jid}-${this.get("jid")}`;
+        this.devices = new _converse.exports.Devices(null, { version: this.getVersion() });
+        const bare_jid = _converse.session.get('bare_jid');
+        const version_suffix = this.isV2() ? '-omemo2' : '';
+        const id = `converse.devicelist-${bare_jid}-${this.get('jid')}${version_suffix}`;
         u.initStorage(this.devices, id);
         return this.fetchDevices();
     }
@@ -32,11 +43,25 @@ class DeviceList extends Model {
     /**
      * @param {import('./devices').default} collection
      */
+    /**
+     * Whether the most recent server fetch for this device list failed
+     * (timeout or error stanza), as opposed to authoritatively returning no
+     * devices (an empty list or item-not-found). Callers use this to decide
+     * whether an empty device list is worth re-fetching: a genuine "no devices"
+     * answer is not (a PEP push will inform us if that changes, since we
+     * advertise `+notify`), but a transient failure is.
+     * @returns {boolean}
+     */
+    get lastFetchFailed() {
+        return this.#last_fetch_failed;
+    }
+
     async onDevicesFound(collection) {
         if (collection.length === 0) {
             let ids = [];
             try {
                 ids = await this.fetchDevicesFromServer();
+                this.#last_fetch_failed = false;
             } catch (e) {
                 // We deliberately leave this (empty) device list in place
                 // instead of destroying it. `onDevicesFound` runs from within
@@ -48,18 +73,26 @@ class DeviceList extends Model {
                 // in `getDevicesForContact`, and via a fresh server fetch on
                 // the next reload.
                 if (e === null) {
-                    log.error(`Timeout error while fetching OMEMO devices for ${this.get("jid")}`);
+                    this.#last_fetch_failed = true;
+                    log.error(`Timeout error while fetching OMEMO devices for ${this.get('jid')}`);
                 } else if (u.isElement(e) && (await parsers.parseErrorStanza(e)) instanceof errors.ItemNotFoundError) {
-                    log.debug(`No OMEMO devices found for ${this.get("jid")}`);
+                    // An authoritative "no such node" — the contact simply has
+                    // no device list for this OMEMO version. Not a failure, so
+                    // we don't keep retrying on every send.
+                    this.#last_fetch_failed = false;
+                    log.debug(`No OMEMO devices found for ${this.get('jid')}`);
                 } else {
-                    log.error(`Could not fetch OMEMO devices for ${this.get("jid")}`);
+                    this.#last_fetch_failed = true;
+                    log.error(`Could not fetch OMEMO devices for ${this.get('jid')}`);
                     log.error(e);
                 }
             }
-            const bare_jid = _converse.session.get("bare_jid");
-            if (this.get("jid") === bare_jid) {
+            const bare_jid = _converse.session.get('bare_jid');
+            if (this.get('jid') === bare_jid) {
                 this.publishCurrentDevice(ids);
             }
+        } else {
+            this.#last_fetch_failed = false;
         }
     }
 
@@ -92,11 +125,17 @@ class DeviceList extends Model {
      */
     async getOwnDeviceId() {
         const { omemo_store } = _converse.state;
-        let device_id = omemo_store.get("device_id");
-        if (!this.devices.get(device_id)) {
-            // Generate a new bundle if we cannot find our device
+        let device_id = omemo_store.get('device_id');
+        if (!device_id) {
+            // No bundle at all. Generate one (creates device in legacy list)
             await omemo_store.generateBundle();
-            device_id = omemo_store.get("device_id");
+            device_id = omemo_store.get('device_id');
+        }
+        if (!this.devices.get(device_id)) {
+            // generateBundle always creates the device in the legacy collection.
+            // For the v2 list we create a bare entry so publishDevices() includes us.
+            const jid = this.get('jid');
+            await this.devices.create({ id: device_id, jid }, { promise: true });
         }
         return device_id;
     }
@@ -105,8 +144,8 @@ class DeviceList extends Model {
      * @param {string[]} device_ids
      */
     async publishCurrentDevice(device_ids) {
-        const bare_jid = _converse.session.get("bare_jid");
-        if (this.get("jid") !== bare_jid) {
+        const bare_jid = _converse.session.get('bare_jid');
+        if (this.get('jid') !== bare_jid) {
             return; // We only publish for ourselves.
         }
         await api.omemo.session.restore();
@@ -114,7 +153,7 @@ class DeviceList extends Model {
         if (!_converse.state.omemo_store) {
             // Happens during tests. The connection gets torn down
             // before publishCurrentDevice has time to finish.
-            log.debug("publishCurrentDevice: omemo_store is not defined, likely a timing issue");
+            log.debug('publishCurrentDevice: omemo_store is not defined, likely a timing issue');
             return;
         }
         if (!device_ids.includes(await this.getOwnDeviceId())) {
@@ -126,18 +165,27 @@ class DeviceList extends Model {
      * @returns {Promise<import('./device').default[]>}
      */
     async fetchDevicesFromServer() {
-        const bare_jid = _converse.session.get("bare_jid");
+        const bare_jid = _converse.session.get('bare_jid');
+        const node = this.isV2() ? Strophe.NS.OMEMO2_DEVICELIST : Strophe.NS.OMEMO_DEVICELIST;
         const stanza = stx`
-            <iq type='get' from='${bare_jid}' to='${this.get("jid")}' xmlns="jabber:client">
+            <iq type='get' from='${bare_jid}' to='${this.get('jid')}' xmlns="jabber:client">
                 <pubsub xmlns='${Strophe.NS.PUBSUB}'>
-                    <items node='${Strophe.NS.OMEMO_DEVICELIST}'/>
+                    <items node='${node}'/>
                 </pubsub>
             </iq>`;
 
         const iq = await api.sendIQ(stanza);
-        const selector = `list[xmlns="${Strophe.NS.OMEMO}"] device`;
-        const device_ids = sizzle(selector, iq).map((d) => d.getAttribute("id"));
-        const jid = this.get("jid");
+
+        let device_ids;
+        if (this.isV2()) {
+            const selector = `devices[xmlns="${Strophe.NS.OMEMO2_DEVICELIST}"] device`;
+            device_ids = sizzle(selector, iq).map((d) => d.getAttribute('id'));
+        } else {
+            const selector = `list[xmlns="${Strophe.NS.OMEMO}"] device`;
+            device_ids = sizzle(selector, iq).map((d) => d.getAttribute('id'));
+        }
+
+        const jid = this.get('jid');
         return Promise.all(device_ids.map((id) => this.devices.create({ id, jid }, { promise: true })));
     }
 
@@ -147,22 +195,34 @@ class DeviceList extends Model {
      * See: https://xmpp.org/extensions/attic/xep-0384-0.3.0.html#usecases-announcing
      */
     publishDevices() {
-        const item = stx`
-            <item id='current'>
-                <list xmlns='${Strophe.NS.OMEMO}'>
-                    ${this.devices.filter((d) => d.get("active")).map((d) => stx`<device id='${d.get("id")}'/>`)}
-                </list>
-            </item>`;
-        const options = { access_model: "open" };
-        return api.pubsub.publish(null, Strophe.NS.OMEMO_DEVICELIST, item, options, false);
+        const active_devices = this.devices.filter((d) => d.get('active'));
+        let item;
+        if (this.isV2()) {
+            item = stx`
+                <item id='current'>
+                    <devices xmlns='${Strophe.NS.OMEMO2_DEVICELIST}'>
+                        ${active_devices.map((d) => stx`<device id='${d.get('id')}'/>`)}
+                    </devices>
+                </item>`;
+        } else {
+            item = stx`
+                <item id='current'>
+                    <list xmlns='${Strophe.NS.OMEMO}'>
+                        ${active_devices.map((d) => stx`<device id='${d.get('id')}'/>`)}
+                    </list>
+                </item>`;
+        }
+        const node = this.isV2() ? Strophe.NS.OMEMO2_DEVICELIST : Strophe.NS.OMEMO_DEVICELIST;
+        const options = { access_model: 'open' };
+        return api.pubsub.publish(null, node, item, options, false);
     }
 
     /**
      * @param {string[]} device_ids
      */
     async removeOwnDevices(device_ids) {
-        const bare_jid = _converse.session.get("bare_jid");
-        if (this.get("jid") !== bare_jid) {
+        const bare_jid = _converse.session.get('bare_jid');
+        if (this.get('jid') !== bare_jid) {
             throw new Error("Cannot remove devices from someone else's device list");
         }
         await Promise.all(
@@ -177,9 +237,9 @@ class DeviceList extends Model {
                                     log.error(e);
                                     resolve();
                                 },
-                            })
-                        )
-                )
+                            }),
+                        ),
+                ),
         );
         return this.publishDevices();
     }

--- a/src/headless/plugins/omemo/devices.js
+++ b/src/headless/plugins/omemo/devices.js
@@ -5,9 +5,31 @@ import Device from "./device.js";
  * @extends {Collection<Device>}
  */
 class Devices extends Collection {
-    constructor() {
-        super();
+    /**
+     * @param {Device[]|object[]} [models]
+     * @param {object} [options]
+     * @param {import('./types').OMEMOVersion} [options.version]
+     */
+    constructor(models, options = {}) {
+        super(models, options);
         this.model = Device;
+        // The OMEMO version this collection belongs to. Stamped onto every
+        // device so that Device.isV2() (and thus bundle node selection and
+        // parsing) is correct for the contact's devices, not just our own.
+        this.version = options.version;
+    }
+
+    /**
+     * Stamp the collection's OMEMO version onto every device created through it,
+     * unless one was explicitly provided.
+     * @param {object|Device} attrs
+     * @param {object} [options]
+     */
+    _prepareModel(attrs, options) {
+        if (this.version && attrs && !(attrs instanceof Device) && !attrs.version) {
+            attrs.version = this.version;
+        }
+        return super._prepareModel(attrs, options);
     }
 }
 

--- a/src/headless/plugins/omemo/index.js
+++ b/src/headless/plugins/omemo/index.js
@@ -12,4 +12,11 @@ Strophe.addNamespace('OMEMO_VERIFICATION', Strophe.NS.OMEMO + '.verification');
 Strophe.addNamespace('OMEMO_WHITELISTED', Strophe.NS.OMEMO + '.whitelisted');
 Strophe.addNamespace('OMEMO_BUNDLES', Strophe.NS.OMEMO + '.bundles');
 
-export { Device, Devices, DeviceList, DeviceLists  };
+// OMEMO 2 (urn:xmpp:omemo:2) namespaces
+Strophe.addNamespace('OMEMO2', 'urn:xmpp:omemo:2');
+Strophe.addNamespace('OMEMO2_DEVICELIST', 'urn:xmpp:omemo:2:devices');
+Strophe.addNamespace('OMEMO2_BUNDLES', 'urn:xmpp:omemo:2:bundles');
+
+Strophe.addNamespace('SCE', 'urn:xmpp:sce:1');
+
+export { Device, Devices, DeviceList, DeviceLists };

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -1,6 +1,8 @@
 /**
- * @typedef {import('../..//shared/types').MessageAttributes} MessageAttributes
+ * @typedef {import('../../shared/types').MessageAttributes} MessageAttributes
  * @typedef {import('../../plugins/muc/types').MUCMessageAttributes} MUCMessageAttributes
+ * @typedef {import('./types').MUCMessageAttrsWithEncryption} MUCMessageAttrsWithEncryption
+ * @typedef {import('./types').MessageAttrsWithEncryption} MessageAttrsWithEncryption
  */
 import sizzle from 'sizzle';
 import log from '@converse/log';
@@ -9,20 +11,33 @@ import _converse from '../../shared/_converse.js';
 import converse from '../../shared/api/public.js';
 import u from '../../utils/index.js';
 import { decryptMessage, getSessionCipher } from './utils.js';
+import { decryptSCE } from './sce.js';
 
 const { Strophe } = converse.env;
 
+const DECRYPTION_ERROR_ATTRS = {
+    error_type: 'Decryption',
+    is_ephemeral: true,
+    is_error: true,
+    type: 'error',
+};
+
+const NO_KEY_ERROR_ATTRS = {
+    ...DECRYPTION_ERROR_ATTRS,
+    error_condition: 'not-encrypted-for-this-device',
+};
+
+/**
+ * @param {Error} e
+ */
 function getDecryptionErrorAttributes(e) {
     const { __ } = _converse;
     return {
-        'error_text':
+        ...DECRYPTION_ERROR_ATTRS,
+        error_text:
             __('Sorry, could not decrypt a received OMEMO message due to an error.') + ` ${e.name} ${e.message}`,
-        'error_condition': e.name,
-        'error_message': e.message,
-        'error_type': 'Decryption',
-        'is_ephemeral': true,
-        'is_error': true,
-        'type': 'error',
+        error_condition: e.name,
+        error_message: e.message,
     };
 }
 
@@ -154,22 +169,12 @@ async function decryptPrekeyWhisperMessage(attrs) {
 }
 
 /**
- * Hook handler for {@link parseMessage} and {@link parseMUCMessage}, which
- * parses the passed in `message` stanza for OMEMO attributes and then sets
- * them on the attrs object.
- * @param {Element} stanza - The message stanza
+ * Decrypt a legacy OMEMO (eu.siacs.conversations.axolotl) message.
+ * @param {Element} stanza
  * @param {MUCMessageAttributes|MessageAttributes} attrs
- * @returns {Promise<MUCMessageAttributes| MessageAttributes|
-        import('./types').MUCMessageAttrsWithEncryption|import('./types').MessageAttrsWithEncryption>}
+ * @returns {Promise<MUCMessageAttributes|MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
  */
-export async function parseEncryptedMessage(stanza, attrs) {
-    if (
-        api.settings.get('clear_cache_on_logout') ||
-        !attrs.is_encrypted ||
-        attrs.encryption_namespace !== Strophe.NS.OMEMO
-    ) {
-        return attrs;
-    }
+async function decryptLegacyOMEMOMessage(stanza, attrs) {
     const encrypted_el = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, stanza).pop();
     const header = encrypted_el.querySelector('header');
     attrs.encrypted = { 'device_id': header.getAttribute('sid') };
@@ -184,13 +189,7 @@ export async function parseEncryptedMessage(stanza, attrs) {
             prekey: ['true', '1'].includes(key.getAttribute('prekey')),
         });
     } else {
-        return Object.assign(attrs, {
-            error_condition: 'not-encrypted-for-this-device',
-            error_type: 'Decryption',
-            is_ephemeral: true,
-            is_error: true,
-            type: 'error',
-        });
+        return Object.assign(attrs, NO_KEY_ERROR_ATTRS);
     }
     // https://xmpp.org/extensions/xep-0384.html#usecases-receiving
     if (attrs.encrypted.prekey === true) {
@@ -201,7 +200,149 @@ export async function parseEncryptedMessage(stanza, attrs) {
 }
 
 /**
- * Given an XML element representing a user's OMEMO bundle, parse it
+ * Decrypt an OMEMO 2 message.
+ * @param {Element} stanza
+ * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @returns {Promise<MUCMessageAttributes|MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
+ */
+async function decryptOMEMO2Message(stanza, attrs) {
+    const encrypted_el = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, stanza).pop();
+    if (!encrypted_el) return attrs;
+
+    const header = encrypted_el.querySelector('header');
+    const sender_device_id = header.getAttribute('sid');
+
+    const device_id = await api.omemo?.getDeviceID();
+    if (!device_id) return attrs;
+
+    // Find our <key rid='...'> under any <keys jid='our_bare_jid'>
+    const bare_jid = _converse.session.get('bare_jid');
+    const keys_el = sizzle(`keys[jid="${bare_jid}"]`, encrypted_el).pop();
+    if (!keys_el) {
+        return Object.assign(attrs, NO_KEY_ERROR_ATTRS);
+    }
+
+    const key_el = keys_el.querySelector(`key[rid="${device_id}"]`);
+    if (!key_el) {
+        return Object.assign(attrs, NO_KEY_ERROR_ATTRS);
+    }
+
+    const from_jid = getJIDForDecryption(attrs);
+    const is_kex = key_el.getAttribute('kex') === 'true';
+    const key_b64 = key_el.textContent.trim();
+
+    attrs.encrypted = {
+        device_id: sender_device_id,
+        key: key_b64,
+        payload: encrypted_el.querySelector('payload')?.textContent?.trim() || null,
+        prekey: is_kex,
+    };
+
+    const session_cipher = await getSessionCipher(from_jid, parseInt(sender_device_id, 10), Strophe.NS.OMEMO2);
+    const key_bytes = u.base64ToArrayBuffer(key_b64);
+
+    let key_and_tag;
+    try {
+        if (is_kex) {
+            key_and_tag = await session_cipher.decryptPreKeyWhisperMessage(key_bytes, 'binary');
+            // After handling a key exchange, regenerate and publish prekeys
+            const { omemo_store } = _converse.state;
+            await omemo_store.generateMissingPreKeys();
+            await omemo_store.publishBundle();
+        } else {
+            key_and_tag = await session_cipher.decryptWhisperMessage(key_bytes, 'binary');
+        }
+    } catch (e) {
+        log.error(`OMEMO 2 decryption failed: ${e.name} ${e.message}`);
+        return Object.assign(attrs, getDecryptionErrorAttributes(e));
+    }
+
+    if (!attrs.encrypted.payload) {
+        // Empty/heartbeat message
+        return Object.assign(attrs, { 'is_only_key': true });
+    }
+
+    try {
+        const is_muc = 'from_real_jid' in attrs;
+        const muc_jid = is_muc ? attrs.from : null;
+        const plaintext = await decryptSCE(key_and_tag, attrs.encrypted.payload, {
+            sender_jid: from_jid,
+            to_jid: muc_jid,
+        });
+
+        // Update device active state
+        const devicelist = await api.omemo.devicelists.get(from_jid, true, Strophe.NS.OMEMO2);
+        let device = devicelist.devices.get(sender_device_id);
+        if (!device) {
+            device = await devicelist.devices.create({ 'id': sender_device_id, 'jid': from_jid }, { 'promise': true });
+        }
+        device.save('active', true);
+
+        if (plaintext) {
+            return Object.assign(attrs, { plaintext });
+        } else {
+            return Object.assign(attrs, { 'is_only_key': true });
+        }
+    } catch (e) {
+        log.error(`SCE decryption failed: ${e.name} ${e.message}`);
+        return Object.assign(attrs, getDecryptionErrorAttributes(e));
+    }
+}
+
+/**
+ * Hook handler for {@link parseMessage} and {@link parseMUCMessage}, which
+ * parses the passed in `message` stanza for OMEMO attributes and then sets
+ * them on the attrs object.
+ *
+ * A single stanza may carry both an `urn:xmpp:omemo:2` and a legacy
+ * `eu.siacs.conversations.axolotl` `<encrypted>` element: a sender that
+ * supports both addresses each recipient device in whichever version that
+ * device understands. The EME (XEP-0380) hint names only one method and exists
+ * for clients that can decrypt *neither* — it must not be used to pick a
+ * decryption path. So we route on which `<encrypted>` block actually contains a
+ * `<key>` for our own device, preferring omemo:2.
+ *
+ * @param {Element} stanza - The message stanza
+ * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @returns {Promise<MUCMessageAttributes| MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
+ */
+export async function parseEncryptedMessage(stanza, attrs) {
+    if (api.settings.get('clear_cache_on_logout') || !attrs.is_encrypted) {
+        return attrs;
+    }
+
+    const device_id = await api.omemo?.getDeviceID();
+    const bare_jid = _converse.session.get('bare_jid');
+
+    const v2_el = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, stanza).pop();
+    const legacy_el = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, stanza).pop();
+
+    const has_v2_key =
+        !!(v2_el && device_id) && sizzle(`keys[jid="${bare_jid}"] key[rid="${device_id}"]`, v2_el).length > 0;
+    const has_legacy_key = !!(legacy_el && device_id) && sizzle(`key[rid="${device_id}"]`, legacy_el).length > 0;
+
+    if (has_v2_key) {
+        return await decryptOMEMO2Message(stanza, attrs);
+    }
+    if (has_legacy_key) {
+        return await decryptLegacyOMEMOMessage(stanza, attrs);
+    }
+
+    // The message is OMEMO-encrypted but no <key> is addressed to this device.
+    // Only surface the "not encrypted for this device" error once we actually
+    // know our own device id, otherwise OMEMO isn't ready yet and we'd raise a
+    // spurious error during an init race.
+    if (device_id && (v2_el || legacy_el)) {
+        return Object.assign(attrs, NO_KEY_ERROR_ATTRS);
+    }
+
+    // Not an OMEMO message we can handle; leave attrs untouched so any EME
+    // fallback body is shown.
+    return attrs;
+}
+
+/**
+ * Given an XML element representing a legacy OMEMO bundle, parse it
  * and return a map.
  * @param {Element} bundle_el
  * @returns {import('./types').Bundle}
@@ -226,9 +367,39 @@ export function parseBundle(bundle_el) {
     };
 }
 
+/**
+ * Given an XML element representing an OMEMO 2 bundle, parse it
+ * and return a map using the same internal format as the legacy bundle.
+ *
+ * All key values are base64-encoded 32-byte raw Curve25519/Ed25519 bytes
+ * (the leading 0x05 byte is absent for v2).
+ *
+ * @param {Element} bundle_el
+ * @returns {import('./types').Bundle}
+ */
+export function parseBundleV2(bundle_el) {
+    const spk_el = bundle_el.querySelector('spk');
+    const prekeys = sizzle('prekeys > pk', bundle_el).map(
+        /** @param {Element} el */ (el) => ({
+            id: parseInt(el.getAttribute('id'), 10),
+            key: el.textContent.trim(),
+        }),
+    );
+    return {
+        identity_key: bundle_el.querySelector('ik').textContent.trim(),
+        signed_prekey: {
+            id: parseInt(spk_el.getAttribute('id'), 10),
+            public_key: spk_el.textContent.trim(),
+            signature: bundle_el.querySelector('spks').textContent.trim(),
+        },
+        prekeys,
+    };
+}
+
 Object.assign(u, {
     omemo: {
         ...u.omemo,
         parseBundle,
+        parseBundleV2,
     },
 });

--- a/src/headless/plugins/omemo/plugin.js
+++ b/src/headless/plugins/omemo/plugin.js
@@ -74,7 +74,10 @@ converse.plugins.add('converse-omemo', {
         api.listen.on('getOutgoingMessageAttributes', getOutgoingMessageAttributes);
 
         api.listen.on('statusInitialized', initOMEMO);
-        api.listen.on('addClientFeatures', () => api.disco.own.features.add(`${Strophe.NS.OMEMO_DEVICELIST}+notify`));
+        api.listen.on('addClientFeatures', () => {
+            api.disco.own.features.add(`${Strophe.NS.OMEMO_DEVICELIST}+notify`);
+            api.disco.own.features.add(`${Strophe.NS.OMEMO2_DEVICELIST}+notify`);
+        });
 
         api.listen.on('parseMessage', parseEncryptedMessage);
         api.listen.on('parseMUCMessage', parseEncryptedMessage);
@@ -91,9 +94,15 @@ converse.plugins.add('converse-omemo', {
 
         api.listen.on('clearSession', () => {
             delete _converse.state.omemo_store;
-            if (u.shouldClearCache(_converse) && _converse.state.devicelists) {
-                _converse.state.devicelists.clearStore();
-                delete _converse.state.devicelists;
+            if (u.shouldClearCache(_converse)) {
+                if (_converse.state.devicelists) {
+                    _converse.state.devicelists.clearStore();
+                    delete _converse.state.devicelists;
+                }
+                if (_converse.state.devicelists_v2) {
+                    _converse.state.devicelists_v2.clearStore();
+                    delete _converse.state.devicelists_v2;
+                }
             }
         });
     },

--- a/src/headless/plugins/omemo/profiles.js
+++ b/src/headless/plugins/omemo/profiles.js
@@ -1,0 +1,66 @@
+import { Model } from '@converse/skeletor';
+import converse from '../../shared/api/public.js';
+
+const { u, Strophe } = converse.env;
+
+/**
+ * Base model for the OMEMO models (Device, DeviceList) that carry an OMEMO
+ * protocol version in their `version` attribute, defaulting to the legacy
+ * (0.3.0) version when unset.
+ * @template {import('../../shared/types').ModelAttributes} [T=import('../../shared/types').ModelAttributes]
+ * @extends {Model<T>}
+ */
+export class OMEMOVersionAwareModel extends Model {
+    /** @returns {import('./types').OMEMOVersion} */
+    getVersion() {
+        return this.get('version') || Strophe.NS.OMEMO;
+    }
+
+    isV2() {
+        return this.getVersion() === Strophe.NS.OMEMO2;
+    }
+}
+
+/**
+ * Strip the leading 0x05 encoding byte from a 33-byte Curve25519 key produced
+ * by libomemo.js, returning the raw 32-byte value as base64. Used when
+ * publishing v2 bundle elements.
+ * @param {string} b64 - base64-encoded 33-byte key
+ * @returns {string}
+ */
+export function stripKeyByte(b64) {
+    const buf = u.base64ToArrayBuffer(b64);
+    return u.arrayBufferToBase64(buf.slice(1));
+}
+
+/**
+ * Returns the protocol profile for a given OMEMO version.
+ * @param {import('./types').OMEMOVersion} version
+ * @returns {import('./types').OMEMOProfile}
+ */
+export function getProfile(version) {
+    if (version === Strophe.NS.OMEMO2) {
+        return {
+            version: Strophe.NS.OMEMO2,
+            get devicelist_node() {
+                return converse.env.Strophe.NS.OMEMO2_DEVICELIST;
+            },
+            get bundle_node_prefix() {
+                return converse.env.Strophe.NS.OMEMO2_BUNDLES;
+            },
+            usesSCE: true,
+            encodePubKey: stripKeyByte,
+        };
+    }
+    return {
+        version: Strophe.NS.OMEMO,
+        get devicelist_node() {
+            return converse.env.Strophe.NS.OMEMO_DEVICELIST;
+        },
+        get bundle_node_prefix() {
+            return converse.env.Strophe.NS.OMEMO_BUNDLES;
+        },
+        usesSCE: false,
+        encodePubKey: (/** @type {string} */ b64) => b64,
+    };
+}

--- a/src/headless/plugins/omemo/sce.js
+++ b/src/headless/plugins/omemo/sce.js
@@ -1,0 +1,211 @@
+/**
+ * SCE (Stanza Content Encryption, XEP-0420) payload encryption for OMEMO 2.
+ *
+ * Implements the crypto layer required by XEP-0384 when using urn:xmpp:omemo:2:
+ *   - AES-256-CBC + HMAC-SHA-256 authenticated encryption
+ *   - HKDF-SHA-256 key derivation (80 bytes → encKey || authKey || IV)
+ *   - The 48-byte tuple (key ‖ truncated-HMAC) is what each per-device
+ *     SessionCipher.encrypt() receives
+ *   - The SCE envelope wraps the plaintext XML in <envelope xmlns='urn:xmpp:sce:1'>
+ */
+import converse from '../../shared/api/public.js';
+
+const { Strophe, u, stx, sizzle } = converse.env;
+
+const HKDF_INFO = 'OMEMO Payload';
+
+/**
+ * Constant-time comparison of two byte arrays. Unlike a short-circuiting
+ * compare (e.g. `Array.every`), the running time does not depend on where the
+ * first differing byte is, so it leaks no information about the expected value
+ * to a timing attacker. Used to verify the SCE HMAC tag.
+ *
+ * We hand-roll this rather than use `crypto.subtle.verify('HMAC', …)` (which
+ * compares internally) because SCE truncates the HMAC to 16 bytes, and
+ * `subtle.verify` only checks the full 32-byte SHA-256 output — there's no
+ * supported way to verify a truncation. Node's `crypto.timingSafeEqual` isn't
+ * an option either: it's absent in the browser, our production target.
+ * @param {Uint8Array} a
+ * @param {Uint8Array} b
+ * @returns {boolean}
+ */
+function constantTimeEqual(a, b) {
+    // Fold the length difference into the accumulator so unequal-length inputs
+    // can never compare equal, without an early return.
+    let diff = a.length ^ b.length;
+    const len = Math.max(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+        diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+    }
+    return diff === 0;
+}
+
+/**
+ * Derive encKey, authKey, IV from a random 32-byte content key using HKDF-SHA-256.
+ * @param {ArrayBuffer} content_key - 32 random bytes
+ * @returns {Promise<{encKey: ArrayBuffer, authKey: ArrayBuffer, iv: ArrayBuffer}>}
+ */
+async function deriveKeys(content_key) {
+    const salt = new ArrayBuffer(32); // 32 zero bytes
+    const ikm = await crypto.subtle.importKey('raw', content_key, 'HKDF', false, ['deriveBits']);
+    const derived = await crypto.subtle.deriveBits(
+        {
+            name: 'HKDF',
+            hash: 'SHA-256',
+            salt,
+            info: new TextEncoder().encode(HKDF_INFO),
+        },
+        ikm,
+        640, // 80 bytes = 640 bits
+    );
+    return {
+        encKey: derived.slice(0, 32),
+        authKey: derived.slice(32, 64),
+        iv: derived.slice(64, 80),
+    };
+}
+
+/**
+ * Build the SCE <envelope> XML string for a given message body.
+ *
+ * Affixes per XEP-0384 SCE profile:
+ *   - <rpad> MUST
+ *   - <from> SHOULD (included)
+ *   - <to> MUST for MUC (included when muc_jid is provided)
+ *   - <time> MAY (omitted for now)
+ *
+ * @param {string} body - plaintext message body
+ * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @returns {import('strophe.js').Builder}
+ */
+function buildSCEEnvelope(body, { from_jid, to_jid }) {
+    const rpad_len = 1 + Math.floor(Math.random() * 100);
+    const rpad = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(rpad_len))));
+
+    return stx`
+        <envelope xmlns="${Strophe.NS.SCE}">
+            <content><body xmlns="jabber:client">${body}</body></content>
+            <rpad>${rpad}</rpad>
+            <from xmlns="${Strophe.NS.SCE}" jid="${from_jid}"/>
+            ${to_jid ? stx`<to xmlns="${Strophe.NS.SCE}" jid="${to_jid}"/>` : ''}
+        </envelope>`;
+}
+
+/**
+ * Encrypt a message body using the SCE/OMEMO 2 scheme.
+ *
+ * Returns the 48-byte key_and_tag (content_key ‖ truncated-HMAC) as an
+ * ArrayBuffer — this is what gets encrypted with SessionCipher per device —
+ * and the base64-encoded AES-256-CBC ciphertext as the <payload> value.
+ *
+ * @param {string} plaintext - the message body to encrypt
+ * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
+ */
+export async function encryptSCE(plaintext, affixes) {
+    // Random 32-byte content key
+    const content_key = crypto.getRandomValues(new Uint8Array(32)).buffer;
+    const { encKey, authKey, iv } = await deriveKeys(content_key);
+
+    const envelope = buildSCEEnvelope(plaintext, affixes);
+    const plaintext_bytes = new TextEncoder().encode(envelope.toString());
+
+    // AES-256-CBC encryption
+    const aes_key = await crypto.subtle.importKey('raw', encKey, 'AES-CBC', false, ['encrypt']);
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-CBC', iv }, aes_key, plaintext_bytes);
+
+    // HMAC-SHA-256 over ciphertext, truncated to 16 bytes
+    const hmac_key = await crypto.subtle.importKey('raw', authKey, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const hmac_full = await crypto.subtle.sign('HMAC', hmac_key, ciphertext);
+    const hmac_16 = hmac_full.slice(0, 16);
+
+    // 48-byte tuple: content_key(32) ‖ HMAC(16)
+    const key_and_tag = new Uint8Array(48);
+    key_and_tag.set(new Uint8Array(content_key), 0);
+    key_and_tag.set(new Uint8Array(hmac_16), 32);
+
+    return {
+        key_and_tag: key_and_tag.buffer,
+        payload: u.arrayBufferToBase64(ciphertext),
+    };
+}
+
+/**
+ * Decrypt an SCE/OMEMO 2 payload.
+ *
+ * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
+ * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext
+ * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes - for validation
+ * @returns {Promise<string|null>} - plaintext message body
+ */
+export async function decryptSCE(key_and_tag, payload_b64, expected_affixes) {
+    if (key_and_tag.byteLength !== 48) {
+        throw new Error(`SCE key_and_tag must be 48 bytes, got ${key_and_tag.byteLength}`);
+    }
+
+    const content_key = key_and_tag.slice(0, 32);
+    const expected_hmac = key_and_tag.slice(32, 48);
+    const { encKey, authKey, iv } = await deriveKeys(content_key);
+
+    const ciphertext = u.base64ToArrayBuffer(payload_b64);
+
+    // Verify HMAC before decrypting
+    const hmac_key = await crypto.subtle.importKey('raw', authKey, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const hmac_full = await crypto.subtle.sign('HMAC', hmac_key, ciphertext);
+    const hmac_16 = new Uint8Array(hmac_full.slice(0, 16));
+    const expected = new Uint8Array(expected_hmac);
+    if (!constantTimeEqual(hmac_16, expected)) {
+        throw new Error('SCE HMAC verification failed');
+    }
+
+    // AES-256-CBC decrypt
+    const aes_key = await crypto.subtle.importKey('raw', encKey, 'AES-CBC', false, ['decrypt']);
+    const plaintext_bytes = await crypto.subtle.decrypt({ name: 'AES-CBC', iv }, aes_key, ciphertext);
+    const envelope_xml = new TextDecoder().decode(plaintext_bytes);
+
+    return parseSCEEnvelope(envelope_xml, expected_affixes);
+}
+
+/**
+ * Parse an SCE <envelope> and validate affixes, returning the message body.
+ * @param {string} envelope_xml
+ * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes
+ * @returns {string}
+ */
+function parseSCEEnvelope(envelope_xml, { sender_jid, to_jid }) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(envelope_xml, 'application/xml');
+
+    const envelope = doc.documentElement;
+    if (!envelope || envelope.localName !== 'envelope' || envelope.namespaceURI !== Strophe.NS.SCE) {
+        throw new Error('SCE: no <envelope> found in decrypted payload');
+    }
+
+    // Validate <from> affix (SHOULD be present, MUST match sender if present)
+    const from_el = sizzle(`> from[xmlns="${Strophe.NS.SCE}"]`, envelope).pop();
+    if (from_el) {
+        const from_jid = from_el.getAttribute('jid');
+        if (sender_jid && !u.isSameBareJID(from_jid, sender_jid)) {
+            throw new Error(`SCE affix mismatch: <from> is ${from_jid}, expected ${sender_jid}`);
+        }
+    }
+
+    // Validate <to> affix (MUST be present and correct for MUC)
+    if (to_jid) {
+        const to_el = sizzle(`> to[xmlns="${Strophe.NS.SCE}"]`, envelope).pop();
+        if (!to_el) {
+            throw new Error('SCE: missing required <to> affix for MUC message');
+        }
+        if (!u.isSameBareJID(to_el.getAttribute('jid'), to_jid)) {
+            throw new Error(`SCE affix mismatch: <to> is ${to_el.getAttribute('jid')}, expected ${to_jid}`);
+        }
+    }
+
+    const content_el = sizzle('> content', envelope).pop();
+    const body_el = content_el ? sizzle('> body', content_el).pop() : null;
+    if (!body_el) {
+        // Empty/heartbeat message — no body
+        return null;
+    }
+    return body_el.textContent;
+}

--- a/src/headless/plugins/omemo/store.js
+++ b/src/headless/plugins/omemo/store.js
@@ -5,6 +5,7 @@ import converse from '../../shared/api/public.js';
 import api from '../../shared/api/index.js';
 import { getCrypto } from './crypto.js';
 import { getDeviceList } from './utils.js';
+export { VersionedOMEMOStore } from './versioned-store.js';
 
 const { Strophe, stx, u } = converse.env;
 
@@ -12,6 +13,9 @@ const { Strophe, stx, u } = converse.env;
  * @extends {Model<import('./types').OMEMOStoreAttributes>}
  */
 class OMEMOStore extends Model {
+    /** @type {Promise<void>} */
+    #setup_promise;
+
     get Direction() {
         return {
             SENDING: 1,
@@ -70,7 +74,7 @@ class OMEMOStore extends Model {
 
     /**
      * @param {string} address
-     * @param {string} identity_key
+     * @param {ArrayBuffer} identity_key
      * @returns {boolean}
      */
     saveIdentity(address, identity_key) {
@@ -93,7 +97,7 @@ class OMEMOStore extends Model {
     }
 
     /**
-     * @param {string} key_id
+     * @param {string|number} key_id
      * @returns {Promise<{ keyPair: import('libomemo.js').KeyPair }|void>}
      */
     loadPreKey(key_id) {
@@ -124,7 +128,7 @@ class OMEMOStore extends Model {
     }
 
     /**
-     * @param {string} key_id
+     * @param {string|number} key_id
      */
     removePreKey(key_id) {
         const prekeys = { ...this.getPreKeys() };
@@ -157,6 +161,24 @@ class OMEMOStore extends Model {
             throw new Error('storeSignedPreKey: expected an object');
         }
         this.save('signed_prekey', {
+            id: spk.keyId,
+            privKey: u.arrayBufferToBase64(spk.keyPair.privKey),
+            pubKey: u.arrayBufferToBase64(spk.keyPair.pubKey),
+            signature: u.arrayBufferToBase64(spk.signature),
+        });
+    }
+
+    /**
+     * Store the v2 (urn:xmpp:omemo:2) signed prekey. Kept separate from the
+     * legacy SPK because the signature covers different bytes (32-byte curve vs
+     * 33-byte curve form).
+     * @param {import('libomemo.js').SignedPreKey} spk
+     */
+    storeSignedPreKeyV2(spk) {
+        if (typeof spk !== 'object') {
+            throw new Error('storeSignedPreKeyV2: expected an object');
+        }
+        this.save('signed_prekey_omemo2', {
             id: spk.keyId,
             privKey: u.arrayBufferToBase64(spk.keyPair.privKey),
             pubKey: u.arrayBufferToBase64(spk.keyPair.pubKey),
@@ -200,9 +222,7 @@ class OMEMOStore extends Model {
      * @param {string} [address='']
      */
     removeAllSessions(address = '') {
-        const keys = Object.keys(this.attributes).filter((key) =>
-            key.startsWith('session' + address) ? key : false,
-        );
+        const keys = Object.keys(this.attributes).filter((key) => (key.startsWith('session' + address) ? key : false));
         const attrs = {};
         keys.forEach((key) => {
             attrs[key] = undefined;
@@ -212,6 +232,13 @@ class OMEMOStore extends Model {
     }
 
     publishBundle() {
+        // The v2 bundle publish runs in the background: failing it (e.g. on a
+        // server that doesn't support omemo:2) must not block legacy OMEMO setup.
+        this.#publishV2Bundle().catch((e) => log.error(e));
+        return this.#publishLegacyBundle();
+    }
+
+    #publishLegacyBundle() {
         const signed_prekey = this.get('signed_prekey');
         const node = `${Strophe.NS.OMEMO_BUNDLES}:${this.get('device_id')}`;
         const item = stx`
@@ -225,6 +252,47 @@ class OMEMOStore extends Model {
                         (prekey, id) => stx`<preKeyPublic preKeyId="${id}">${prekey.pubKey}</preKeyPublic>`,
                     )}
                     </prekeys>
+                </bundle>
+            </item>`;
+        const options = { access_model: 'open' };
+        return api.pubsub.publish(null, node, item, options, false);
+    }
+
+    async #publishV2Bundle() {
+        const spk = this.get('signed_prekey_omemo2');
+        if (!spk) {
+            log.warn('No v2 signed prekey found, skipping v2 bundle publication');
+            return;
+        }
+        const { curvePubKeyToEd25519PubKey } = await getCrypto();
+        const identity_keypair = this.get('identity_keypair');
+        const device_id = this.get('device_id');
+        const node = `${Strophe.NS.OMEMO2_BUNDLES}:${device_id}`;
+
+        // Ed25519 IK from curve pubkey
+        const curve_ik = u.base64ToArrayBuffer(identity_keypair.pubKey);
+        const ed25519_ik = await curvePubKeyToEd25519PubKey(curve_ik);
+        const ed25519_ik_b64 = u.arrayBufferToBase64(ed25519_ik);
+
+        // Strip leading byte from SPK pubkey (33 → 32 bytes) for v2 wire format
+        const spk_pub_raw = u.base64ToArrayBuffer(spk.pubKey);
+        const spk_pub_b64 = u.arrayBufferToBase64(spk_pub_raw.slice(1));
+
+        // Prekeys with stripped leading byte
+        const prekeys_obj = this.get('prekeys');
+        const prekey_items = Object.entries(prekeys_obj).map(([key_id, pk]) => {
+            const raw = u.base64ToArrayBuffer(/** @type {{pubKey:string}} */ (pk).pubKey);
+            const stripped = u.arrayBufferToBase64(raw.slice(1));
+            return stx`<pk id="${key_id}">${stripped}</pk>`;
+        });
+
+        const item = stx`
+            <item>
+                <bundle xmlns="${Strophe.NS.OMEMO2}">
+                    <spk id="${spk.id}">${spk_pub_b64}</spk>
+                    <spks>${spk.signature}</spks>
+                    <ik>${ed25519_ik_b64}</ik>
+                    <prekeys>${prekey_items}</prekeys>
                 </bundle>
             </item>`;
         const options = { access_model: 'open' };
@@ -290,6 +358,9 @@ class OMEMOStore extends Model {
      * By generating a bundle, and publishing it via PubSub, we allow other
      * clients to download it and start asynchronous encrypted sessions with us,
      * even if we're offline at that time.
+     *
+     * Generates both legacy (0.3.0) and v2 (omemo:2) bundle material and
+     * publishes both PEP nodes.
      */
     async generateBundle() {
         const { KeyHelper } = await getCrypto();
@@ -314,8 +385,13 @@ class OMEMOStore extends Model {
             },
         });
 
-        const signed_prekey = await KeyHelper.generateSignedPreKey(identity_keypair, 0);
+        // Generate both legacy and v2 signed prekeys (signatures differ in key encoding).
+        const [signed_prekey, signed_prekey_v2] = await Promise.all([
+            KeyHelper.generateSignedPreKey(identity_keypair, 0, Strophe.NS.OMEMO),
+            KeyHelper.generateSignedPreKey(identity_keypair, 0, Strophe.NS.OMEMO2),
+        ]);
         this.storeSignedPreKey(signed_prekey);
+        this.storeSignedPreKeyV2(signed_prekey_v2);
 
         const prekeys = await this.generatePreKeys();
 
@@ -332,15 +408,47 @@ class OMEMOStore extends Model {
         device.save('bundle', bundle);
     }
 
+    /**
+     * Backfills omemo:2 key material for an already provisioned device.
+     *
+     * Stores created before omemo:2 support have a device_id, identity key and
+     * legacy signed prekey, but no `signed_prekey_omemo2`.
+     *
+     * This generates the missing v2 signed prekey, reusing the existing
+     * identity key so our fingerprint and device_id are unchanged. The v2 bundle
+     * itself is published by the regular {@link OMEMOStore#publishBundle} call in
+     * initOMEMO, which runs right after the session is restored.
+     */
+    async ensureV2SignedPreKey() {
+        if (this.get('signed_prekey_omemo2') || !this.get('identity_keypair')) {
+            return;
+        }
+        log.info('Migrating OMEMO store: generating the missing omemo:2 signed prekey');
+        const { KeyHelper } = await getCrypto();
+        const signed_prekey_v2 = await KeyHelper.generateSignedPreKey(this.getIdentityKeyPair(), 0, Strophe.NS.OMEMO2);
+        this.storeSignedPreKeyV2(signed_prekey_v2);
+    }
+
     fetchSession() {
-        if (this._setup_promise === undefined) {
-            this._setup_promise = new Promise((resolve, reject) => {
+        if (this.#setup_promise === undefined) {
+            this.#setup_promise = new Promise((resolve, reject) => {
                 this.fetch({
                     success: () => {
                         if (!this.get('device_id')) {
                             this.generateBundle().then(resolve).catch(reject);
                         } else {
-                            resolve();
+                            // Existing store: backfill omemo:2 key material for
+                            // stores created before omemo:2 support. A migration
+                            // failure must not break legacy OMEMO, so resolve
+                            // regardless (we simply remain legacy-only until the
+                            // next successful attempt).
+                            this.ensureV2SignedPreKey()
+                                .then(resolve)
+                                .catch((e) => {
+                                    log.error('Could not migrate OMEMO store to omemo:2');
+                                    log.error(e);
+                                    resolve();
+                                });
                         }
                     },
                     /**
@@ -354,7 +462,7 @@ class OMEMOStore extends Model {
                 });
             });
         }
-        return this._setup_promise;
+        return this.#setup_promise;
     }
 }
 

--- a/src/headless/plugins/omemo/types.ts
+++ b/src/headless/plugins/omemo/types.ts
@@ -1,11 +1,21 @@
 import { MUCMessageAttributes } from '../../plugins/muc/types';
-import { MessageAttributes, ModelAttributes } from '../../shared/types';
+import { JIDModelAttributes, MessageAttributes, ModelAttributes } from '../../shared/types';
 
 declare global {
     interface Window {
         libomemo?: Record<string, unknown>;
     }
 }
+
+export type OMEMOVersion = 'eu.siacs.conversations.axolotl' | 'urn:xmpp:omemo:2';
+
+export type OMEMOProfile = {
+    version: OMEMOVersion;
+    readonly devicelist_node: string;
+    readonly bundle_node_prefix: string;
+    usesSCE: boolean;
+    encodePubKey: (b64: string) => string;
+};
 
 export type CounterpartyPreKey = {
     id: number;
@@ -23,9 +33,8 @@ export type Bundle = {
     fingerprint?: string;
 };
 
-export type DeviceAttributes = ModelAttributes & {
+export type DeviceAttributes = JIDModelAttributes & {
     id: number;
-    jid: string;
     bundle?: Bundle;
     trusted: 0 | 1 | -1;
     active: boolean;

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -9,21 +9,55 @@ import MUC from '../../plugins/muc/muc.js';
 import { getCrypto } from './crypto.js';
 import { KEY_ALGO, TAG_LENGTH, UNTRUSTED } from './constants.js';
 import DeviceLists from './devicelists.js';
+import { VersionedOMEMOStore } from './versioned-store.js';
+import { encryptSCE, decryptSCE } from './sce.js';
 
 const { u, Strophe, stx } = converse.env;
 const { arrayBufferToHex, base64ToArrayBuffer } = u;
 
 /**
+ * Returns a VersionedOMEMOStore proxy for the given OMEMO version.
+ *
+ * The proxy implements the subset of libomemo's `OMEMOStore` interface that
+ * `SessionCipher` and `SessionBuilder` actually exercise at runtime (the
+ * crypto/session methods); the interface's raw key-value members
+ * (`store`/`put`/`get`/`remove`) are part of the reference `InMemoryStore` and
+ * are never called on a consumer store, so we present the proxy as an
+ * `OMEMOStore` here.
+ * @param {import('./types').OMEMOVersion} version
+ * @returns {import('libomemo.js').OMEMOStore}
+ */
+export function getVersionedStore(version) {
+    return /** @type {import('libomemo.js').OMEMOStore} */ (
+        /** @type {unknown} */ (new VersionedOMEMOStore(_converse.state.omemo_store, version))
+    );
+}
+
+/**
  * @param {Element} stanza
  */
 async function updateDevicesFromStanza(stanza) {
-    const items_el = sizzle(`items[node="${Strophe.NS.OMEMO_DEVICELIST}"]`, stanza).pop();
-    if (!items_el) return;
+    // Detect which version's devicelist was pushed
+    let items_el = sizzle(`items[node="${Strophe.NS.OMEMO_DEVICELIST}"]`, stanza).pop();
+    let version = Strophe.NS.OMEMO;
 
-    const device_selector = `item list[xmlns="${Strophe.NS.OMEMO}"] device`;
-    const device_ids = sizzle(device_selector, items_el).map((d) => d.getAttribute('id'));
+    if (!items_el) {
+        items_el = sizzle(`items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`, stanza).pop();
+        if (!items_el) return;
+        version = Strophe.NS.OMEMO2;
+    }
+
+    let device_ids;
+    if (version === Strophe.NS.OMEMO2) {
+        const sel = `item devices[xmlns="${Strophe.NS.OMEMO2_DEVICELIST}"] device`;
+        device_ids = sizzle(sel, items_el).map((d) => d.getAttribute('id'));
+    } else {
+        const sel = `item list[xmlns="${Strophe.NS.OMEMO}"] device`;
+        device_ids = sizzle(sel, items_el).map((d) => d.getAttribute('id'));
+    }
+
     const jid = stanza.getAttribute('from');
-    const devicelist = await api.omemo.devicelists.get(jid, true);
+    const devicelist = await api.omemo.devicelists.get(jid, true, version);
     const devices = devicelist.devices;
     const removed_ids = devices.pluck('id').filter(/** @param {string} id */ (id) => !device_ids.includes(id));
 
@@ -59,16 +93,33 @@ async function updateDevicesFromStanza(stanza) {
  */
 async function updateBundleFromStanza(stanza) {
     const items_el = sizzle(`items`, stanza).pop();
-    if (!items_el || !items_el.getAttribute('node').startsWith(Strophe.NS.OMEMO_BUNDLES)) {
+    if (!items_el) return;
+
+    const node = items_el.getAttribute('node');
+    let version, device_id;
+
+    if (node.startsWith(Strophe.NS.OMEMO2_BUNDLES + ':')) {
+        version = Strophe.NS.OMEMO2;
+        device_id = node.slice(Strophe.NS.OMEMO2_BUNDLES.length + 1);
+    } else if (node.startsWith(Strophe.NS.OMEMO_BUNDLES + ':')) {
+        version = Strophe.NS.OMEMO;
+        device_id = node.slice(Strophe.NS.OMEMO_BUNDLES.length + 1);
+    } else {
         return;
     }
-    const device_id = items_el.getAttribute('node').split(':')[1];
+
     const jid = stanza.getAttribute('from');
     const bundle_el = sizzle(`item > bundle`, items_el).pop();
-    const devicelist = await api.omemo.devicelists.get(jid, true);
+    const devicelist = await api.omemo.devicelists.get(jid, true, version);
     const device = devicelist.devices.get(device_id) || devicelist.devices.create({ 'id': device_id, jid });
-    const bundle = u.omemo.parseBundle(bundle_el);
-    device.save({ bundle });
+
+    if (version === Strophe.NS.OMEMO2) {
+        const bundle = u.omemo.parseBundleV2(bundle_el);
+        device.save({ bundle });
+    } else {
+        const bundle = u.omemo.parseBundle(bundle_el);
+        device.save({ bundle });
+    }
 }
 
 /**
@@ -110,20 +161,36 @@ async function fetchDeviceLists() {
     await new Promise((resolve) => {
         _converse.state.devicelists.fetch({
             success: resolve,
-            /**
-             * @param {unknown} _m
-             * @param {unknown} e
-             */
             error: (_m, e) => {
                 log.error(e);
                 resolve();
             },
         });
     });
-    // Call API method to wait for our own device list to be fetched from the
-    // server or to be created. If we have no pre-existing OMEMO session, this
-    // will cause a new device and bundle to be generated and published.
+
+    _converse.state.devicelists_v2 = new DeviceLists();
+    const id_v2 = `converse.devicelists-v2-${bare_jid}`;
+    initStorage(_converse.state.devicelists_v2, id_v2);
+    await new Promise((resolve) => {
+        _converse.state.devicelists_v2.fetch({
+            success: resolve,
+            error: (_m, e) => {
+                log.error(e);
+                resolve();
+            },
+        });
+    });
+
+    // Ensure our own legacy device list exists (creates + publishes if needed).
+    // This is awaited (unlike the v2 fetch below) because OMEMO initialization
+    // depends on it: by the time `session.restore` runs and `OMEMOInitialized`
+    // fires, our own device must already be present in (and published to) the
+    // legacy device list, otherwise consumers race against `publishCurrentDevice`.
     await api.omemo.devicelists.get(bare_jid, true);
+    // Start v2 device list initialization without blocking legacy OMEMO setup.
+    // The v2 PEP fetch can take time and failing it (e.g. on servers that don't
+    // support omemo:2) must not prevent the legacy path from working.
+    api.omemo.devicelists.get(bare_jid, true, Strophe.NS.OMEMO2).catch((e) => log.error(e));
 }
 
 /**
@@ -156,12 +223,14 @@ export async function initOMEMO(reconnecting) {
 
 /**
  * @param {String} jid - The Jabber ID for which the device list will be returned.
- * @param {boolean} [create=false] - Set to `true` if the device list
- *      should be created if it cannot be found.
+ * @param {boolean} [create=false] - Set to `true` if the device list should be
+ *      created if it cannot be found.
+ * @param {import('./types').OMEMOVersion} [version] - Defaults to legacy version.
  */
-export async function getDeviceList(jid, create = false) {
-    const { devicelists } = _converse.state;
-    const list = devicelists.get(jid) || (create ? devicelists.create({ jid }) : null);
+export async function getDeviceList(jid, create = false, version = Strophe.NS.OMEMO) {
+    const collection = version === Strophe.NS.OMEMO2 ? _converse.state.devicelists_v2 : _converse.state.devicelists;
+
+    const list = collection.get(jid) || (create ? collection.create({ jid, version }) : null);
     await list?.initialized;
     return list;
 }
@@ -174,7 +243,12 @@ export async function generateFingerprint(device) {
         return;
     }
     const bundle = await device.getBundle();
-    bundle['fingerprint'] = arrayBufferToHex(base64ToArrayBuffer(bundle['identity_key']));
+    const raw = base64ToArrayBuffer(bundle['identity_key']);
+    // For legacy (33-byte Curve25519), strip the leading 0x05 encoding byte
+    // so the display fingerprint is always the 64-char (32-byte) key hex.
+    // For v2 (32-byte Ed25519), the key has no leading byte.
+    const fp_buf = device.isV2 && device.isV2() ? raw : raw.slice(1);
+    bundle['fingerprint'] = arrayBufferToHex(fp_buf);
     device.save('bundle', bundle);
     device.trigger('change:bundle'); // Doesn't get triggered automatically due to pass-by-reference
 }
@@ -216,53 +290,61 @@ export function handleMessageSendError(e, chat) {
 }
 
 /**
+ * Returns the device collection for a contact and OMEMO version.
+ * Doesn't throw on any failure, instead logs and returns an empty collection.
  * @param {string} jid
+ * @param {import('./types').OMEMOVersion} [version]
  * @returns {Promise<import('./devices.js').default>}
  */
-export async function getDevicesForContact(jid) {
+export async function getDevicesForContact(jid, version = Strophe.NS.OMEMO) {
     await api.waitUntil('OMEMOInitialized');
-    const devicelist = await api.omemo.devicelists.get(jid, true);
-    await devicelist.fetchDevices();
-    if (devicelist.devices.length === 0) {
-        // We don't have any devices for this contact. This can happen when an
-        // earlier fetch failed (e.g. due to a connectivity issue) or because
-        // the contact had not yet published their device list when we last
-        // checked. The result of `fetchDevices` is memoized, so without an
-        // explicit refresh we'd never query the server again for the lifetime
-        // of this device list. Force a re-fetch so we can recover.
-        await devicelist.fetchDevices(true);
+    try {
+        const devicelist = await api.omemo.devicelists.get(jid, true, version);
+        await devicelist.fetchDevices();
+        // Only force a re-fetch when the previous attempt actually failed (timeout or error).
+        if (devicelist.devices.length === 0 && devicelist.lastFetchFailed) {
+            await devicelist.fetchDevices(true);
+        }
+        return devicelist.devices;
+    } catch (e) {
+        log.error(e);
+        return new _converse.exports.Devices(null, { version });
     }
-    return devicelist.devices;
 }
 
 /**
  * @param {string} jid
  * @param {number} id
+ * @param {import('./types').OMEMOVersion} [version]
  * @returns {Promise<import('libomemo.js').SessionCipher>}
  */
-export async function getSessionCipher(jid, id) {
+export async function getSessionCipher(jid, id, version = Strophe.NS.OMEMO) {
     const { OMEMOAddress, SessionCipher } = await getCrypto();
     const address = new OMEMOAddress(jid, id);
-    return new SessionCipher(_converse.state.omemo_store, address);
+    const store = getVersionedStore(version);
+    return new SessionCipher(store, address, version);
 }
 
 /**
  * @param {ArrayBuffer} key_and_tag
  * @param {import('./device').default} device
+ * @param {import('./types').OMEMOVersion} [version]
  */
-async function encryptKey(key_and_tag, device) {
-    const session_cipher = await getSessionCipher(device.get('jid'), Number(device.get('id')));
+async function encryptKey(key_and_tag, device, version = Strophe.NS.OMEMO) {
+    const session_cipher = await getSessionCipher(device.get('jid'), Number(device.get('id')), version);
     const payload = await session_cipher.encrypt(key_and_tag);
     return { payload, device };
 }
 
 /**
  * @param {import('./device').default} device
+ * @param {import('./types').OMEMOVersion} [version]
  */
-async function buildSession(device) {
+async function buildSession(device, version = Strophe.NS.OMEMO) {
     const { OMEMOAddress, SessionBuilder } = await getCrypto();
     const address = new OMEMOAddress(device.get('jid'), device.get('id'));
-    const sessionBuilder = new SessionBuilder(_converse.state.omemo_store, address);
+    const store = getVersionedStore(version);
+    const sessionBuilder = new SessionBuilder(store, address, version);
     const prekey = device.getRandomPreKey();
     const bundle = await device.getBundle();
     const device_id = device.get('id');
@@ -284,20 +366,22 @@ async function buildSession(device) {
 
 /**
  * @param {import('./device').default} device
+ * @param {import('./types').OMEMOVersion} [version]
  */
-export async function getSession(device) {
+export async function getSession(device, version = Strophe.NS.OMEMO) {
     if (!device.get('bundle')) {
         log.error(`Could not build an OMEMO session for device ${device.get('id')} because we don't have its bundle`);
         return null;
     }
     const { OMEMOAddress } = await getCrypto();
     const address = new OMEMOAddress(device.get('jid'), device.get('id'));
-    const session = await _converse.state.omemo_store.loadSession(address.toString());
+    const store = getVersionedStore(version);
+    const session = await store.loadSession(address.toString());
     if (session) {
         return session;
     } else {
         try {
-            return await buildSession(device);
+            return await buildSession(device, version);
         } catch (e) {
             log.error(`Could not build an OMEMO session for device ${device.get('id')}`);
             log.error(e);
@@ -307,57 +391,155 @@ export async function getSession(device) {
 }
 
 /**
+ * OMEMO in a MUC requires that real JIDs are visible (non-anonymous) and that
+ * the membership is restricted (members-only). This is the single source of
+ * truth for that rule.
+ * @param {MUC} chatroom
+ */
+function isOMEMOMUCEligible(chatroom) {
+    return !!(chatroom.features.get('nonanonymous') && chatroom.features.get('membersonly'));
+}
+
+/**
+ * A bundle-fetch error is "actionable" when it tells the user something they
+ * can fix and applies to the whole contact/server rather than a single stale
+ * device: presence-subscription-required or remote-server-not-found. These must
+ * abort the send and be surfaced; any other (benign) per-device failure is
+ * dropped silently so it only loses that one device.
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+function isActionableBundleError(e) {
+    return (
+        e instanceof errors.IQError &&
+        sizzle(
+            `presence-subscription-required[xmlns="${Strophe.NS.PUBSUB_ERROR}"], ` +
+                `remote-server-not-found[xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"]`,
+            e.iq,
+        ).length > 0
+    );
+}
+
+/**
+ * Collects the set of recipient devices for a given chatbox, split by OMEMO
+ * version.  Deduplicates across versions (by device id) so each physical
+ * device is addressed exactly once. V2 is preferred when both versions are present.
  * @param {import('../../shared/chatbox.js').default} chatbox
- * @returns {Promise<import('./device.js').default[]>}
+ * @returns {Promise<{legacy: import('./device.js').default[], v2: import('./device.js').default[]}>}
  */
 async function getBundlesAndBuildSessions(chatbox) {
-    /**
-     * @typedef {import('./device.js').default} Device
-     */
     const { __ } = _converse;
     const no_devices_err = __('Sorry, no devices found to which we can send an OMEMO encrypted message.');
-    let devices;
+
+    let legacy_devices = [];
+    let v2_devices = [];
+
     if (chatbox instanceof MUC) {
-        const collections = await Promise.all(
-            chatbox.occupants.map(
-                /** @param {import('../../plugins/muc/occupant').default} o */
-                (o) => getDevicesForContact(o.get('jid')),
-            ),
+        // Defense-in-depth: OMEMO activation is already gated on this upstream
+        // (checkOMEMOSupported), but a room can flip to anonymous mid-session.
+        if (!isOMEMOMUCEligible(chatbox)) {
+            throw new errors.UserFacingError(
+                __('Cannot use OMEMO in this groupchat — it must be non-anonymous and members-only.'),
+            );
+        }
+        // Our own devices are included here via the self-occupant (it carries
+        // our real JID in a non-anonymous room); the our_id filter below then
+        // drops the sending device, exactly as the 1:1 branch does.
+        const occupants = chatbox.occupants.filter(
+            /** @param {import('../../plugins/muc/occupant').default} o */
+            (o) => o.get('jid'),
         );
-        devices = collections.reduce((a, b) => a.concat(b.models), []);
+        const [legacy_cols, v2_cols] = await Promise.all([
+            Promise.all(occupants.map((o) => getDevicesForContact(o.get('jid'), Strophe.NS.OMEMO))),
+            Promise.all(occupants.map((o) => getDevicesForContact(o.get('jid'), Strophe.NS.OMEMO2))),
+        ]);
+        legacy_devices = legacy_cols.flatMap((c) => c.models);
+        v2_devices = v2_cols.flatMap((c) => c.models);
     } else if (chatbox.get('type') === constants.PRIVATE_CHAT_TYPE) {
-        const their_devices = await getDevicesForContact(chatbox.get('jid'));
-        if (their_devices.length === 0) {
-            throw new errors.UserFacingError(no_devices_err);
-        }
+        const contact_jid = chatbox.get('jid');
         const bare_jid = _converse.session.get('bare_jid');
-        const own_list = await api.omemo.devicelists.get(bare_jid);
-        const own_devices = own_list.devices;
-        devices = [...own_devices.models, ...their_devices.models];
-    }
-    // Filter out our own device
-    const id = _converse.state.omemo_store.get('device_id');
-    devices = devices.filter(/** @param {Device} d */ (d) => d.get('id') !== id);
 
-    // Fetch bundles if necessary
-    await Promise.all(devices.map(/** @param {Device} d */ (d) => d.getBundle()));
+        // Fetch the contact's devices for both versions in parallel (same
+        // server, different PEP node), so v2 activates deterministically rather
+        // than only when the contact's v2 devicelist happens to already be
+        // cached (e.g. from a PEP push). An empty v2 list just means the contact
+        // doesn't support omemo:2, in which case we fall back to legacy.
+        const [their_legacy, their_v2] = await Promise.all([
+            getDevicesForContact(contact_jid, Strophe.NS.OMEMO),
+            getDevicesForContact(contact_jid, Strophe.NS.OMEMO2),
+        ]);
 
-    const sessions = await Promise.all(
-        devices.map(
-            /** @param {Device} [d] */ (d) => {
-                return (d && getSession(d)) || null;
-            },
-        ),
-    );
+        // Our own device lists are populated at init, so a cached lookup suffices.
+        const [own_legacy_list, own_v2_list] = await Promise.all([
+            api.omemo.devicelists.get(bare_jid, false, Strophe.NS.OMEMO),
+            api.omemo.devicelists.get(bare_jid, false, Strophe.NS.OMEMO2),
+        ]);
 
-    if (sessions.includes(null)) {
-        // We couldn't build a session for certain devices.
-        devices = devices.filter(/** @param {Device} d */ (d) => sessions[devices.indexOf(d)]);
-        if (devices.length === 0) {
+        if (their_legacy.length === 0 && their_v2.length === 0) {
             throw new errors.UserFacingError(no_devices_err);
         }
+
+        legacy_devices = [...(own_legacy_list?.devices.models ?? []), ...their_legacy.models];
+        v2_devices = [...(own_v2_list?.devices.models ?? []), ...their_v2.models];
     }
-    return devices;
+
+    // A device's identity for routing is the (bare JID, id) pair: device ids are
+    // unique only per user, so the JID is needed to disambiguate.
+    /** @param {string} jid @param {string} id */
+    const deviceKey = (jid, id) => `${Strophe.getBareJidFromJid(jid).toLowerCase()}/${id}`;
+
+    // Exclude our own sending device (we encrypt to our other devices, never the
+    // one composing the message).
+    const our_id = _converse.state.omemo_store.get('device_id');
+    const our_key = deviceKey(_converse.session.get('bare_jid'), our_id);
+    legacy_devices = legacy_devices.filter((d) => deviceKey(d.get('jid'), d.get('id')) !== our_key);
+    v2_devices = v2_devices.filter((d) => deviceKey(d.get('jid'), d.get('id')) !== our_key);
+
+    // Deduplicate across versions: a device that supports both is addressed via
+    // omemo:2 only (preferred), so we drop it from the legacy list here and never
+    // fetch its legacy bundle.
+    const v2_keys = new Set(v2_devices.map((d) => deviceKey(d.get('jid'), d.get('id'))));
+    legacy_devices = legacy_devices.filter((d) => !v2_keys.has(deviceKey(d.get('jid'), d.get('id'))));
+
+    // Fetch bundles for the remaining devices. A benign single-device failure
+    // (e.g. a stale/orphaned device with no published bundle) must only drop
+    // that one device, not abort the whole send — so fetchBundle swallows it and
+    // returns null. A genuinely actionable, contact-wide error
+    // (presence-subscription-required, remote-server-not-found) is rethrown
+    // instead: it aborts the send and propagates to the user, even when our own
+    // other devices are still reachable (encrypting only to ourselves would
+    // silently leave the intended recipient unable to read the message).
+    const fetchBundle = async (d) => {
+        try {
+            await d.getBundle();
+            return d;
+        } catch (e) {
+            if (isActionableBundleError(e)) throw e;
+            log.error(`Skipping device ${d.get('id')} of ${d.get('jid')}: could not fetch its OMEMO bundle`);
+            log.error(e);
+            return null;
+        }
+    };
+    const [legacy_fetched, v2_fetched] = await Promise.all([
+        Promise.all(legacy_devices.map(fetchBundle)),
+        Promise.all(v2_devices.map(fetchBundle)),
+    ]);
+    legacy_devices = legacy_devices.filter((_d, i) => legacy_fetched[i] !== null);
+    v2_devices = v2_devices.filter((_d, i) => v2_fetched[i] !== null);
+
+    // Build sessions, dropping devices where session establishment fails.
+    const [legacy_sessions, v2_sessions] = await Promise.all([
+        Promise.all(legacy_devices.map((d) => getSession(d, Strophe.NS.OMEMO))),
+        Promise.all(v2_devices.map((d) => getSession(d, Strophe.NS.OMEMO2))),
+    ]);
+    legacy_devices = legacy_devices.filter((_d, i) => legacy_sessions[i] !== null);
+    v2_devices = v2_devices.filter((_d, i) => v2_sessions[i] !== null);
+
+    if (legacy_devices.length === 0 && v2_devices.length === 0) {
+        // Nothing reachable and no actionable server error to explain why.
+        throw new errors.UserFacingError(no_devices_err);
+    }
+    return { legacy: legacy_devices, v2: v2_devices };
 }
 
 /**
@@ -412,20 +594,26 @@ export async function decryptMessage(obj) {
 }
 
 /**
- * @param {import('../../shared/chatbox').default} chat
- * @param {import('../../shared/types').MessageAndStanza} data
- * @return {Promise<import('../../shared/types').MessageAndStanza>}
+ * Groups an array of {payload, device} dicts by the device's bare JID.
+ * Used to produce <keys jid="..."> groupings in the v2 <encrypted> element.
+ * @param {Array<{payload: import('libomemo.js').EncryptResult, device: import('./device.js').default}>} dicts
+ * @returns {Map<string, Array<{payload: import('libomemo.js').EncryptResult, device: import('./device.js').default}>>}
  */
-export async function createOMEMOMessageStanza(chat, data) {
-    const { stanza } = data;
-    const { message } = data;
-    if (!message.get('is_encrypted')) {
-        return data;
+function groupByJID(dicts) {
+    const map = new Map();
+    for (const entry of dicts) {
+        const jid = entry.device.get('jid');
+        if (!map.has(jid)) map.set(jid, []);
+        map.get(jid).push(entry);
     }
-    if (!message.get('body')) {
-        throw new Error('No message body to encrypt!');
-    }
-    const devices = await getBundlesAndBuildSessions(chat);
+    return map;
+}
+
+/**
+ * @param {import('../../shared/message').default} message
+ * @param {import('./device').default[]} devices
+ */
+async function getLegacyEncryptedElement(message, devices) {
     const { key_and_tag, iv, payload } = await encryptMessage(message.get('plaintext'));
 
     // The 16 bytes key and the GCM authentication tag (The tag
@@ -433,12 +621,14 @@ export async function createOMEMOMessageStanza(chat, data) {
     // intended recipient device, i.e. both own devices as well as
     // devices associated with the contact, the result of this
     // concatenation is encrypted using the corresponding
-    // long-standing SignalProtocol session.
-    const dicts = await Promise.all(
+    // long-standing OMEMO session.
+    const legacy_dicts = await Promise.all(
         devices
-            .filter((device) => device.get('trusted') != UNTRUSTED && device.get('active'))
-            .map((device) => encryptKey(key_and_tag, device)),
+            .filter((d) => d.get('trusted') != UNTRUSTED && d.get('active'))
+            .map((d) => encryptKey(key_and_tag, d, Strophe.NS.OMEMO)),
     );
+
+    const sid = _converse.state.omemo_store.get('device_id');
 
     // An encrypted header is added to the message for
     // each device that is supposed to receive it.
@@ -446,27 +636,93 @@ export async function createOMEMOMessageStanza(chat, data) {
     // payload message is encrypted with,
     // and they are separately encrypted using the
     // session corresponding to the counterpart device.
-    stanza
-        .cnode(
-            stx`
-            <encrypted xmlns="${Strophe.NS.OMEMO}">
-                <header sid="${_converse.state.omemo_store.get('device_id')}">
-                    ${dicts.map(({ payload, device }) => {
-                        const prekey = 3 == payload.type;
-                        if (prekey) {
-                            return stx`<key rid="${device.get('id')}" prekey="true">${btoa(payload.body)}</key>`;
-                        }
-                        return stx`<key rid="${device.get('id')}">${btoa(payload.body)}</key>`;
-                    })}
-                    <iv>${iv}</iv>
-                </header>
-                <payload>${payload}</payload>
-            </encrypted>`,
-        )
-        .root();
+    return stx`<encrypted xmlns="${Strophe.NS.OMEMO}">
+            <header sid="${sid}">
+                ${legacy_dicts.map(({ payload: p, device }) => {
+                    const prekey = 3 == p.type;
+                    if (prekey) {
+                        return stx`<key rid="${device.get('id')}" prekey="true">${btoa(p.body)}</key>`;
+                    }
+                    return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
+                })}
+                <iv>${iv}</iv>
+            </header>
+            <payload>${payload}</payload>
+        </encrypted>`;
+}
+
+/**
+ * @param {import('../../shared/chatbox').default} chat
+ * @param {import('../../shared/message').default} message
+ * @param {import('./device').default[]} devices
+ */
+async function getOMEMO2EncryptedElement(chat, message, devices) {
+    const is_muc = chat instanceof MUC;
+    const muc_jid = is_muc ? chat.get('jid') : null;
+    const bare_jid = _converse.session.get('bare_jid');
+
+    // Build SCE envelope and encrypt it
+    const { key_and_tag, payload } = await encryptSCE(message.get('plaintext'), {
+        from_jid: bare_jid,
+        to_jid: muc_jid,
+    });
+
+    const v2_dicts = await Promise.all(
+        devices
+            .filter((d) => d.get('trusted') != UNTRUSTED && d.get('active'))
+            .map((d) => encryptKey(key_and_tag, d, Strophe.NS.OMEMO2)),
+    );
+
+    // Group keys by recipient JID for the v2 <keys jid='...'> structure
+    const by_jid = groupByJID(v2_dicts);
+    const keys_elements = [];
+    for (const [jid, entries] of by_jid) {
+        const key_els = entries.map(({ payload: p, device }) => {
+            if (p.kex) {
+                return stx`<key rid="${device.get('id')}" kex="true">${btoa(p.body)}</key>`;
+            }
+            return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
+        });
+        keys_elements.push(stx`<keys jid="${jid}">${key_els}</keys>`);
+    }
+
+    const sid = _converse.state.omemo_store.get('device_id');
+
+    return stx`<encrypted xmlns="${Strophe.NS.OMEMO2}">
+            <header sid="${sid}">${keys_elements}</header>
+            <payload>${payload}</payload>
+        </encrypted>`;
+}
+
+/**
+ * @param {import('../../shared/chatbox').default} chat
+ * @param {import('../../shared/types').MessageAndStanza} data
+ * @return {Promise<import('../../shared/types').MessageAndStanza>}
+ */
+export async function createOMEMOMessageStanza(chat, data) {
+    const { stanza } = data;
+    const { message } = data;
+
+    if (!message.get('is_encrypted')) return data;
+    if (!message.get('body')) throw new Error('No message body to encrypt!');
+
+    const { legacy, v2 } = await getBundlesAndBuildSessions(chat);
+
+    if (legacy.length > 0) {
+        stanza.cnode(await getLegacyEncryptedElement(message, legacy)).root();
+    }
+
+    if (v2.length > 0) {
+        stanza.cnode(await getOMEMO2EncryptedElement(chat, message, v2)).root();
+    }
 
     stanza.cnode(stx`<store xmlns="${Strophe.NS.HINTS}"/>`).root();
-    stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>`).root();
+
+    if (v2.length > 0) {
+        stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>`).root();
+    } else if (legacy.length > 0) {
+        stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>`).root();
+    }
     return { message, stanza };
 }
 
@@ -483,7 +739,7 @@ export function getOutgoingMessageAttributes(chat, attrs) {
             is_encrypted: true,
             plaintext: attrs.body,
             body: __(
-                'This is an OMEMO encrypted message which your client doesn\u2019t seem to support. ' +
+                'This is an OMEMO encrypted message which your client doesn’t seem to support. ' +
                     'Find more information on https://conversations.im/omemo',
             ),
         };
@@ -507,8 +763,7 @@ async function checkOMEMOSupported(chatbox) {
     let supported;
     if (chatbox.get('type') === constants.CHATROOMS_TYPE) {
         await api.waitUntil('OMEMOInitialized');
-        const { features } = /** @type {MUC} */ (chatbox);
-        supported = features.get('nonanonymous') && features.get('membersonly');
+        supported = isOMEMOMUCEligible(/** @type {MUC} */ (chatbox));
     } else if (chatbox.get('type') === constants.PRIVATE_CHAT_TYPE) {
         supported = await contactHasOMEMOSupport(chatbox.get('jid'));
     }
@@ -523,7 +778,7 @@ async function checkOMEMOSupported(chatbox) {
  * @param {import('../../plugins/muc/occupant').default} occupant
  */
 async function onOccupantAdded(chatroom, occupant) {
-    if (occupant.isSelf() || !chatroom.features.get('nonanonymous') || !chatroom.features.get('membersonly')) {
+    if (occupant.isSelf() || !isOMEMOMUCEligible(chatroom)) {
         return;
     }
     const { __ } = _converse;
@@ -596,8 +851,11 @@ Object.assign(u, {
     omemo: {
         ...u.omemo,
         decryptMessage,
+        decryptSCE,
         encryptMessage,
+        encryptSCE,
         generateFingerprint,
         getDevicesForContact,
+        getVersionedStore,
     },
 });

--- a/src/headless/plugins/omemo/versioned-store.js
+++ b/src/headless/plugins/omemo/versioned-store.js
@@ -1,0 +1,134 @@
+import converse from '../../shared/api/public.js';
+
+const { u, Strophe } = converse.env;
+
+/**
+ * The session/identity-key storage prefix for a given OMEMO version. Legacy is
+ * unprefixed (`''`) so sessions persisted by older Converse versions keep
+ * working without migration; v2 carries a `v2:` prefix.
+ * @param {import('./types').OMEMOVersion} version
+ */
+function prefixForVersion(version) {
+    return version === Strophe.NS.OMEMO2 ? 'v2:' : '';
+}
+
+/**
+ * A thin proxy around OMEMOStore that namespaces session and identity-key
+ * storage by OMEMO version.  Legacy sessions use unprefixed keys (no
+ * migration needed); v2 sessions use a `v2:` prefix so the two protocol
+ * versions never collide inside the same underlying model.
+ *
+ * Prekeys and the identity keypair are shared across both versions — only
+ * the signed prekey and the session/trust data are version-specific.
+ */
+export class VersionedOMEMOStore {
+    /** @type {import('./store.js').default} */
+    #base;
+    /** @type {import('./types').OMEMOVersion} */
+    #version;
+    /** @type {string} */
+    #prefix;
+
+    /**
+     * @param {import('./store.js').default} base_store
+     * @param {import('./types').OMEMOVersion} version
+     */
+    constructor(base_store, version) {
+        this.#base = base_store;
+        this.#version = version;
+        this.#prefix = prefixForVersion(version);
+    }
+
+    getIdentityKeyPair() {
+        return this.#base.getIdentityKeyPair();
+    }
+    getLocalRegistrationId() {
+        return this.#base.getLocalRegistrationId();
+    }
+
+    /** @param {string} address @param {ArrayBuffer} identity_key @param {unknown} direction */
+    isTrustedIdentity(address, identity_key, direction) {
+        return this.#base.isTrustedIdentity(this.#prefix + address, identity_key, direction);
+    }
+
+    /** @param {string} address @param {ArrayBuffer} identity_key */
+    saveIdentity(address, identity_key) {
+        return this.#base.saveIdentity(this.#prefix + address, identity_key);
+    }
+
+    /** @param {string|number} key_id */
+    loadPreKey(key_id) {
+        return this.#base.loadPreKey(key_id);
+    }
+
+    getPreKeys() {
+        return this.#base.getPreKeys();
+    }
+
+    /** @param {number} key_id @param {import('libomemo.js').KeyPair} key_pair */
+    storePreKey(key_id, key_pair) {
+        return this.#base.storePreKey(key_id, key_pair);
+    }
+
+    /** @param {string|number} key_id */
+    removePreKey(key_id) {
+        return this.#base.removePreKey(key_id);
+    }
+
+    /** @param {string|number} _key_id */
+    loadSignedPreKey(_key_id) {
+        const attr = this.#version === Strophe.NS.OMEMO2 ? 'signed_prekey_omemo2' : 'signed_prekey';
+        const res = this.#base.get(attr);
+        if (res) {
+            return {
+                keyPair: {
+                    privKey: u.base64ToArrayBuffer(res.privKey),
+                    pubKey: u.base64ToArrayBuffer(res.pubKey),
+                },
+            };
+        }
+    }
+
+    /** @param {number} key_id */
+    removeSignedPreKey(key_id) {
+        return this.#base.removeSignedPreKey(key_id);
+    }
+
+    /** @param {string} address */
+    loadSession(address) {
+        return this.#base.loadSession(this.#prefix + address);
+    }
+
+    /** @param {string} address @param {string} record */
+    storeSession(address, record) {
+        return this.#base.storeSession(this.#prefix + address, record);
+    }
+
+    /** @param {string} address */
+    removeSession(address) {
+        return this.#base.removeSession(this.#prefix + address);
+    }
+
+    /** @param {string} [address=''] */
+    removeAllSessions(address = '') {
+        // We can't delegate to the base store's removeAllSessions: legacy keys
+        // are unprefixed (for backward compat), which makes the legacy prefix
+        // ('') a string-prefix of every versioned key (e.g. `sessionv2:…`), so a
+        // legacy wipe there would also clear v2 sessions. Instead we scope the
+        // wipe to this version's keys here, where we know our prefix, and
+        // exclude the other versions' prefixes that ours would falsely match.
+        const match = 'session' + this.#prefix + address;
+
+        // Only non-empty version prefixes can be falsely matched by ours; the
+        // legacy prefix ('') is shorter than every key, so it never needs
+        // excluding. So a legacy wipe excludes 'v2:', and a 'v2:' wipe excludes
+        // nothing (no other prefix starts with it).
+        const exclude = [prefixForVersion(Strophe.NS.OMEMO2)]
+            .filter((p) => p !== this.#prefix && p.startsWith(this.#prefix))
+            .map((p) => 'session' + p);
+        Object.keys(this.#base.attributes)
+            .filter((key) => key.startsWith(match) && !exclude.some((e) => key.startsWith(e)))
+            .forEach((key) => this.#base.removeSession(key.replace(/^session/, '')));
+        return Promise.resolve();
+    }
+}

--- a/src/headless/plugins/status/api.js
+++ b/src/headless/plugins/status/api.js
@@ -110,7 +110,7 @@ export default {
          * @param {import('./types').IdleStatus} status
          */
         set(status) {
-            if (status.idle) {
+            if (typeof status.idle === 'boolean') {
                 idle = status.idle;
             }
             if (typeof status.seconds === 'number') {

--- a/src/headless/plugins/status/profile.js
+++ b/src/headless/plugins/status/profile.js
@@ -52,7 +52,11 @@ export default class Profile extends ModelWithVCard(ColorAwareModel(Model)) {
     initialize() {
         super.initialize();
         this.on('change', (item) => {
-            if (item.changed?.status || item.changed?.status_message || item.changed?.show) {
+            // Use `hasChanged` (membership) rather than truthiness of the new value:
+            // clearing `show` (e.g. auto-away reset on user activity, or going back to
+            // 'online') sets it to undefined, which a `item.changed?.show` check would
+            // miss — leaving contacts seeing the stale away/xa presence.
+            if (item.hasChanged('status') || item.hasChanged('status_message') || item.hasChanged('show')) {
                 api.user.presence.send({
                     show: this.get('show'),
                     status: this.get('status_message'),

--- a/src/headless/shared/parsers.js
+++ b/src/headless/shared/parsers.js
@@ -135,6 +135,9 @@ export function getEncryptionAttributes (stanza) {
     if (namespace) {
         attrs.is_encrypted = true;
         attrs.encryption_namespace = namespace;
+    } else if (sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, stanza).pop()) {
+        attrs.is_encrypted = true;
+        attrs.encryption_namespace = Strophe.NS.OMEMO2;
     } else if (sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, stanza).pop()) {
         attrs.is_encrypted = true;
         attrs.encryption_namespace = Strophe.NS.OMEMO;

--- a/src/headless/shared/types.ts
+++ b/src/headless/shared/types.ts
@@ -14,6 +14,10 @@ export type ReplaceableOpenPromise = ReturnType<typeof getOpenPromise> & {
 
 export type ModelAttributes = Record<string, any>;
 
+export type JIDModelAttributes = ModelAttributes & {
+    jid: string;
+};
+
 export interface ModelOptions {
     collection?: Collection;
     parse?: boolean;

--- a/src/headless/types/plugins/omemo/api.d.ts
+++ b/src/headless/types/plugins/omemo/api.d.ts
@@ -13,10 +13,12 @@ declare namespace _default {
              * The device list will be created if it doesn't exist already.
              * @method _converse.api.omemo.devicelists.get
              * @param {String} jid - The Jabber ID for which the device list will be returned.
-             * @param {boolean} create=false - Set to `true` if the device list
+             * @param {boolean} [create=false] - Set to `true` if the device list
              *      should be created if it cannot be found.
+             * @param {import('./types').OMEMOVersion} [version] - The OMEMO version.
+             *      Defaults to the legacy version.
              */
-            function get(jid: string, create?: boolean): Promise<any>;
+            function get(jid: string, create?: boolean, version?: import("./types").OMEMOVersion): Promise<any>;
         }
         namespace bundle {
             /**

--- a/src/headless/types/plugins/omemo/device.d.ts
+++ b/src/headless/types/plugins/omemo/device.d.ts
@@ -1,8 +1,8 @@
 export default Device;
 /**
- * @extends {Model<import('./types').DeviceAttributes>}
+ * @extends {OMEMOVersionAwareModel<import('./types').DeviceAttributes>}
  */
-declare class Device extends Model<import("./types").DeviceAttributes> {
+declare class Device extends OMEMOVersionAwareModel<import("./types").DeviceAttributes> {
     constructor(attributes?: Partial<import("./types").DeviceAttributes>, options?: import("@converse/skeletor").ModelOptions);
     defaults(): {
         trusted: 0;
@@ -27,5 +27,5 @@ declare class Device extends Model<import("./types").DeviceAttributes> {
      */
     getBundle(): Promise<import("./types").Bundle>;
 }
-import { Model } from '@converse/skeletor';
+import { OMEMOVersionAwareModel } from './profiles.js';
 //# sourceMappingURL=device.d.ts.map

--- a/src/headless/types/plugins/omemo/devicelist.d.ts
+++ b/src/headless/types/plugins/omemo/devicelist.d.ts
@@ -1,6 +1,9 @@
 export default DeviceList;
-declare class DeviceList extends Model<import("@converse/skeletor").ModelAttributes> {
-    constructor(attributes?: Partial<import("@converse/skeletor").ModelAttributes>, options?: import("@converse/skeletor").ModelOptions);
+/**
+ * @extends {OMEMOVersionAwareModel<import('../../shared/types').JIDModelAttributes>}
+ */
+declare class DeviceList extends OMEMOVersionAwareModel<import("../../shared/types").JIDModelAttributes> {
+    constructor(attributes?: Partial<import("../../shared/types").JIDModelAttributes>, options?: import("@converse/skeletor").ModelOptions);
     initialize(): Promise<void>;
     initialized: Promise<any> & {
         isResolved: boolean;
@@ -14,7 +17,17 @@ declare class DeviceList extends Model<import("@converse/skeletor").ModelAttribu
     /**
      * @param {import('./devices').default} collection
      */
-    onDevicesFound(collection: import("./devices").default): Promise<void>;
+    /**
+     * Whether the most recent server fetch for this device list failed
+     * (timeout or error stanza), as opposed to authoritatively returning no
+     * devices (an empty list or item-not-found). Callers use this to decide
+     * whether an empty device list is worth re-fetching: a genuine "no devices"
+     * answer is not (a PEP push will inform us if that changes, since we
+     * advertise `+notify`), but a transient failure is.
+     * @returns {boolean}
+     */
+    get lastFetchFailed(): boolean;
+    onDevicesFound(collection: any): Promise<void>;
     /**
      * @param {boolean} [refresh=false] - Discard any previously memoized
      *      result and fetch the devices anew. Used to recover from a state
@@ -45,6 +58,7 @@ declare class DeviceList extends Model<import("@converse/skeletor").ModelAttribu
      * @param {string[]} device_ids
      */
     removeOwnDevices(device_ids: string[]): Promise<any>;
+    #private;
 }
-import { Model } from '@converse/skeletor';
+import { OMEMOVersionAwareModel } from './profiles.js';
 //# sourceMappingURL=devicelist.d.ts.map

--- a/src/headless/types/plugins/omemo/devices.d.ts
+++ b/src/headless/types/plugins/omemo/devices.d.ts
@@ -3,8 +3,23 @@ export default Devices;
  * @extends {Collection<Device>}
  */
 declare class Devices extends Collection<Device> {
-    constructor();
+    /**
+     * @param {Device[]|object[]} [models]
+     * @param {object} [options]
+     * @param {import('./types').OMEMOVersion} [options.version]
+     */
+    constructor(models?: Device[] | object[], options?: {
+        version?: import("./types").OMEMOVersion;
+    });
     model: typeof Device;
+    version: import("./types").OMEMOVersion;
+    /**
+     * Stamp the collection's OMEMO version onto every device created through it,
+     * unless one was explicitly provided.
+     * @param {object|Device} attrs
+     * @param {object} [options]
+     */
+    _prepareModel(attrs: object | Device, options?: object): Device;
 }
 import Device from "./device.js";
 import { Collection } from "@converse/skeletor";

--- a/src/headless/types/plugins/omemo/parsers.d.ts
+++ b/src/headless/types/plugins/omemo/parsers.d.ts
@@ -2,19 +2,40 @@
  * Hook handler for {@link parseMessage} and {@link parseMUCMessage}, which
  * parses the passed in `message` stanza for OMEMO attributes and then sets
  * them on the attrs object.
+ *
+ * A single stanza may carry both an `urn:xmpp:omemo:2` and a legacy
+ * `eu.siacs.conversations.axolotl` `<encrypted>` element: a sender that
+ * supports both addresses each recipient device in whichever version that
+ * device understands. The EME (XEP-0380) hint names only one method and exists
+ * for clients that can decrypt *neither* — it must not be used to pick a
+ * decryption path. So we route on which `<encrypted>` block actually contains a
+ * `<key>` for our own device, preferring omemo:2.
+ *
  * @param {Element} stanza - The message stanza
  * @param {MUCMessageAttributes|MessageAttributes} attrs
- * @returns {Promise<MUCMessageAttributes| MessageAttributes|
-        import('./types').MUCMessageAttrsWithEncryption|import('./types').MessageAttrsWithEncryption>}
+ * @returns {Promise<MUCMessageAttributes| MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
  */
-export function parseEncryptedMessage(stanza: Element, attrs: MUCMessageAttributes | MessageAttributes): Promise<MUCMessageAttributes | MessageAttributes | import("./types").MUCMessageAttrsWithEncryption | import("./types").MessageAttrsWithEncryption>;
+export function parseEncryptedMessage(stanza: Element, attrs: MUCMessageAttributes | MessageAttributes): Promise<MUCMessageAttributes | MessageAttributes | MUCMessageAttrsWithEncryption | MessageAttrsWithEncryption>;
 /**
- * Given an XML element representing a user's OMEMO bundle, parse it
+ * Given an XML element representing a legacy OMEMO bundle, parse it
  * and return a map.
  * @param {Element} bundle_el
  * @returns {import('./types').Bundle}
  */
 export function parseBundle(bundle_el: Element): import("./types").Bundle;
-export type MessageAttributes = import("../..//shared/types").MessageAttributes;
+/**
+ * Given an XML element representing an OMEMO 2 bundle, parse it
+ * and return a map using the same internal format as the legacy bundle.
+ *
+ * All key values are base64-encoded 32-byte raw Curve25519/Ed25519 bytes
+ * (the leading 0x05 byte is absent for v2).
+ *
+ * @param {Element} bundle_el
+ * @returns {import('./types').Bundle}
+ */
+export function parseBundleV2(bundle_el: Element): import("./types").Bundle;
+export type MessageAttributes = import("../../shared/types").MessageAttributes;
 export type MUCMessageAttributes = import("../../plugins/muc/types").MUCMessageAttributes;
+export type MUCMessageAttrsWithEncryption = import("./types").MUCMessageAttrsWithEncryption;
+export type MessageAttrsWithEncryption = import("./types").MessageAttrsWithEncryption;
 //# sourceMappingURL=parsers.d.ts.map

--- a/src/headless/types/plugins/omemo/profiles.d.ts
+++ b/src/headless/types/plugins/omemo/profiles.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Strip the leading 0x05 encoding byte from a 33-byte Curve25519 key produced
+ * by libomemo.js, returning the raw 32-byte value as base64. Used when
+ * publishing v2 bundle elements.
+ * @param {string} b64 - base64-encoded 33-byte key
+ * @returns {string}
+ */
+export function stripKeyByte(b64: string): string;
+/**
+ * Returns the protocol profile for a given OMEMO version.
+ * @param {import('./types').OMEMOVersion} version
+ * @returns {import('./types').OMEMOProfile}
+ */
+export function getProfile(version: import("./types").OMEMOVersion): import("./types").OMEMOProfile;
+/**
+ * Base model for the OMEMO models (Device, DeviceList) that carry an OMEMO
+ * protocol version in their `version` attribute, defaulting to the legacy
+ * (0.3.0) version when unset.
+ * @template {import('../../shared/types').ModelAttributes} [T=import('../../shared/types').ModelAttributes]
+ * @extends {Model<T>}
+ */
+export class OMEMOVersionAwareModel<T extends import("../../shared/types").ModelAttributes = import("../../shared/types").ModelAttributes> extends Model<T> {
+    constructor(attributes?: Partial<T>, options?: import("@converse/skeletor").ModelOptions);
+    /** @returns {import('./types').OMEMOVersion} */
+    getVersion(): import("./types").OMEMOVersion;
+    isV2(): boolean;
+}
+import { Model } from '@converse/skeletor';
+//# sourceMappingURL=profiles.d.ts.map

--- a/src/headless/types/plugins/omemo/sce.d.ts
+++ b/src/headless/types/plugins/omemo/sce.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Encrypt a message body using the SCE/OMEMO 2 scheme.
+ *
+ * Returns the 48-byte key_and_tag (content_key ‖ truncated-HMAC) as an
+ * ArrayBuffer — this is what gets encrypted with SessionCipher per device —
+ * and the base64-encoded AES-256-CBC ciphertext as the <payload> value.
+ *
+ * @param {string} plaintext - the message body to encrypt
+ * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
+ */
+export function encryptSCE(plaintext: string, affixes: {
+    from_jid: string;
+    to_jid: string | null;
+}): Promise<{
+    key_and_tag: ArrayBuffer;
+    payload: string;
+}>;
+/**
+ * Decrypt an SCE/OMEMO 2 payload.
+ *
+ * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
+ * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext
+ * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes - for validation
+ * @returns {Promise<string|null>} - plaintext message body
+ */
+export function decryptSCE(key_and_tag: ArrayBuffer, payload_b64: string, expected_affixes: {
+    sender_jid: string;
+    to_jid?: string | null;
+}): Promise<string | null>;
+//# sourceMappingURL=sce.d.ts.map

--- a/src/headless/types/plugins/omemo/store.d.ts
+++ b/src/headless/types/plugins/omemo/store.d.ts
@@ -1,4 +1,5 @@
 export function generateDeviceID(): Promise<string>;
+export { VersionedOMEMOStore } from "./versioned-store.js";
 export default OMEMOStore;
 /**
  * @extends {Model<import('./types').OMEMOStoreAttributes>}
@@ -31,16 +32,16 @@ declare class OMEMOStore extends Model<import("./types").OMEMOStoreAttributes> {
     loadIdentityKey(address: string): ArrayBuffer;
     /**
      * @param {string} address
-     * @param {string} identity_key
+     * @param {ArrayBuffer} identity_key
      * @returns {boolean}
      */
-    saveIdentity(address: string, identity_key: string): boolean;
+    saveIdentity(address: string, identity_key: ArrayBuffer): boolean;
     getPreKeys(): any;
     /**
-     * @param {string} key_id
+     * @param {string|number} key_id
      * @returns {Promise<{ keyPair: import('libomemo.js').KeyPair }|void>}
      */
-    loadPreKey(key_id: string): Promise<{
+    loadPreKey(key_id: string | number): Promise<{
         keyPair: import("libomemo.js").KeyPair;
     } | void>;
     /**
@@ -49,9 +50,9 @@ declare class OMEMOStore extends Model<import("./types").OMEMOStoreAttributes> {
      */
     storePreKey(key_id: number, key_pair: import("libomemo.js").KeyPair): void;
     /**
-     * @param {string} key_id
+     * @param {string|number} key_id
      */
-    removePreKey(key_id: string): Promise<void>;
+    removePreKey(key_id: string | number): Promise<void>;
     /**
      * @param {string} _key_id
      * @returns {{ keyPair: import('libomemo.js').KeyPair }|void}
@@ -63,6 +64,13 @@ declare class OMEMOStore extends Model<import("./types").OMEMOStoreAttributes> {
      * @param {import('libomemo.js').SignedPreKey} spk
      */
     storeSignedPreKey(spk: import("libomemo.js").SignedPreKey): void;
+    /**
+     * Store the v2 (urn:xmpp:omemo:2) signed prekey. Kept separate from the
+     * legacy SPK because the signature covers different bytes (32-byte curve vs
+     * 33-byte curve form).
+     * @param {import('libomemo.js').SignedPreKey} spk
+     */
+    storeSignedPreKeyV2(spk: import("libomemo.js").SignedPreKey): void;
     /**
      * @param {number} key_id
      */
@@ -107,10 +115,25 @@ declare class OMEMOStore extends Model<import("./types").OMEMOStoreAttributes> {
      * By generating a bundle, and publishing it via PubSub, we allow other
      * clients to download it and start asynchronous encrypted sessions with us,
      * even if we're offline at that time.
+     *
+     * Generates both legacy (0.3.0) and v2 (omemo:2) bundle material and
+     * publishes both PEP nodes.
      */
     generateBundle(): Promise<void>;
-    fetchSession(): Promise<any>;
-    _setup_promise: Promise<any>;
+    /**
+     * Backfills omemo:2 key material for an already provisioned device.
+     *
+     * Stores created before omemo:2 support have a device_id, identity key and
+     * legacy signed prekey, but no `signed_prekey_omemo2`.
+     *
+     * This generates the missing v2 signed prekey, reusing the existing
+     * identity key so our fingerprint and device_id are unchanged. The v2 bundle
+     * itself is published by the regular {@link OMEMOStore#publishBundle} call in
+     * initOMEMO, which runs right after the session is restored.
+     */
+    ensureV2SignedPreKey(): Promise<void>;
+    fetchSession(): Promise<void>;
+    #private;
 }
 import { Model } from '@converse/skeletor';
 //# sourceMappingURL=store.d.ts.map

--- a/src/headless/types/plugins/omemo/types.d.ts
+++ b/src/headless/types/plugins/omemo/types.d.ts
@@ -1,10 +1,18 @@
 import { MUCMessageAttributes } from '../../plugins/muc/types';
-import { MessageAttributes, ModelAttributes } from '../../shared/types';
+import { JIDModelAttributes, MessageAttributes, ModelAttributes } from '../../shared/types';
 declare global {
     interface Window {
         libomemo?: Record<string, unknown>;
     }
 }
+export type OMEMOVersion = 'eu.siacs.conversations.axolotl' | 'urn:xmpp:omemo:2';
+export type OMEMOProfile = {
+    version: OMEMOVersion;
+    readonly devicelist_node: string;
+    readonly bundle_node_prefix: string;
+    usesSCE: boolean;
+    encodePubKey: (b64: string) => string;
+};
 export type CounterpartyPreKey = {
     id: number;
     key: string;
@@ -19,9 +27,8 @@ export type Bundle = {
     prekeys: CounterpartyPreKey[];
     fingerprint?: string;
 };
-export type DeviceAttributes = ModelAttributes & {
+export type DeviceAttributes = JIDModelAttributes & {
     id: number;
-    jid: string;
     bundle?: Bundle;
     trusted: 0 | 1 | -1;
     active: boolean;

--- a/src/headless/types/plugins/omemo/utils.d.ts
+++ b/src/headless/types/plugins/omemo/utils.d.ts
@@ -1,4 +1,17 @@
 /**
+ * Returns a VersionedOMEMOStore proxy for the given OMEMO version.
+ *
+ * The proxy implements the subset of libomemo's `OMEMOStore` interface that
+ * `SessionCipher` and `SessionBuilder` actually exercise at runtime (the
+ * crypto/session methods); the interface's raw key-value members
+ * (`store`/`put`/`get`/`remove`) are part of the reference `InMemoryStore` and
+ * are never called on a consumer store, so we present the proxy as an
+ * `OMEMOStore` here.
+ * @param {import('./types').OMEMOVersion} version
+ * @returns {import('libomemo.js').OMEMOStore}
+ */
+export function getVersionedStore(version: import("./types").OMEMOVersion): import("libomemo.js").OMEMOStore;
+/**
  * Register a pubsub handler for devices pushed from other connected clients
  */
 export function registerPEPPushHandler(): void;
@@ -8,10 +21,11 @@ export function registerPEPPushHandler(): void;
 export function initOMEMO(reconnecting: boolean): Promise<void>;
 /**
  * @param {String} jid - The Jabber ID for which the device list will be returned.
- * @param {boolean} [create=false] - Set to `true` if the device list
- *      should be created if it cannot be found.
+ * @param {boolean} [create=false] - Set to `true` if the device list should be
+ *      created if it cannot be found.
+ * @param {import('./types').OMEMOVersion} [version] - Defaults to legacy version.
  */
-export function getDeviceList(jid: string, create?: boolean): Promise<any>;
+export function getDeviceList(jid: string, create?: boolean, version?: import("./types").OMEMOVersion): Promise<any>;
 /**
  * @param {import('./device.js').default} device
  */
@@ -22,20 +36,25 @@ export function generateFingerprint(device: import("./device.js").default): Prom
  */
 export function handleMessageSendError(e: Error | errors.IQError | errors.UserFacingError, chat: import("../../shared/chatbox.js").default): void;
 /**
+ * Returns the device collection for a contact and OMEMO version.
+ * Doesn't throw on any failure, instead logs and returns an empty collection.
  * @param {string} jid
+ * @param {import('./types').OMEMOVersion} [version]
  * @returns {Promise<import('./devices.js').default>}
  */
-export function getDevicesForContact(jid: string): Promise<import("./devices.js").default>;
+export function getDevicesForContact(jid: string, version?: import("./types").OMEMOVersion): Promise<import("./devices.js").default>;
 /**
  * @param {string} jid
  * @param {number} id
+ * @param {import('./types').OMEMOVersion} [version]
  * @returns {Promise<import('libomemo.js').SessionCipher>}
  */
-export function getSessionCipher(jid: string, id: number): Promise<import("libomemo.js").SessionCipher>;
+export function getSessionCipher(jid: string, id: number, version?: import("./types").OMEMOVersion): Promise<import("libomemo.js").SessionCipher>;
 /**
  * @param {import('./device').default} device
+ * @param {import('./types').OMEMOVersion} [version]
  */
-export function getSession(device: import("./device").default): Promise<any>;
+export function getSession(device: import("./device").default, version?: import("./types").OMEMOVersion): Promise<string | void>;
 /**
  * @param {import('./types').EncryptedMessage} obj
  * @returns {Promise<string>}

--- a/src/headless/types/plugins/omemo/versioned-store.d.ts
+++ b/src/headless/types/plugins/omemo/versioned-store.d.ts
@@ -1,0 +1,50 @@
+/**
+ * A thin proxy around OMEMOStore that namespaces session and identity-key
+ * storage by OMEMO version.  Legacy sessions use unprefixed keys (no
+ * migration needed); v2 sessions use a `v2:` prefix so the two protocol
+ * versions never collide inside the same underlying model.
+ *
+ * Prekeys and the identity keypair are shared across both versions — only
+ * the signed prekey and the session/trust data are version-specific.
+ */
+export class VersionedOMEMOStore {
+    /**
+     * @param {import('./store.js').default} base_store
+     * @param {import('./types').OMEMOVersion} version
+     */
+    constructor(base_store: import("./store.js").default, version: import("./types").OMEMOVersion);
+    getIdentityKeyPair(): import("libomemo.js").KeyPair;
+    getLocalRegistrationId(): number;
+    /** @param {string} address @param {ArrayBuffer} identity_key @param {unknown} direction */
+    isTrustedIdentity(address: string, identity_key: ArrayBuffer, direction: unknown): boolean;
+    /** @param {string} address @param {ArrayBuffer} identity_key */
+    saveIdentity(address: string, identity_key: ArrayBuffer): boolean;
+    /** @param {string|number} key_id */
+    loadPreKey(key_id: string | number): Promise<void | {
+        keyPair: import("libomemo.js").KeyPair;
+    }>;
+    getPreKeys(): any;
+    /** @param {number} key_id @param {import('libomemo.js').KeyPair} key_pair */
+    storePreKey(key_id: number, key_pair: import("libomemo.js").KeyPair): void;
+    /** @param {string|number} key_id */
+    removePreKey(key_id: string | number): Promise<void>;
+    /** @param {string|number} _key_id */
+    loadSignedPreKey(_key_id: string | number): {
+        keyPair: {
+            privKey: any;
+            pubKey: any;
+        };
+    };
+    /** @param {number} key_id */
+    removeSignedPreKey(key_id: number): void;
+    /** @param {string} address */
+    loadSession(address: string): Promise<any>;
+    /** @param {string} address @param {string} record */
+    storeSession(address: string, record: string): Promise<any>;
+    /** @param {string} address */
+    removeSession(address: string): Promise<import("./store.js").default>;
+    /** @param {string} [address=''] */
+    removeAllSessions(address?: string): Promise<void>;
+    #private;
+}
+//# sourceMappingURL=versioned-store.d.ts.map

--- a/src/headless/types/shared/types.d.ts
+++ b/src/headless/types/shared/types.d.ts
@@ -10,6 +10,9 @@ export type ReplaceableOpenPromise = ReturnType<typeof getOpenPromise> & {
     replace?: boolean;
 };
 export type ModelAttributes = Record<string, any>;
+export type JIDModelAttributes = ModelAttributes & {
+    jid: string;
+};
 export interface ModelOptions {
     collection?: Collection;
     parse?: boolean;

--- a/src/plugins/bookmark-views/tests/bookmarks.js
+++ b/src/plugins/bookmark-views/tests/bookmarks.js
@@ -279,7 +279,7 @@ describe('Bookmarks', function () {
             <c xmlns="http://jabber.org/protocol/caps"
                hash="sha-1"
                node="https://conversejs.org"
-               ver="Hbd4V8rlZualGDSkxW/4bVlnudc="/>
+               ver="aU8gtptxi4fPJB8IPibd7tJbTLE="/>
             </presence>`);
         }),
     );

--- a/src/plugins/muc-views/tests/autocomplete.js
+++ b/src/plugins/muc-views/tests/autocomplete.js
@@ -12,7 +12,8 @@ describe('The nickname autocomplete feature', function () {
             // Nicknames from presences
             ['dick', 'harry'].forEach((nick) => {
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`<presence
                     to="tom@montague.lit/resource"
                     from="lounge@montague.lit/${nick}"
@@ -84,7 +85,8 @@ describe('The nickname autocomplete feature', function () {
             // Nicknames from presences
             ['dick', 'harry'].forEach((nick) => {
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`<presence
                         to="tom@montague.lit/resource"
                         from="lounge@montague.lit/${nick}"
@@ -149,15 +151,20 @@ describe('The nickname autocomplete feature', function () {
 
     it(
         'shows all autocompletion options when the user presses @ right after an allowed character',
-        mock.initConverse(converse, ['chatBoxesFetched'], { 'opening_mention_characters': ['('] }, async function (_converse) {
-            await mock.openAndEnterMUC(_converse, 'lounge@montague.lit', 'tom');
-            const view = _converse.chatboxviews.get('lounge@montague.lit');
+        mock.initConverse(
+            converse,
+            ['chatBoxesFetched'],
+            { 'opening_mention_characters': ['('] },
+            async function (_converse) {
+                await mock.openAndEnterMUC(_converse, 'lounge@montague.lit', 'tom');
+                const view = _converse.chatboxviews.get('lounge@montague.lit');
 
-            // Nicknames from presences
-            ['dick', 'harry'].forEach((nick) => {
-                _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
-                        stx`<presence
+                // Nicknames from presences
+                ['dick', 'harry'].forEach((nick) => {
+                    _converse.api.connection.get()._dataRecv(
+                        mock.createRequest(
+                            _converse,
+                            stx`<presence
                     to="tom@montague.lit/resource"
                     from="lounge@montague.lit/${nick}"
                     xmlns="jabber:client">
@@ -165,13 +172,13 @@ describe('The nickname autocomplete feature', function () {
                         <item affiliation="none" jid="${nick}@montague.lit/resource" role="participant"/>
                     </x>
                 </presence>`,
-                    ),
-                );
-            });
+                        ),
+                    );
+                });
 
-            // Nicknames from messages
-            await view.model.handleMessageStanza(
-                stx`<message
+                // Nicknames from messages
+                await view.model.handleMessageStanza(
+                    stx`<message
                     from="lounge@montague.lit/jane"
                     id="${u.getUniqueId()}"
                     to="romeo@montague.lit"
@@ -179,45 +186,46 @@ describe('The nickname autocomplete feature', function () {
                     xmlns="jabber:client">
                 <body>Hello world</body>
             </message>`,
-            );
+                );
 
-            await u.waitUntil(() => view.model.messages.last()?.get('received'));
+                await u.waitUntil(() => view.model.messages.last()?.get('received'));
 
-            // Test that pressing @ brings up all options
-            const textarea = await u.waitUntil(() => view.querySelector('.chat-textarea'));
-            const at_event = {
-                'target': textarea,
-                'preventDefault': function preventDefault() {},
-                'stopPropagation': function stopPropagation() {},
-                'key': '@',
-            };
-            textarea.value = '(';
-            const message_form = view.querySelector('converse-muc-message-form');
-            message_form.onKeyDown(at_event);
-            textarea.value = '(@';
-            message_form.onKeyUp(at_event);
+                // Test that pressing @ brings up all options
+                const textarea = await u.waitUntil(() => view.querySelector('.chat-textarea'));
+                const at_event = {
+                    'target': textarea,
+                    'preventDefault': function preventDefault() {},
+                    'stopPropagation': function stopPropagation() {},
+                    'key': '@',
+                };
+                textarea.value = '(';
+                const message_form = view.querySelector('converse-muc-message-form');
+                message_form.onKeyDown(at_event);
+                textarea.value = '(@';
+                message_form.onKeyUp(at_event);
 
-            await u.waitUntil(() => view.querySelectorAll('.suggestion-box__results li').length === 4);
-            const first_child = view.querySelector('.suggestion-box__results li:first-child');
-            const first_child_avatar = first_child.querySelector('converse-avatar');
-            expect(first_child_avatar.textContent.trim()).toBe('D');
-            expect(first_child.textContent.trim()).toBe('D dick');
+                await u.waitUntil(() => view.querySelectorAll('.suggestion-box__results li').length === 4);
+                const first_child = view.querySelector('.suggestion-box__results li:first-child');
+                const first_child_avatar = first_child.querySelector('converse-avatar');
+                expect(first_child_avatar.textContent.trim()).toBe('D');
+                expect(first_child.textContent.trim()).toBe('D dick');
 
-            const second_child = view.querySelector('.suggestion-box__results li:nth-child(2)');
-            const second_child_avatar = second_child.querySelector('converse-avatar');
-            expect(second_child_avatar.textContent.trim()).toBe('H');
-            expect(second_child.textContent.trim()).toBe('H harry');
+                const second_child = view.querySelector('.suggestion-box__results li:nth-child(2)');
+                const second_child_avatar = second_child.querySelector('converse-avatar');
+                expect(second_child_avatar.textContent.trim()).toBe('H');
+                expect(second_child.textContent.trim()).toBe('H harry');
 
-            const third_child = view.querySelector('.suggestion-box__results li:nth-child(3)');
-            const third_child_avatar = third_child.querySelector('converse-avatar');
-            expect(third_child_avatar.textContent.trim()).toBe('J');
-            expect(third_child.textContent.trim()).toBe('J jane');
+                const third_child = view.querySelector('.suggestion-box__results li:nth-child(3)');
+                const third_child_avatar = third_child.querySelector('converse-avatar');
+                expect(third_child_avatar.textContent.trim()).toBe('J');
+                expect(third_child.textContent.trim()).toBe('J jane');
 
-            const fourth_child = view.querySelector('.suggestion-box__results li:nth-child(4)');
-            const fourth_child_avatar = fourth_child.querySelector('converse-avatar');
-            expect(fourth_child_avatar.textContent.trim()).toBe('T');
-            expect(fourth_child.textContent.trim()).toBe('T tom');
-        }),
+                const fourth_child = view.querySelector('.suggestion-box__results li:nth-child(4)');
+                const fourth_child_avatar = fourth_child.querySelector('converse-avatar');
+                expect(fourth_child_avatar.textContent.trim()).toBe('T');
+                expect(fourth_child.textContent.trim()).toBe('T tom');
+            },
+        ),
     );
 
     it(
@@ -230,7 +238,8 @@ describe('The nickname autocomplete feature', function () {
             // Nicknames from presences
             ['bernard', 'naber', 'helberlo', 'john', 'jones'].forEach((nick) => {
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`<presence
                     to="tom@montague.lit/resource"
                     from="lounge@montague.lit/${nick}"
@@ -384,7 +393,8 @@ describe('The nickname autocomplete feature', function () {
 
             // Test that pressing tab twice selects
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, 
+                mock.createRequest(
+                    _converse,
                     stx`<presence
                     to="romeo@montague.lit/orchard"
                     from="lounge@montague.lit/z3r0"
@@ -416,7 +426,8 @@ describe('The nickname autocomplete feature', function () {
             const view = _converse.chatboxviews.get('lounge@montague.lit');
             expect(view.model.occupants.length).toBe(1);
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, 
+                mock.createRequest(
+                    _converse,
                     stx`<presence
                     to="romeo@montague.lit/orchard"
                     from="lounge@montague.lit/some1"

--- a/src/plugins/muc-views/tests/corrections.js
+++ b/src/plugins/muc-views/tests/corrections.js
@@ -10,7 +10,9 @@ describe('A Groupchat Message', function () {
             const muc_jid = 'lounge@montague.lit';
             const model = await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, stx`
+                mock.createRequest(
+                    _converse,
+                    stx`
             <presence
                 to="romeo@montague.lit/_converse.js-29092160"
                 from="coven@chat.shakespeare.lit/newguy"
@@ -18,7 +20,8 @@ describe('A Groupchat Message', function () {
                 <x xmlns="${Strophe.NS.MUC_USER}">
                     <item affiliation="none" jid="newguy@montague.lit/_converse.js-290929789" role="participant"/>
                 </x>
-            </presence>`),
+            </presence>`,
+                ),
             );
 
             const msg_id = u.getUniqueId();
@@ -100,7 +103,9 @@ describe('A Groupchat Message', function () {
             await mock.openAndEnterMUC(_converse, muc_jid, 'romeo');
             const view = _converse.chatboxviews.get(muc_jid);
             _converse.api.connection.get()._dataRecv(
-                mock.createRequest(_converse, stx`
+                mock.createRequest(
+                    _converse,
+                    stx`
             <presence
                 to="romeo@montague.lit/_converse.js-29092160"
                 from="coven@chat.shakespeare.lit/newguy"
@@ -108,7 +113,8 @@ describe('A Groupchat Message', function () {
                 <x xmlns="${Strophe.NS.MUC_USER}">
                     <item affiliation="none" jid="newguy@montague.lit/_converse.js-290929789" role="participant"/>
                 </x>
-            </presence>`),
+            </presence>`,
+                ),
             );
 
             const msg_id = u.getUniqueId();

--- a/src/plugins/muc-views/tests/nickname.js
+++ b/src/plugins/muc-views/tests/nickname.js
@@ -6,7 +6,8 @@ const { Strophe, sizzle, u, stx } = converse.env;
 describe('A MUC', function () {
     it(
         'allows you to change your nickname via a modal',
-        mock.initConverse(converse, 
+        mock.initConverse(
+            converse,
             [],
             { view_mode: 'fullscreen', auto_register_muc_nickname: true },
             async function (_converse) {
@@ -48,7 +49,8 @@ describe('A MUC', function () {
 
                 // Two presence stanzas are received from the MUC service
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`
             <presence
                 xmlns="jabber:client"
@@ -72,7 +74,8 @@ describe('A MUC', function () {
 
                 // Check that the new nickname gets registered with the MUC
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`
             <presence
                 xmlns="jabber:client"
@@ -106,7 +109,8 @@ describe('A MUC', function () {
                 );
 
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, 
+                    mock.createRequest(
+                        _converse,
                         stx`<iq from="${muc_jid}"
                 id="${stanza.getAttribute('id')}"
                 to="${_converse.session.get('jid')}"
@@ -330,7 +334,8 @@ describe('A MUC', function () {
 
         it(
             "will use the nickname set in the global settings if the user doesn't have a VCard nickname",
-            mock.initConverse(converse, 
+            mock.initConverse(
+                converse,
                 ['chatBoxesFetched'],
                 {
                     blacklisted_plugins: ['converse-vcard'],
@@ -357,7 +362,9 @@ describe('A MUC', function () {
                 await mock.waitForMUCDiscoInfo(_converse, muc_jid);
 
                 _converse.api.connection.get()._dataRecv(
-                    mock.createRequest(_converse, stx`
+                    mock.createRequest(
+                        _converse,
+                        stx`
                 <presence
                         from="${muc_jid}/romeo"
                         id="${u.getUniqueId()}"
@@ -368,7 +375,8 @@ describe('A MUC', function () {
                     <error by="${muc_jid}" type="cancel">
                         <conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
                     </error>
-                </presence>`),
+                </presence>`,
+                    ),
                 );
 
                 const view = await u.waitUntil(() => _converse.chatboxviews.get(muc_jid));
@@ -431,7 +439,7 @@ describe('A MUC', function () {
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="Hbd4V8rlZualGDSkxW/4bVlnudc="/>>
+                        ver="aU8gtptxi4fPJB8IPibd7tJbTLE="/>>
                 </presence>`);
 
                 while (IQ_stanzas.length) IQ_stanzas.pop();
@@ -465,7 +473,7 @@ describe('A MUC', function () {
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="Hbd4V8rlZualGDSkxW/4bVlnudc="/>>
+                        ver="aU8gtptxi4fPJB8IPibd7tJbTLE="/>>
                 </presence>`);
 
                 while (IQ_stanzas.length) IQ_stanzas.pop();
@@ -499,7 +507,7 @@ describe('A MUC', function () {
                         xmlns="jabber:client">
                     <x xmlns="http://jabber.org/protocol/muc"><history maxstanzas="0"/></x>
                     <c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://conversejs.org"
-                        ver="Hbd4V8rlZualGDSkxW/4bVlnudc="/>>
+                        ver="aU8gtptxi4fPJB8IPibd7tJbTLE="/>>
                 </presence>`);
             }),
         );
@@ -536,7 +544,8 @@ describe('A MUC', function () {
 
         it(
             "doesn't show the nickname field if locked_muc_nickname is true",
-            mock.initConverse(converse, 
+            mock.initConverse(
+                converse,
                 ['chatBoxesFetched'],
                 {
                     locked_muc_nickname: true,
@@ -568,7 +577,8 @@ describe('A MUC', function () {
 
         it(
             'uses the JID node if muc_nickname_from_jid is set to true',
-            mock.initConverse(converse, 
+            mock.initConverse(
+                converse,
                 ['chatBoxesFetched'],
                 {
                     'muc_nickname_from_jid': true,

--- a/src/plugins/muc-views/tests/probes.js
+++ b/src/plugins/muc-views/tests/probes.js
@@ -32,7 +32,10 @@ describe('Groupchats', function () {
                     stx`<presence to="${muc_jid}/ralphm" type="probe" xmlns="jabber:client">
                         <priority>0</priority>
                         <x xmlns="vcard-temp:x:update"/>
-                        <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                        <c hash="sha-1"
+                            node="https://conversejs.org"
+                            ver="aU8gtptxi4fPJB8IPibd7tJbTLE="
+                            xmlns="http://jabber.org/protocol/caps"/>
                     </presence>`,
                 );
 
@@ -47,9 +50,12 @@ describe('Groupchats', function () {
                 expect(occupant.get('role')).toBe('participant');
 
                 // Check that unavailable but affiliated occupants don't get destroyed
-                stanza = stx`<message xmlns="jabber:client" to="${_converse.jid}" type="groupchat" from="${muc_jid}/gonePhising">
-                    <body>This message from an unavailable user will trigger a presence probe</body>
-                </message>`;
+                stanza = stx`<message xmlns="jabber:client"
+                            to="${_converse.jid}"
+                            type="groupchat"
+                            from="${muc_jid}/gonePhising">
+                        <body>This message from an unavailable user will trigger a presence probe</body>
+                    </message>`;
                 _converse.api.connection.get()._dataRecv(mock.createRequest(_converse, stanza));
 
                 await u.waitUntil(() => view.model.messages.length === 2);
@@ -66,11 +72,15 @@ describe('Groupchats', function () {
                     stx`<presence to="${muc_jid}/gonePhising" type="probe" xmlns="jabber:client">
                         <priority>0</priority>
                         <x xmlns="vcard-temp:x:update"/>
-                        <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                        <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
                     </presence>`,
                 );
 
-                presence = stx`<presence xmlns="jabber:client" type="unavailable" to="${_converse.jid}" from="${muc_jid}/gonePhising">
+                presence = stx`<presence
+                        xmlns="jabber:client"
+                        type="unavailable"
+                        to="${_converse.jid}"
+                        from="${muc_jid}/gonePhising">
                     <x xmlns="http://jabber.org/protocol/muc#user">
                         <item affiliation="member" jid="gonePhishing@example.org/d34dBEEF" role="participant"/>
                     </x>

--- a/src/plugins/muc-views/tests/rai.js
+++ b/src/plugins/muc-views/tests/rai.js
@@ -8,7 +8,8 @@ const { Strophe, u, stx, sizzle } = converse.env;
 describe('XEP-0437 Room Activity Indicators', function () {
     it(
         'will be activated for a MUC that becomes hidden',
-        mock.initConverse(converse, 
+        mock.initConverse(
+            converse,
             [],
             {
                 'allow_bookmarks': false, // Hack to get the rooms list to render
@@ -91,13 +92,13 @@ describe('XEP-0437 Room Activity Indicators', function () {
             <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="FbNYz6snHqlCzoYc4qsybHgn624=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
                 expect(sent_stanzas[3]).toEqualStanza(stx`
             <presence to="montague.lit" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="FbNYz6snHqlCzoYc4qsybHgn624=" xmlns="http://jabber.org/protocol/caps"/>
                 <rai xmlns="urn:xmpp:rai:0"/>
             </presence>`);
 
@@ -129,7 +130,8 @@ describe('XEP-0437 Room Activity Indicators', function () {
 
     it(
         'will be activated for a MUC that starts out hidden',
-        mock.initConverse(converse, 
+        mock.initConverse(
+            converse,
             [],
             {
                 allow_bookmarks: false, // Hack to get the rooms list to render
@@ -162,13 +164,13 @@ describe('XEP-0437 Room Activity Indicators', function () {
             <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="FbNYz6snHqlCzoYc4qsybHgn624=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
                 expect(sent_presences[2]).toEqualStanza(stx`
             <presence to="montague.lit" xmlns="jabber:client">
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="FbNYz6snHqlCzoYc4qsybHgn624=" xmlns="http://jabber.org/protocol/caps"/>
                 <rai xmlns="urn:xmpp:rai:0"/>
             </presence>`);
 
@@ -198,7 +200,8 @@ describe('XEP-0437 Room Activity Indicators', function () {
 
     it(
         'may not be activated due to server resource constraints',
-        mock.initConverse(converse, 
+        mock.initConverse(
+            converse,
             [],
             {
                 'allow_bookmarks': false, // Hack to get the rooms list to render
@@ -218,18 +221,24 @@ describe('XEP-0437 Room Activity Indicators', function () {
 
                 const sent_presences = sent_stanzas.filter((s) => s.nodeName === 'presence');
                 expect(sent_presences[0]).toEqualStanza(stx`
-            <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
-                <priority>0</priority>
-                <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
-            </presence>`);
+                    <presence to="${muc_jid}/romeo" type="unavailable" xmlns="jabber:client">
+                        <priority>0</priority>
+                        <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
+                        <c hash="sha-1" node="https://conversejs.org"
+                            ver="FbNYz6snHqlCzoYc4qsybHgn624="
+                        xmlns="http://jabber.org/protocol/caps"/>
+                    </presence>`);
+
                 expect(sent_presences[1]).toEqualStanza(stx`
-            <presence to="montague.lit" xmlns="jabber:client">
-                <priority>0</priority>
-                <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="gdck24wSF+suQUiLraUQ715DZm0=" xmlns="http://jabber.org/protocol/caps"/>
-                <rai xmlns="urn:xmpp:rai:0"/>
-            </presence>`);
+                    <presence to="montague.lit" xmlns="jabber:client">
+                        <priority>0</priority>
+                        <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
+                        <c hash="sha-1" node="https://conversejs.org"
+                            ver="FbNYz6snHqlCzoYc4qsybHgn624="
+                            xmlns="http://jabber.org/protocol/caps"/>
+                        <rai xmlns="urn:xmpp:rai:0"/>
+                    </presence>`);
+
                 // If an error presence with "resource-constraint" is returned, we rejoin
                 const activity_stanza = stx`
             <presence type="error"

--- a/src/plugins/omemo-views/fingerprints.js
+++ b/src/plugins/omemo-views/fingerprints.js
@@ -1,4 +1,4 @@
-import { api } from '@converse/headless';
+import { api, log } from '@converse/headless';
 import { CustomElement } from 'shared/components/element.js';
 import tplFingerprints from './templates/fingerprints.js';
 
@@ -6,28 +6,72 @@ export class Fingerprints extends CustomElement {
     constructor() {
         super();
         this.jid = null;
+        this.loading = true;
         this.show_inactive_devices = false;
     }
 
     static get properties() {
         return {
             jid: { type: String },
-            show_inactive_devices: { type: Boolean, state: true }
+            loading: { type: Boolean, state: true },
+            show_inactive_devices: { type: Boolean, state: true },
         };
     }
 
-    async initialize() {
-        this.devicelist = await api.omemo.devicelists.get(this.jid, true);
-        this.listenTo(this.devicelist.devices, 'change:bundle', () => this.requestUpdate());
-        this.listenTo(this.devicelist.devices, 'change:trusted', () => this.requestUpdate());
-        this.listenTo(this.devicelist.devices, 'remove', () => this.requestUpdate());
-        this.listenTo(this.devicelist.devices, 'add', () => this.requestUpdate());
-        this.listenTo(this.devicelist.devices, 'reset', () => this.requestUpdate());
-        this.requestUpdate();
+    initialize() {
+        this.fetchDeviceLists();
+    }
+
+    /**
+     * Fetch both the legacy and the omemo:2 device lists in the background so
+     * neither blocks rendering; each renders its devices as soon as it resolves.
+     * A failure (e.g. on a server without omemo:2 support) must not block the
+     * other list. The loading flag is cleared once both have settled so the
+     * empty state only shows when there genuinely are no devices.
+     */
+    fetchDeviceLists() {
+        const update = () => this.requestUpdate();
+        /** @param {import('@converse/headless').DeviceList} list */
+        const listen = (list) => {
+            this.listenTo(list.devices, 'change:bundle', update);
+            this.listenTo(list.devices, 'change:trusted', update);
+            this.listenTo(list.devices, 'remove', update);
+            this.listenTo(list.devices, 'add', update);
+            this.listenTo(list.devices, 'reset', update);
+        };
+
+        const legacy = api.omemo.devicelists
+            .get(this.jid, true)
+            .then((/** @type {import('@converse/headless').DeviceList} */ list) => {
+                this.devicelist = list;
+                listen(list);
+                this.requestUpdate();
+            })
+            .catch((e) => log.error(e));
+
+        const v2 = api.omemo.devicelists
+            .get(this.jid, true, 'urn:xmpp:omemo:2')
+            .then((/** @type {import('@converse/headless').DeviceList} */ v2_list) => {
+                this.devicelist_v2 = v2_list;
+                listen(v2_list);
+                this.requestUpdate();
+            })
+            .catch((e) => log.error(e));
+
+        Promise.allSettled([legacy, v2]).then(() => {
+            this.loading = false;
+        });
+    }
+
+    /** Returns all devices (legacy + v2) as a flat array for rendering. */
+    getAllDevices() {
+        const legacy = this.devicelist?.devices?.models ?? [];
+        const v2 = this.devicelist_v2?.devices?.models ?? [];
+        return [...legacy, ...v2];
     }
 
     render() {
-        return this.devicelist ? tplFingerprints(this) : '';
+        return tplFingerprints(this);
     }
 
     /**
@@ -35,8 +79,16 @@ export class Fingerprints extends CustomElement {
      */
     toggleDeviceTrust(ev) {
         const radio = /** @type {HTMLInputElement} */ (ev.target);
-        const device = this.devicelist.devices.get(radio.getAttribute('name'));
-        device.save('trusted', parseInt(radio.value, 10));
+        const device_id = radio.getAttribute('name');
+        // A physical device publishes the same device id to both the legacy and
+        // the omemo:2 device list, but each version has its own identity key
+        // (and thus its own trust state). Resolve the device from the collection
+        // matching the radio's version, otherwise trust changes on a v2 device
+        // would silently be written to the legacy device of the same id.
+        const collection =
+            radio.dataset.version === 'urn:xmpp:omemo:2' ? this.devicelist_v2?.devices : this.devicelist?.devices;
+        const device = collection?.get(device_id);
+        device?.save('trusted', parseInt(radio.value, 10));
     }
 
     /**

--- a/src/plugins/omemo-views/templates/fingerprints.js
+++ b/src/plugins/omemo-views/templates/fingerprints.js
@@ -1,5 +1,6 @@
 import { __ } from 'i18n';
 import { html } from 'lit';
+import tplSpinner from 'templates/spinner.js';
 import { formatFingerprint } from '../utils.js';
 import { converse } from '@converse/headless';
 
@@ -32,6 +33,7 @@ const device_fingerprint = (el, device) => {
                                 type="radio"
                                 class="btn-check"
                                 name="${device.get('id')}"
+                                data-version="${device.getVersion()}"
                                 id="${id1}"
                                 autocomplete="off"
                                 value="1"
@@ -48,6 +50,7 @@ const device_fingerprint = (el, device) => {
                                 type="radio"
                                 class="btn-check"
                                 name="${device.get('id')}"
+                                data-version="${device.getVersion()}"
                                 id="${id2}"
                                 autocomplete="off"
                                 value="-1"
@@ -82,19 +85,22 @@ const device_fingerprint = (el, device) => {
 export default (el) => {
     const i18n_fingerprints = __('OMEMO Fingerprints');
     const i18n_no_devices = __('No OMEMO-enabled devices found');
-    const devices = el.devicelist.devices;
+    // Combine legacy and v2 devices for display; each has its own trust state.
+    const all_devices = el.getAllDevices?.() ?? el.devicelist?.devices?.models ?? [];
 
     const i18n_show_inactive = __('Show inactive devices');
-    const active_devices = devices?.filter((device) => device.get('active') !== false);
-    const inactive_devices = devices?.filter((device) => device.get('active') === false);
+    const active_devices = all_devices.filter((device) => device.get('active') !== false);
+    const inactive_devices = all_devices.filter((device) => device.get('active') === false);
 
     return html`
         <div class="fingerprints">
             <ul class="list-group mb-3">
                 <li class="list-group-item active">${i18n_fingerprints}</li>
-                ${active_devices.length
-                    ? active_devices.map((device) => device_fingerprint(el, device))
-                    : html`<li class="list-group-item">${i18n_no_devices}</li>`}
+                ${el.loading
+                    ? html`<li class="list-group-item">${tplSpinner()}</li>`
+                    : active_devices.length
+                      ? active_devices.map((device) => device_fingerprint(el, device))
+                      : html`<li class="list-group-item">${i18n_no_devices}</li>`}
                 <li class="list-group-item">
                     <div class="form-check">
                         <input

--- a/src/plugins/omemo-views/tests/fingerprints.js
+++ b/src/plugins/omemo-views/tests/fingerprints.js
@@ -1,0 +1,63 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+import { answerV2DeviceList, answerV2Bundle } from './utils.js';
+
+const { u } = converse.env;
+
+describe('OMEMO 2 fingerprints', function () {
+    it(
+        'displays a fingerprint for both the legacy and the omemo:2 device of the same id',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitUntilBlocklistInitialized(_converse);
+            await mock.waitForRoster(_converse, 'current', 1);
+            await mock.waitUntilDiscoConfirmed(
+                _converse,
+                _converse.bare_jid,
+                [{ category: 'pubsub', type: 'pep' }],
+                ['http://jabber.org/protocol/pubsub#publish-options'],
+            );
+
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            _converse.api.trigger('OMEMOInitialized');
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.querySelector('.show-user-details-modal').click();
+            const modal = _converse.api.modal.get('converse-user-details-modal');
+            await u.waitUntil(() => u.isVisible(modal), 1000);
+
+            // The same physical device id (555) is published to both the legacy
+            // and the omemo:2 device list, each with its own identity key.
+            await mock.deviceListFetched(_converse, contact_jid, ['555']);
+            await mock.bundleFetched(_converse, {
+                jid: contact_jid,
+                device_id: '555',
+                identity_key: '3333',
+                signed_prekey_id: '4223',
+                signed_prekey_public: '1111',
+                signed_prekey_sig: '2222',
+                prekeys: ['1001', '1002', '1003'],
+            });
+            await answerV2DeviceList(_converse, contact_jid, ['555']);
+            await answerV2Bundle(_converse, contact_jid, '555');
+
+            modal.querySelector('.nav-item #omemo-tab').click();
+
+            // Both versions render their own fingerprint row. Before omemo:2
+            // fingerprints were generated, only the legacy row appeared.
+            await u.waitUntil(() => modal.querySelectorAll('.fingerprints .fingerprint').length === 2, 2000);
+
+            const fingerprints = Array.from(modal.querySelectorAll('.fingerprints .fingerprint')).map((el) =>
+                el.textContent.trim(),
+            );
+            // The legacy (Curve25519) and omemo:2 (Ed25519) fingerprints differ.
+            expect(fingerprints[0]).not.toBe(fingerprints[1]);
+
+            // Each version's trust radios are tagged with their version.
+            expect(
+                modal.querySelector('input[type="radio"][data-version="eu.siacs.conversations.axolotl"]'),
+            ).toBeTruthy();
+            expect(modal.querySelector('input[type="radio"][data-version="urn:xmpp:omemo:2"]')).toBeTruthy();
+        }),
+    );
+});

--- a/src/plugins/omemo-views/tests/muc.js
+++ b/src/plugins/omemo-views/tests/muc.js
@@ -451,25 +451,10 @@ describe('The OMEMO module', function () {
                 </iq>`;
             _converse.api.connection.get()._dataRecv(mock.createRequest(_converse, stanza));
 
-            // getDevicesForContact retries on empty results, so expect a second IQ
-            const selector = `iq[to="${contact_jid}"] items[node="eu.siacs.conversations.axolotl.devicelist"]`;
-            const retry_iq = await u.waitUntil(() => {
-                const iqs = Array.from(_converse.api.connection.get().IQ_stanzas)
-                    .filter((iq) => iq.querySelector(selector));
-                return iqs.length >= 2 ? iqs[iqs.length - 1] : null;
-            });
-            stanza = stx`
-                <iq from="${contact_jid}"
-                    id="${retry_iq.getAttribute('id')}"
-                    to="${_converse.bare_jid}"
-                    type="error"
-                    xmlns="jabber:client">
-                    <error type="cancel">
-                        <item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
-                    </error>
-                </iq>`;
-            _converse.api.connection.get()._dataRecv(mock.createRequest(_converse, stanza));
-
+            // `item-not-found` is an authoritative "this contact has no device
+            // list", so getDevicesForContact does NOT retry (only transient
+            // failures are retried). A single response is enough to conclude
+            // that OMEMO is no longer supported in this groupchat.
             await u.waitUntil(() => !view.model.get('omemo_supported'));
             await u.waitUntil(
                 () =>

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -1,0 +1,364 @@
+/**
+ * Tests for OMEMO 2 (urn:xmpp:omemo:2) functionality:
+ *   - OMEMO 2 bundle parsing
+ *   - OMEMO 2 message stanza routing
+ */
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+import { answerV2DeviceList, answerV2Bundle } from './utils.js';
+
+const { Strophe, sizzle, stx, u } = converse.env;
+
+describe('OMEMO 2 message reception', function () {
+    it(
+        'decrypts an incoming omemo:2 message and renders the plaintext',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const sender_device_id = '555';
+            const plaintext = 'This is an OMEMO 2 encrypted message';
+
+            // Build the SCE payload exactly as the sending contact would.
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, {
+                from_jid: contact_jid,
+                to_jid: null,
+            });
+
+            // During decryption the device's active state is updated, which
+            // fetches the contact's v2 device list. Answer that IQ in the
+            // background with a list containing the sending device.
+            const conn = api.connection.get();
+            const v2_dl_selector = `iq[to="${contact_jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+            const interval = setInterval(() => {
+                const iq = Array.from(conn.IQ_stanzas)
+                    .filter((i) => i.querySelector(v2_dl_selector) && !i.dataset_handled)
+                    .pop();
+                if (!iq) return;
+                iq.dataset_handled = true;
+                const result = stx`<iq from="${contact_jid}"
+                                       id="${iq.getAttribute('id')}"
+                                       to="${conn.jid}"
+                                       xmlns="jabber:server"
+                                       type="result">
+                    <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                        <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                            <item>
+                                <devices xmlns="${Strophe.NS.OMEMO2_DEVICELIST}">
+                                    <device id="${sender_device_id}"/>
+                                </devices>
+                            </item>
+                        </items>
+                    </pubsub>
+                </iq>`;
+                conn._dataRecv(mock.createRequest(_converse, result));
+            }, 50);
+
+            const stanza = stx`<message from="${contact_jid}"
+                    to="${conn.jid}"
+                    type="chat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <body>This is a fallback message</body>
+                <encrypted xmlns="${Strophe.NS.OMEMO2}">
+                    <header sid="${sender_device_id}">
+                        <keys jid="${_converse.bare_jid}">
+                            <key rid="${our_device_id}">${u.arrayBufferToBase64(key_and_tag)}</key>
+                        </keys>
+                    </header>
+                    <payload>${payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, stanza));
+
+            await new Promise((resolve) => view.model.messages.once('rendered', resolve));
+            clearInterval(interval);
+
+            expect(view.model.messages.length).toBe(1);
+            expect(view.querySelector('.chat-msg__body').textContent.trim()).toBe(plaintext);
+            expect(view.model.messages.at(0).get('is_encrypted')).toBe(true);
+            expect(view.model.messages.at(0).get('encryption_namespace')).toBe(Strophe.NS.OMEMO2);
+        }),
+    );
+
+    it(
+        'routes by which <encrypted> block addresses our device, not by the EME hint',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            const conn = _converse.api.connection.get();
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const plaintext = 'Legacy block addressed to me, even though EME says omemo:2';
+
+            // The legacy decryption path fetches the contact's (legacy) device
+            // list to mark the sending device active. Answer that IQ in the
+            // background with a list containing the sending device.
+            const dl_selector = `iq[to="${contact_jid}"] items[node="${Strophe.NS.OMEMO_DEVICELIST}"]`;
+            const interval = setInterval(() => {
+                const iq = Array.from(conn.IQ_stanzas)
+                    .filter((i) => i.querySelector(dl_selector) && !i.dataset_handled)
+                    .pop();
+                if (!iq) return;
+                iq.dataset_handled = true;
+                const result = stx`<iq from="${contact_jid}"
+                                       id="${iq.getAttribute('id')}"
+                                       to="${conn.jid}"
+                                       xmlns="jabber:server"
+                                       type="result">
+                    <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                        <items node="${Strophe.NS.OMEMO_DEVICELIST}">
+                            <item>
+                                <list xmlns="${Strophe.NS.OMEMO}">
+                                    <device id="555"/>
+                                </list>
+                            </item>
+                        </items>
+                    </pubsub>
+                </iq>`;
+                conn._dataRecv(mock.createRequest(_converse, result));
+            }, 50);
+
+            // A dual-stack sender addressed one of *their own* omemo:2 devices in
+            // the omemo:2 block (<keys jid> is the sender, not us) and addressed
+            // *us* in the legacy block. The EME hint points at omemo:2 (the
+            // newest method, meant only for clients that can decrypt neither),
+            // but our key lives only in the legacy block — we must still decrypt
+            // it instead of mis-routing to the omemo:2 path and erroring out.
+            const obj = await u.omemo.encryptMessage(plaintext);
+            const stanza = stx`<message from="${contact_jid}"
+                    to="${conn.jid}"
+                    type="chat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <body>This is a fallback message</body>
+                <encrypted xmlns="${Strophe.NS.OMEMO2}">
+                    <header sid="999">
+                        <keys jid="${contact_jid}">
+                            <key rid="111">${btoa('not-for-us')}</key>
+                        </keys>
+                    </header>
+                    <payload>${btoa('irrelevant')}</payload>
+                </encrypted>
+                <encrypted xmlns="${Strophe.NS.OMEMO}">
+                    <header sid="555">
+                        <key rid="${our_device_id}">${u.arrayBufferToBase64(obj.key_and_tag)}</key>
+                        <iv>${obj.iv}</iv>
+                    </header>
+                    <payload>${obj.payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, stanza));
+
+            await new Promise((resolve) => view.model.messages.once('rendered', resolve));
+            clearInterval(interval);
+
+            expect(view.model.messages.length).toBe(1);
+            expect(view.model.messages.at(0).get('is_error')).not.toBe(true);
+            expect(view.querySelector('.chat-msg__body').textContent.trim()).toBe(plaintext);
+        }),
+    );
+});
+
+describe('OMEMO 2 bundle parsing', function () {
+    it(
+        'parses an omemo:2 bundle element into the internal bundle format',
+        mock.initConverse(converse, [], {}, function (_converse) {
+            const bundle_el = stx`
+                <bundle xmlns="${Strophe.NS.OMEMO2}">
+                    <spk id="42">${btoa('signed-prekey-pub')}</spk>
+                    <spks>${btoa('signed-prekey-sig')}</spks>
+                    <ik>${btoa('identity-key')}</ik>
+                    <prekeys>
+                        <pk id="1">${btoa('prekey-1')}</pk>
+                        <pk id="2">${btoa('prekey-2')}</pk>
+                        <pk id="3">${btoa('prekey-3')}</pk>
+                    </prekeys>
+                </bundle>`.tree();
+
+            const bundle = u.omemo.parseBundleV2(bundle_el);
+            expect(bundle.identity_key).toBe(btoa('identity-key'));
+            expect(bundle.signed_prekey.id).toBe(42);
+            expect(bundle.signed_prekey.public_key).toBe(btoa('signed-prekey-pub'));
+            expect(bundle.signed_prekey.signature).toBe(btoa('signed-prekey-sig'));
+            expect(bundle.prekeys.length).toBe(3);
+            expect(bundle.prekeys[0]).toEqual({ id: 1, key: btoa('prekey-1') });
+            expect(bundle.prekeys[2]).toEqual({ id: 3, key: btoa('prekey-3') });
+        }),
+    );
+});
+
+describe('OMEMO 2 sending', function () {
+    it(
+        "fetches a contact's v2 devicelist on send and encrypts via omemo:2",
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+
+            // Kick off the send (don't await yet — we still have to answer the
+            // device-list and bundle fetches it triggers).
+            const rendered = mock.sendMessage(_converse, view, 'This is an omemo:2 message');
+
+            // The send path fetches the contact's devices for BOTH versions.
+            // Before the fetch-on-send fix the v2 list was never queried, so a
+            // contact whose v2 devicelist isn't already cached went out
+            // legacy-only.
+            await mock.deviceListFetched(_converse, contact_jid, ['555']);
+            await answerV2DeviceList(_converse, contact_jid, ['555']);
+
+            // Our own second (legacy-only) device still needs its bundle; the
+            // contact's device 555 is addressed via v2 (preferred on dedup).
+            await mock.bundleFetched(_converse, {
+                jid: _converse.bare_jid,
+                device_id: '482886413b977930064a5888b92134fe',
+                identity_key: '300000',
+                signed_prekey_id: '4224',
+                signed_prekey_public: '100000',
+                signed_prekey_sig: '200000',
+                prekeys: ['1991', '1992', '1993'],
+            });
+            await answerV2Bundle(_converse, contact_jid, '555');
+
+            await rendered;
+
+            const sent_stanza = await u.waitUntil(
+                () =>
+                    _converse.api.connection
+                        .get()
+                        .sent_stanzas.filter((s) => s.querySelector('encrypted'))
+                        .pop(),
+                1000,
+            );
+
+            // The contact (device 555) is addressed via an omemo:2 <encrypted>
+            // element, grouped under <keys jid="contact">.
+            const v2_enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, sent_stanza).pop();
+            expect(v2_enc).toBeTruthy();
+            expect(sizzle(`keys[jid="${contact_jid}"] key[rid="555"]`, v2_enc).length).toBe(1);
+            expect(v2_enc.querySelector('payload')).toBeTruthy();
+
+            // The EME hint advertises omemo:2 (the newest method present).
+            const eme = sizzle(`encryption[xmlns="${Strophe.NS.EME}"]`, sent_stanza).pop();
+            expect(eme.getAttribute('namespace')).toBe(Strophe.NS.OMEMO2);
+
+            // Our own legacy-only device is still addressed via the legacy
+            // element, but the contact's 555 is NOT (deduplicated to v2).
+            const legacy_enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, sent_stanza).pop();
+            expect(legacy_enc).toBeTruthy();
+            expect(sizzle(`key[rid="482886413b977930064a5888b92134fe"]`, legacy_enc).length).toBe(1);
+            expect(sizzle(`key[rid="555"]`, legacy_enc).length).toBe(0);
+        }),
+    );
+
+    it(
+        'does not drop a device whose id collides with a different JID across versions',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+
+            // Our own (non-sending) legacy device has this id. We deliberately
+            // give the *contact* an omemo:2 device with the SAME id but on a
+            // different JID. Device ids are unique only per user, so keying the
+            // cross-version dedup on the id alone would treat the contact's v2
+            // device and our own legacy device as the same physical device and
+            // drop ours — silently leaving our other device unable to read what
+            // we send. Keying on (JID, id) keeps both.
+            const shared_id = '482886413b977930064a5888b92134fe';
+
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+
+            const rendered = mock.sendMessage(_converse, view, 'Collision test');
+
+            // The contact has no legacy devices, but an omemo:2 device whose id
+            // collides with our own legacy device's id.
+            await mock.deviceListFetched(_converse, contact_jid, []);
+            await answerV2DeviceList(_converse, contact_jid, [shared_id]);
+
+            // Bundles: our own legacy device (the would-be dedup victim) and the
+            // contact's colliding omemo:2 device.
+            await mock.bundleFetched(_converse, {
+                jid: _converse.bare_jid,
+                device_id: shared_id,
+                identity_key: '300000',
+                signed_prekey_id: '4224',
+                signed_prekey_public: '100000',
+                signed_prekey_sig: '200000',
+                prekeys: ['1991', '1992', '1993'],
+            });
+            await answerV2Bundle(_converse, contact_jid, shared_id);
+
+            await rendered;
+
+            const sent_stanza = await u.waitUntil(
+                () =>
+                    _converse.api.connection
+                        .get()
+                        .sent_stanzas.filter((s) => s.querySelector('encrypted'))
+                        .pop(),
+                1000,
+            );
+
+            // The contact's omemo:2 device is addressed via the v2 element...
+            const v2_enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, sent_stanza).pop();
+            expect(sizzle(`keys[jid="${contact_jid}"] key[rid="${shared_id}"]`, v2_enc).length).toBe(1);
+
+            // ...and our OWN legacy device of the same id is STILL addressed via
+            // the legacy element. With the old id-only dedup it was dropped, so
+            // no legacy <encrypted> element would be emitted at all.
+            const legacy_enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, sent_stanza).pop();
+            expect(legacy_enc).toBeTruthy();
+            expect(sizzle(`key[rid="${shared_id}"]`, legacy_enc).length).toBe(1);
+        }),
+    );
+});
+
+describe('The OMEMO session store', function () {
+    it(
+        'scopes removeAllSessions to its own version (a legacy wipe leaves omemo:2 sessions intact)',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            await mock.initializedOMEMO(_converse);
+
+            const legacy_store = u.omemo.getVersionedStore(Strophe.NS.OMEMO);
+            const v2_store = u.omemo.getVersionedStore(Strophe.NS.OMEMO2);
+
+            // Same libsignal address in both versions. Legacy keys are stored
+            // unprefixed for backward compat, v2 keys behind a 'v2:' prefix, so
+            // the legacy key is a string-prefix of the v2 one.
+            const address = 'juliet@capulet.lit.555';
+            await legacy_store.storeSession(address, { record: 'legacy' });
+            await v2_store.storeSession(address, { record: 'v2' });
+
+            expect(await legacy_store.loadSession(address)).toBeTruthy();
+            expect(await v2_store.loadSession(address)).toBeTruthy();
+
+            // Wiping legacy sessions must not touch the v2 session that merely
+            // shares the key prefix. (Before the fix this also cleared v2.)
+            await legacy_store.removeAllSessions();
+
+            expect(await legacy_store.loadSession(address)).toBeFalsy();
+            expect(await v2_store.loadSession(address)).toBeTruthy();
+        }),
+    );
+});

--- a/src/plugins/omemo-views/tests/sce.js
+++ b/src/plugins/omemo-views/tests/sce.js
@@ -1,0 +1,131 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
+
+describe('OMEMO 2 SCE encryption', function () {
+    it(
+        'can encrypt and decrypt a message body (round-trip)',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const plaintext = 'But soft, what light through yonder airlock breaks?';
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: null };
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes);
+
+            // key_and_tag is the 48-byte tuple (32-byte content key + 16-byte HMAC)
+            expect(key_and_tag.byteLength).toBe(48);
+            expect(typeof payload).toBe('string');
+            // The ciphertext must not contain the plaintext
+            expect(atob(payload).includes(plaintext)).toBe(false);
+
+            const decrypted = await u.omemo.decryptSCE(key_and_tag, payload, {
+                sender_jid: 'romeo@montague.lit',
+            });
+            expect(decrypted).toBe(plaintext);
+        }),
+    );
+
+    it(
+        'round-trips message bodies containing XML special characters',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const plaintext = 'a < b && c > d "quoted" \'single\' <tag/>';
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: null };
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes);
+            const decrypted = await u.omemo.decryptSCE(key_and_tag, payload, {
+                sender_jid: 'romeo@montague.lit',
+            });
+            expect(decrypted).toBe(plaintext);
+        }),
+    );
+
+    it(
+        'includes a <to> affix for MUC messages and validates it on decryption',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const plaintext = 'This is a groupchat message';
+            const muc_jid = 'lounge@montague.lit';
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: muc_jid };
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes);
+
+            // Correct to_jid validates
+            const decrypted = await u.omemo.decryptSCE(key_and_tag, payload, {
+                sender_jid: 'romeo@montague.lit',
+                to_jid: muc_jid,
+            });
+            expect(decrypted).toBe(plaintext);
+
+            // Wrong to_jid is rejected
+            let error;
+            try {
+                await u.omemo.decryptSCE(key_and_tag, payload, {
+                    sender_jid: 'romeo@montague.lit',
+                    to_jid: 'wrong@montague.lit',
+                });
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error.message).toContain('affix mismatch');
+        }),
+    );
+
+    it(
+        'rejects a message whose <from> affix does not match the sender',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const plaintext = 'Spoofed message';
+            const affixes = { from_jid: 'mercutio@montague.lit', to_jid: null };
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes);
+
+            let error;
+            try {
+                await u.omemo.decryptSCE(key_and_tag, payload, {
+                    sender_jid: 'romeo@montague.lit',
+                });
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error.message).toContain('affix mismatch');
+        }),
+    );
+
+    it(
+        'rejects a payload whose HMAC does not verify',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const plaintext = 'Tamper-evident message';
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: null };
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes);
+
+            // Flip the last byte of the HMAC portion of key_and_tag
+            const tampered = key_and_tag.slice(0);
+            const view = new Uint8Array(tampered);
+            view[47] = view[47] ^ 0xff;
+
+            let error;
+            try {
+                await u.omemo.decryptSCE(tampered, payload, { sender_jid: 'romeo@montague.lit' });
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error.message).toContain('HMAC verification failed');
+        }),
+    );
+
+    it(
+        'rejects a key_and_tag that is not 48 bytes',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            let error;
+            try {
+                await u.omemo.decryptSCE(new ArrayBuffer(32), 'AAAA', { sender_jid: 'romeo@montague.lit' });
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error.message).toContain('must be 48 bytes');
+        }),
+    );
+});

--- a/src/plugins/omemo-views/tests/trust.js
+++ b/src/plugins/omemo-views/tests/trust.js
@@ -481,6 +481,79 @@ describe('OMEMO Trust Verification', function () {
                 expect(device.get('trusted')).toBe(TRUSTED);
             }),
         );
+
+        it(
+            'tracks trust per version when a device id appears in both the legacy and omemo:2 lists',
+            mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+                const { Devices } = _converse.exports;
+                const { UNDECIDED, UNTRUSTED } = _converse.constants;
+                await mock.waitForRoster(_converse, 'current', 1);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+                await mock.initializedOMEMO(_converse);
+
+                // The same physical device id is published to both the legacy and
+                // the omemo:2 device list. Each version has its own identity key
+                // (fingerprint) and therefore its own, independent trust state.
+                const legacy_devices = new Devices(null, { version: 'eu.siacs.conversations.axolotl' });
+                u.initStorage(legacy_devices, `converse.test-fp-legacy-${contact_jid}`);
+                const v2_devices = new Devices(null, { version: 'urn:xmpp:omemo:2' });
+                u.initStorage(v2_devices, `converse.test-fp-v2-${contact_jid}`);
+
+                const legacy_device = await legacy_devices.create(
+                    { id: '555', jid: contact_jid, bundle: { fingerprint: 'aaaa' } },
+                    { promise: true },
+                );
+                const v2_device = await v2_devices.create(
+                    { id: '555', jid: contact_jid, bundle: { fingerprint: 'bbbb' } },
+                    { promise: true },
+                );
+                expect(legacy_device.getVersion()).toBe('eu.siacs.conversations.axolotl');
+                expect(v2_device.getVersion()).toBe('urn:xmpp:omemo:2');
+
+                // Feed the prepared lists to the real component (bypassing the
+                // network fetch in initialize()).
+                const orig_get = _converse.api.omemo.devicelists.get;
+                _converse.api.omemo.devicelists.get = (_jid, _create, version) =>
+                    Promise.resolve(
+                        version === 'urn:xmpp:omemo:2'
+                            ? { devices: v2_devices, initialized: Promise.resolve() }
+                            : { devices: legacy_devices, initialized: Promise.resolve() },
+                    );
+
+                const el = document.createElement('converse-omemo-fingerprints');
+                el.setAttribute('jid', contact_jid);
+                document.body.appendChild(el);
+
+                // Both devices render their own fingerprint row.
+                await u.waitUntil(() => el.querySelectorAll('.fingerprint').length === 2, 1000);
+
+                expect(legacy_device.get('trusted')).toBe(UNDECIDED);
+                expect(v2_device.get('trusted')).toBe(UNDECIDED);
+
+                // Untrust the *omemo:2* device. This must update the v2 device and
+                // leave the legacy device of the same id untouched. The pre-fix
+                // handler resolved by id alone and would have written to legacy.
+                const v2_untrusted = el.querySelector(
+                    'input[type="radio"][value="-1"][data-version="urn:xmpp:omemo:2"]',
+                );
+                v2_untrusted.click();
+                await u.waitUntil(() => v2_device.get('trusted') === UNTRUSTED);
+                expect(v2_device.get('trusted')).toBe(UNTRUSTED);
+                expect(legacy_device.get('trusted')).toBe(UNDECIDED);
+
+                // Untrusting the legacy device is likewise independent.
+                const legacy_untrusted = el.querySelector(
+                    'input[type="radio"][value="-1"][data-version="eu.siacs.conversations.axolotl"]',
+                );
+                legacy_untrusted.click();
+                await u.waitUntil(() => legacy_device.get('trusted') === UNTRUSTED);
+                expect(legacy_device.get('trusted')).toBe(UNTRUSTED);
+                expect(v2_device.get('trusted')).toBe(UNTRUSTED);
+
+                _converse.api.omemo.devicelists.get = orig_get;
+                el.remove();
+            }),
+        );
     });
 
     describe('Inactive devices and trust', function () {

--- a/src/plugins/omemo-views/tests/utils.js
+++ b/src/plugins/omemo-views/tests/utils.js
@@ -1,0 +1,67 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { Strophe, stx, u } = converse.env;
+
+/**
+ * Answer a pending omemo:2 device-list fetch for `jid` with `device_ids`.
+ */
+export async function answerV2DeviceList(_converse, jid, device_ids) {
+    const conn = _converse.api.connection.get();
+    const sel = `iq[to="${jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+    const iq = await u.waitUntil(() =>
+        Array.from(conn.IQ_stanzas)
+            .filter((i) => i.querySelector(sel))
+            .pop(),
+    );
+    conn._dataRecv(
+        mock.createRequest(
+            _converse,
+            stx`<iq from="${jid}" id="${iq.getAttribute('id')}" to="${conn.jid}" xmlns="jabber:server" type="result">
+                <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                    <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                        <item>
+                            <devices xmlns="${Strophe.NS.OMEMO2_DEVICELIST}">
+                                ${device_ids.map((id) => stx`<device id="${id}"/>`)}
+                            </devices>
+                        </item>
+                    </items>
+                </pubsub>
+            </iq>`,
+        ),
+    );
+    return iq;
+}
+
+/**
+ * Answer a pending omemo:2 bundle fetch for `jid`/`device_id`.
+ */
+export async function answerV2Bundle(_converse, jid, device_id) {
+    const conn = _converse.api.connection.get();
+    const sel = `iq[to="${jid}"] items[node="${Strophe.NS.OMEMO2_BUNDLES}:${device_id}"]`;
+    const iq = await u.waitUntil(() =>
+        Array.from(conn.IQ_stanzas)
+            .filter((i) => i.querySelector(sel))
+            .pop(),
+    );
+    conn._dataRecv(
+        mock.createRequest(
+            _converse,
+            stx`<iq from="${jid}" id="${iq.getAttribute('id')}" to="${conn.jid}" xmlns="jabber:server" type="result">
+                <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                    <items node="${Strophe.NS.OMEMO2_BUNDLES}:${device_id}">
+                        <item>
+                            <bundle xmlns="${Strophe.NS.OMEMO2}">
+                                <spk id="1">${btoa('v2-spk-pub')}</spk>
+                                <spks>${btoa('v2-spk-sig')}</spks>
+                                <ik>${btoa('v2-identity-key')}</ik>
+                                <prekeys><pk id="1">${btoa('v2-pk-1')}</pk></prekeys>
+                            </bundle>
+                        </item>
+                    </items>
+                </pubsub>
+            </iq>`,
+        ),
+    );
+    return iq;
+}

--- a/src/plugins/omemo-views/utils.js
+++ b/src/plugins/omemo-views/utils.js
@@ -8,7 +8,7 @@
 import { html } from 'lit';
 import { __ } from 'i18n';
 import { until } from 'lit/directives/until.js';
-import { _converse, api, log, u, constants } from '@converse/headless';
+import { _converse, api, converse, log, u, constants } from '@converse/headless';
 import tplAudio from 'shared/texture/templates/audio.js';
 import tplFile from 'templates/file.js';
 import tplImage from 'shared/texture/templates/image.js';
@@ -16,6 +16,7 @@ import tplVideo from 'shared/texture/templates/video.js';
 import { MIMETYPES_MAP } from 'utils/file.js';
 import { getFileName } from 'utils/html.js';
 
+const { Strophe } = converse.env;
 const { CHATROOMS_TYPE } = constants;
 const { hexToArrayBuffer, isAudioURL, isError, isImageURL, isVideoURL } = u;
 
@@ -157,7 +158,7 @@ function addEncryptedFiles(text, offset, richtext) {
                 objs.push({ url, start, end });
                 return url;
             },
-            parse_options
+            parse_options,
         );
     } catch (error) {
         log.debug(error);
@@ -183,10 +184,13 @@ export function handleEncryptedFiles(richtext) {
          * @param {string} text
          * @param {number} offset
          */
-        (text, offset) => addEncryptedFiles(text, offset, richtext)
+        (text, offset) => addEncryptedFiles(text, offset, richtext),
     );
 }
 
+/**
+ * @param {import('shared/components/element').CustomElement} el
+ */
 export function onChatComponentInitialized(el) {
     el.listenTo(el.model.messages, 'add', (message) => {
         if (message.get('is_encrypted') && !message.get('is_error')) {
@@ -199,20 +203,43 @@ export function onChatComponentInitialized(el) {
         } else {
             // Manually trigger an update, setting omemo_active to
             // false above will automatically trigger one.
-            el.querySelector('converse-chat-toolbar')?.requestUpdate();
+            //
+            /*** @type {import('shared/components/element').CustomElement} */
+            (el.querySelector('converse-chat-toolbar'))?.requestUpdate();
         }
     });
     el.listenTo(el.model, 'change:omemo_active', () => {
-        el.querySelector('converse-chat-toolbar').requestUpdate();
+        /*** @type {import('shared/components/element').CustomElement} */
+        (el.querySelector('converse-chat-toolbar')).requestUpdate();
     });
 }
 
 /**
+ * Generate the displayable fingerprints for a contact's devices for a single
+ * OMEMO version.
+ * @param {string} jid
+ * @param {import('@converse/headless/types/plugins/omemo/types').OMEMOVersion} [version]
+ */
+async function generateFingerprintsForVersion(jid, version) {
+    const devices = await u.omemo.getDevicesForContact(jid, version);
+    return Promise.all(
+        devices.map(
+            /** @param {import('@converse/headless/types/plugins/omemo/device').default} d */
+            (d) => u.omemo.generateFingerprint(d),
+        ),
+    );
+}
+
+/**
+ * Generate the displayable fingerprints for a contact's devices across both
+ * OMEMO versions.
  * @param {string} jid
  */
 export async function generateFingerprints(jid) {
-    const devices = await u.omemo.getDevicesForContact(jid);
-    return Promise.all(devices.map((d) => u.omemo.generateFingerprint(d)));
+    await Promise.all([
+        generateFingerprintsForVersion(jid, Strophe.NS.OMEMO).catch((e) => log.error(e)),
+        generateFingerprintsForVersion(jid, Strophe.NS.OMEMO2).catch((e) => log.error(e)),
+    ]);
 }
 
 /**
@@ -238,14 +265,14 @@ function toggleOMEMO(ev) {
             messages = [
                 __(
                     'Cannot use end-to-end encryption in this groupchat, ' +
-                        'either the groupchat has some anonymity or not all participants support OMEMO.'
+                        'either the groupchat has some anonymity or not all participants support OMEMO.',
                 ),
             ];
         } else {
             messages = [
                 __(
                     "Cannot use end-to-end encryption because %1$s uses a client that doesn't support OMEMO.",
-                    toolbar_el.model.contact.getDisplayName()
+                    toolbar_el.model.contact.getDisplayName(),
                 ),
             ];
         }
@@ -269,7 +296,7 @@ export function getOMEMOToolbarButton(toolbar_el, buttons) {
     } else if (is_muc) {
         title = __(
             'This groupchat needs to be members-only and non-anonymous in ' +
-                'order to support OMEMO encrypted messages'
+                'order to support OMEMO encrypted messages',
         );
     } else {
         title = __('OMEMO encryption is not supported');

--- a/src/plugins/profile/tests/csi.js
+++ b/src/plugins/profile/tests/csi.js
@@ -1,4 +1,7 @@
 import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const { u } = converse.env;
 
 describe('A chat state indication', function () {
     it(
@@ -89,6 +92,37 @@ describe('Automatic status change', function () {
 
             _converse.onUserActivity();
             expect(await _converse.api.user.status.get()).toBe('dnd');
+        }),
+    );
+
+    it(
+        'broadcasts an online presence to contacts when the user returns from auto-away',
+        mock.initConverse(converse, ['statusInitialized'], {}, async (_converse) => {
+            const { api } = _converse;
+            api.settings.set('auto_away', 3);
+
+            let i = 0;
+            while (i <= api.settings.get('auto_away')) {
+                _converse.onEverySecond();
+                i++;
+            }
+            expect(await api.user.status.get()).toBe('away');
+
+            const sent_stanzas = api.connection.get().sent_stanzas;
+
+            _converse.onUserActivity();
+            expect(await api.user.status.get()).toBe('online');
+
+            // Returning from auto-away must reach the network: the latest presence
+            // broadcast has no <show> (i.e. online), so contacts stop seeing the
+            // stale 'away'. Before clearing `show` actually notified, the last
+            // presence on the wire stayed the away one and this would time out.
+            const presence = await u.waitUntil(() => {
+                const presences = sent_stanzas.filter((s) => s.nodeName === 'presence');
+                const last = presences[presences.length - 1];
+                return last && !last.querySelector('show') ? last : null;
+            });
+            expect(presence.querySelector('show')).toBe(null);
         }),
     );
 });

--- a/src/plugins/profile/tests/status.js
+++ b/src/plugins/profile/tests/status.js
@@ -1,7 +1,7 @@
 import mock from '../../../shared/tests/mock.js';
 import converse from '../../../../dist/converse.js';
 
-const {u, Strophe} = converse.env;
+const { u, Strophe } = converse.env;
 
 describe('The Controlbox', function () {
     describe('The Status Widget', function () {
@@ -34,7 +34,7 @@ describe('The Controlbox', function () {
                     <show>dnd</show>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
                 const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));
                 const first_child = view.querySelector('.xmpp-status span:first-child');
@@ -65,7 +65,7 @@ describe('The Controlbox', function () {
                     <status>I am happy</status>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
 
                 const view = await u.waitUntil(() => document.querySelector('converse-user-profile'));

--- a/src/plugins/profile/utils.js
+++ b/src/plugins/profile/utils.js
@@ -154,7 +154,18 @@ export function registerIntervalHandler() {
     window.addEventListener('keypress', onUserActivity);
     window.addEventListener('mousemove', onUserActivity);
     window.addEventListener(u.getUnloadEvent(), onUserActivity, { 'once': true, 'passive': true });
-    everySecondTrigger = setInterval(onEverySecond, 1000);
+
+    // Clear any existing interval first, otherwise a reconnect (which fires
+    // `connected` again) orphans the previous timer: it keeps ticking
+    // `onEverySecond` and advances `idle_seconds` too fast.
+    clearInterval(everySecondTrigger);
+
+    // Don't run the real timer under test: the tests drive `onEverySecond`
+    // manually, and a background tick racing that would make CSI/auto-away
+    // fire a second early.
+    if (!u.isTestEnv()) {
+        everySecondTrigger = setInterval(onEverySecond, 1000);
+    }
 }
 
 export function tearDown() {

--- a/src/plugins/rosterview/tests/presence.js
+++ b/src/plugins/rosterview/tests/presence.js
@@ -32,7 +32,7 @@ describe('A sent presence stanza', function () {
                 <status>My custom status</status>
                 <priority>0</priority>
                 <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
             </presence>`);
 
             cbview.querySelector('.change-status').click();
@@ -49,7 +49,7 @@ describe('A sent presence stanza', function () {
                     <status>My custom status</status>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>`);
         }),
     );

--- a/src/plugins/rosterview/tests/protocol.js
+++ b/src/plugins/rosterview/tests/protocol.js
@@ -159,7 +159,7 @@ describe('Presence subscriptions', function () {
                     <nick xmlns="http://jabber.org/protocol/nick">Romeo</nick>
                     <priority>0</priority>
                     <x xmlns="${Strophe.NS.VCARD_UPDATE}"></x>
-                    <c hash="sha-1" node="https://conversejs.org" ver="Hbd4V8rlZualGDSkxW/4bVlnudc=" xmlns="http://jabber.org/protocol/caps"/>
+                    <c hash="sha-1" node="https://conversejs.org" ver="aU8gtptxi4fPJB8IPibd7tJbTLE=" xmlns="http://jabber.org/protocol/caps"/>
                 </presence>
             `);
 

--- a/src/shared/tests/mock.js
+++ b/src/shared/tests/mock.js
@@ -222,6 +222,8 @@ window.libomemo.OMEMOAddress.prototype.toString = function () {
     return this.name + '.' + this.deviceId;
 };
 Object.assign(window.libomemo, {
+    // Mock Ed25519 key conversion: just return the input as-is (real impl converts Curve25519 → Ed25519)
+    'curvePubKeyToEd25519PubKey': async (curve_key) => new Uint8Array(curve_key).slice(0, 32).buffer,
     'SessionCipher': function (storage, remote_address) {
         this.remoteAddress = remote_address;
         this.storage = storage;
@@ -398,6 +400,23 @@ function bundleHasBeenPublished(_converse) {
         .pop();
 }
 
+function v2BundleHasBeenPublished(_converse) {
+    const { Strophe } = _converse.env;
+    const selector = `publish[node="${Strophe.NS.OMEMO2_BUNDLES}:123456789"]`;
+    return Array.from(_converse.api.connection.get().IQ_stanzas)
+        .filter((iq) => iq.querySelector(selector))
+        .pop();
+}
+
+function ownV2DeviceHasBeenPublished(_converse) {
+    const { Strophe } = _converse.env;
+    return Array.from(_converse.api.connection.get().IQ_stanzas)
+        .filter((iq) =>
+            iq.querySelector(`iq[from="${_converse.bare_jid}"] publish[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`),
+        )
+        .pop();
+}
+
 function bundleIQRequestSent(_converse, jid, device_id) {
     return Array.from(_converse.api.connection.get().IQ_stanzas)
         .filter((iq) =>
@@ -437,38 +456,157 @@ async function bundleFetched(
     _converse.api.connection.get()._dataRecv(createRequest(_converse, stanza));
 }
 
+/**
+ * Sends an empty IQ result for the given request stanza.
+ */
+function sendIQResult(_converse, iq_stanza) {
+    const { stx } = _converse.env;
+    const stanza = stx`<iq from="${_converse.bare_jid}"
+                            id="${iq_stanza.getAttribute('id')}"
+                            to="${_converse.bare_jid}"
+                            type="result"
+                            xmlns="jabber:client"/>`;
+    _converse.api.connection.get()._dataRecv(createRequest(_converse, stanza));
+}
+
+// Responds to the v2 (urn:xmpp:omemo:2) IQs which are published in the
+// background during OMEMO initialization.
+const deferred_v2_jids = new Set();
+
+// The currently-running background v2 responder's stop function. Persisted at
+// module scope so each `initializedOMEMO` can stop the previous one and start a
+// fresh one bound to the current connection (the responder must outlive
+// `initializedOMEMO` itself, since sends happen afterwards).
+let stop_v2_responder = null;
+
+/**
+ * Mark a contact's omemo:2 device list as test-managed: the background
+ * responder will not auto-answer its fetch, leaving the test to provide it.
+ * @param {string} jid
+ */
+function deferV2DeviceList(jid) {
+    deferred_v2_jids.add(jid);
+}
+
+function startV2Responder(_converse) {
+    const { stx, Strophe } = _converse.env;
+    const handled = new WeakSet();
+    let active = true;
+
+    const respond = () => {
+        if (!active) return;
+        const conn = _converse.api.connection.get();
+        if (!conn) return;
+        const iqs = Array.from(conn.IQ_stanzas);
+
+        // Own v2 device list fetch
+        const v2_fetch_selector = `iq[to="${_converse.bare_jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+        iqs.filter((iq) => !handled.has(iq) && iq.querySelector(v2_fetch_selector)).forEach((iq) => {
+            handled.add(iq);
+            const result = stx`<iq from="${_converse.bare_jid}"
+                                   id="${iq.getAttribute('id')}"
+                                   to="${conn.jid}"
+                                   xmlns="jabber:server"
+                                   type="result">
+                <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                    <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                        <item><devices xmlns="${Strophe.NS.OMEMO2_DEVICELIST}"/></item>
+                    </items>
+                </pubsub>
+            </iq>`;
+            conn._dataRecv(createRequest(_converse, result));
+        });
+
+        // Contact v2 device list fetch — answer with an empty list (no omemo:2
+        // entry) unless the test opted to manage this jid itself. This keeps the
+        // many legacy send tests working now that the send path fetches each
+        // contact's v2 device list.
+        iqs.filter(
+            (iq) =>
+                !handled.has(iq) &&
+                iq.getAttribute('to') &&
+                iq.getAttribute('to') !== _converse.bare_jid &&
+                iq.querySelector(`items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`),
+        ).forEach((iq) => {
+            const to = iq.getAttribute('to');
+            if (deferred_v2_jids.has(to)) return;
+            handled.add(iq);
+            const result = stx`<iq from="${to}"
+                                   id="${iq.getAttribute('id')}"
+                                   to="${conn.jid}"
+                                   xmlns="jabber:server"
+                                   type="result">
+                <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                    <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                        <item><devices xmlns="${Strophe.NS.OMEMO2_DEVICELIST}"/></item>
+                    </items>
+                </pubsub>
+            </iq>`;
+            conn._dataRecv(createRequest(_converse, result));
+        });
+
+        // v2 device list publish + v2 bundle publish (both answered with empty result)
+        const publish_v2 = (iq) =>
+            iq.querySelector(`iq[from="${_converse.bare_jid}"] publish[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`) ||
+            iq.querySelector(`publish[node="${Strophe.NS.OMEMO2_BUNDLES}:123456789"]`);
+        iqs.filter((iq) => !handled.has(iq) && publish_v2(iq)).forEach((iq) => {
+            handled.add(iq);
+            sendIQResult(_converse, iq);
+        });
+    };
+
+    const interval = setInterval(respond, 50);
+    return () => {
+        active = false;
+        clearInterval(interval);
+    };
+}
+
 async function initializedOMEMO(
     _converse,
     identities = [{ 'category': 'pubsub', 'type': 'pep' }],
     features = ['http://jabber.org/protocol/pubsub#publish-options'],
 ) {
-    const { stx, u } = _converse.env;
+    const { u } = _converse.env;
     await waitUntilDiscoConfirmed(_converse, _converse.bare_jid, identities, features);
+
+    // Respond to the background v2 IQs throughout initialization *and* for the
+    // rest of the test — the send path fetches each contact's v2 device list,
+    // which happens after this helper returns. Stop any responder left over from
+    // a previous test and reset the test-managed jids, then start a fresh one
+    // bound to the current connection. The responder only ever answers omemo:2
+    // IQs, so if it outlives the test it's a no-op for non-OMEMO tests and is
+    // replaced by the next `initializedOMEMO`.
+    stop_v2_responder?.();
+    deferred_v2_jids.clear();
+    stop_v2_responder = startV2Responder(_converse);
+
+    // Respond to legacy device list fetch
     await deviceListFetched(_converse, _converse.bare_jid, ['482886413b977930064a5888b92134fe']);
+
+    // Respond to legacy device list publish
     let iq_stanza = await u.waitUntil(() => ownDeviceHasBeenPublished(_converse));
+    sendIQResult(_converse, iq_stanza);
 
-    let stanza = stx`<iq from="${_converse.bare_jid}"
-                          id="${iq_stanza.getAttribute('id')}"
-                          to="${_converse.bare_jid}"
-                          type="result"
-                          xmlns="jabber:client"/>`;
-    _converse.api.connection.get()._dataRecv(createRequest(_converse, stanza));
-
+    // Respond to legacy bundle publish
     iq_stanza = await u.waitUntil(() => bundleHasBeenPublished(_converse));
+    sendIQResult(_converse, iq_stanza);
 
-    stanza = stx`<iq from="${_converse.bare_jid}"
-                          id="${iq_stanza.getAttribute('id')}"
-                          to="${_converse.bare_jid}"
-                          type="result"
-                          xmlns="jabber:client"/>`;
-    _converse.api.connection.get()._dataRecv(createRequest(_converse, stanza));
     await _converse.api.waitUntil('OMEMOInitialized');
+
+    // Drain any trailing background v2 IQs — the v2 device-list and bundle
+    // publishes can land just after OMEMOInitialized.
+    for (let i = 0; i < 4; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
 }
 
 export default {
     bundleFetched,
     bundleHasBeenPublished,
     bundleIQRequestSent,
+    v2BundleHasBeenPublished,
+    ownV2DeviceHasBeenPublished,
     chatroom_names,
     chatroom_roles,
     checkHeaderToggling,
@@ -482,6 +620,7 @@ export default {
     cur_names,
     current_contacts_map,
     default_muc_features,
+    deferV2DeviceList,
     deviceListFetched,
     event,
     getContactJID,

--- a/src/types/plugins/omemo-views/fingerprints.d.ts
+++ b/src/types/plugins/omemo-views/fingerprints.d.ts
@@ -3,16 +3,31 @@ export class Fingerprints extends CustomElement {
         jid: {
             type: StringConstructor;
         };
+        loading: {
+            type: BooleanConstructor;
+            state: boolean;
+        };
         show_inactive_devices: {
             type: BooleanConstructor;
             state: boolean;
         };
     };
     jid: any;
+    loading: boolean;
     show_inactive_devices: boolean;
-    initialize(): Promise<void>;
-    devicelist: any;
-    render(): import("lit-html").TemplateResult<1> | "";
+    /**
+     * Fetch both the legacy and the omemo:2 device lists in the background so
+     * neither blocks rendering; each renders its devices as soon as it resolves.
+     * A failure (e.g. on a server without omemo:2 support) must not block the
+     * other list. The loading flag is cleared once both have settled so the
+     * empty state only shows when there genuinely are no devices.
+     */
+    fetchDeviceLists(): void;
+    devicelist: import("@converse/headless").DeviceList;
+    devicelist_v2: import("@converse/headless").DeviceList;
+    /** Returns all devices (legacy + v2) as a flat array for rendering. */
+    getAllDevices(): any[];
+    render(): import("lit-html").TemplateResult<1>;
     /**
      * @param {Event} ev
      */

--- a/src/types/plugins/omemo-views/utils.d.ts
+++ b/src/types/plugins/omemo-views/utils.d.ts
@@ -10,11 +10,16 @@ export function formatFingerprintForQRCode(fp: string): string;
  * @param {import('shared/texture/texture.js').Texture} richtext
  */
 export function handleEncryptedFiles(richtext: import("shared/texture/texture.js").Texture): void;
-export function onChatComponentInitialized(el: any): void;
 /**
+ * @param {import('shared/components/element').CustomElement} el
+ */
+export function onChatComponentInitialized(el: import("shared/components/element").CustomElement): void;
+/**
+ * Generate the displayable fingerprints for a contact's devices across both
+ * OMEMO versions.
  * @param {string} jid
  */
-export function generateFingerprints(jid: string): Promise<any[]>;
+export function generateFingerprints(jid: string): Promise<void>;
 /**
  * @param {string} jid
  * @param {string} device_id


### PR DESCRIPTION
New profiles.js with per-version profile objects (LEGACY_VERSION/OMEMO2_VERSION) SCE payload crypto (new sce.js):

Store dual identity material:
  - VersionedOMEMOStore proxy for version-namespaced session/identity storage (legacy unprefixed, v2 uses 'v2:' prefix)
  - Separate signed prekey per version (v2 signature covers 32-byte curve form)
  - generateBundle() now generates both legacy and v2 signed prekeys
  - publishBundle() publishes both PEP nodes; _publishV2Bundle() strips leading byte from curve keys and converts IK to Ed25519 via curvePubKeyToEd25519PubKey

Dual devicelists:
  - Two separate DeviceLists collections: devicelists (legacy) + devicelists_v2 (v2)
  - getDeviceList(jid, create, version) is backward-compatible (version defaults to legacy)
  - api.omemo.devicelists.get() accepts optional version parameter
  - Advertise urn:xmpp:omemo:2:devices+notify in client features

Sending:
  - getBundlesAndBuildSessions() unions devices from both version devicelists
  - createOMEMOMessageStanza() produces both <encrypted> elements in one stanza
  - getSessionCipher/buildSession/encryptKey/getSession all accept version param

Receiving:
  - parseEncryptedMessage() routes by encryption_namespace to legacy or v2 path
  - getEncryptionAttributes() in shared/parsers.js detects urn:xmpp:omemo:2

Version-aware fingerprints and trust UI
  - generateFingerprint() strips the legacy 0x05 encoding byte from the stored fingerprint hex for consistent 64-char display; v2 identity keys are stored as-is (already 32-byte Ed25519, no prefix)
  - Fingerprints component loads both legacy and v2 device lists and combines them for display; trust is tracked per-device per-version
  - toggleDeviceTrust looks up the device in either collection
  - formatFingerprint() ^05 strip remains for backward compat with old data
