### PR TITLE
feat(omemo): send heartbeat messages on ratchet counter >= 53

### DIFF
--- a/src/headless/package.json
+++ b/src/headless/package.json
@@ -63,7 +63,7 @@
     "dayjs": "^1.11.8",
     "dompurify": "^3.0.8",
     "filesize": "^11.0.13",
-    "libomemo.js": "^2.0.0-rc.1",
+    "libomemo.js": "^2.0.0-rc.2",
     "localforage-webextensionstorage-driver": "^3.0.0",
     "lodash-es": "^4.17.21",
     "pluggable.js": "3.0.1",

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -10,10 +10,23 @@ import api from '../../shared/api/index.js';
 import _converse from '../../shared/_converse.js';
 import converse from '../../shared/api/public.js';
 import u from '../../utils/index.js';
-import { decryptMessage, getSessionCipher } from './utils.js';
+import { decryptMessage, getSessionCipher, sendOMEMOHeartbeat } from './utils.js';
+import { getCrypto } from './crypto.js';
+import { VersionedOMEMOStore } from './versioned-store.js';
 import { decryptSCE } from './sce.js';
 
 const { Strophe } = converse.env;
+
+// XEP-0384: "When a client receives the first message for a given ratchet key
+// with a counter of 53 or higher, it MUST send a heartbeat message."
+const HEARTBEAT_COUNTER_THRESHOLD = 53;
+
+// Synchronous guard to prevent concurrent heartbeat sends for the same session.
+// Two decryptions arriving in the same tick could both pass the store.loadHeartbeatKey
+// check before either storeHeartbeatKey() completes. This Set is checked and mutated
+// synchronously (no await), so it closes that window. The store check still handles
+// page reloads (the Set is cleared on reload).
+const heartbeat_in_flight = new Set();
 
 const DECRYPTION_ERROR_ATTRS = {
     error_type: 'Decryption',
@@ -79,8 +92,9 @@ function getJIDForDecryption(attrs) {
         from_jid = _converse.session.get('bare_jid');
     } else if (attrs.contact_jid) {
         from_jid = attrs.contact_jid;
-    } else if ('from_real_jid' in attrs) {
-        from_jid = attrs.from_real_jid;
+    } else if (attrs.type === 'groupchat') {
+        // MUC message: from_real_jid is the occupant's real JID, set by the MUC parser.
+        from_jid = /** @type {MUCMessageAttributes} */ (attrs).from_real_jid;
     } else {
         from_jid = attrs.from;
     }
@@ -99,6 +113,66 @@ function getJIDForDecryption(attrs) {
         throw new Error('Could not find JID to decrypt OMEMO message for');
     }
     return from_jid;
+}
+
+/**
+ * Implements the XEP-0384 heartbeat rule: when we've just decrypted the first
+ * message for a given ratchet key whose counter is >= 53, send a heartbeat (an
+ * empty OMEMO message) to forward the ratchet. We send at most one heartbeat per
+ * ratchet key; the dedup is persisted in the (versioned) OMEMO store so it
+ * survives page reloads (the peer only restarts its counter at 0 a round-trip
+ * after processing our heartbeat). Best-effort and fire-and-forget — failures
+ * are logged, never surfaced to the user.
+ *
+ * The legacy heartbeat is a `KeyTransportElement` (XEP-0384 0.3.0), which the
+ * older protocol defines and conforming clients already handle.
+ * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @param {string} from_jid - the (real) bare JID identifying the OMEMO session
+ * @param {string|number} device_id - the sender's device id
+ * @param {{counter: number, key: ArrayBuffer}|undefined} ratchet - from the decrypt result
+ * @param {import('./types').OMEMOVersion} version
+ */
+async function maybeSendOMEMOHeartbeat(attrs, from_jid, device_id, ratchet, version) {
+    if (!ratchet || ratchet.counter < HEARTBEAT_COUNTER_THRESHOLD) return;
+
+    const { OMEMOAddress } = await getCrypto();
+    const address = new OMEMOAddress(from_jid, parseInt(`${device_id}`, 10)).toString();
+    const ratchet_key_b64 = u.arrayBufferToBase64(ratchet.key);
+
+    if (heartbeat_in_flight.has(address)) return;
+    heartbeat_in_flight.add(address);
+    try {
+        const store = new VersionedOMEMOStore(_converse.state.omemo_store, version);
+        if (store.loadHeartbeatKey(address) === ratchet_key_b64) return;
+
+        // Send to the MUC room (groupchat) or the contact (1:1). The session is
+        // keyed by the sender's real JID, but the heartbeat is addressed to the chat.
+        // For MUC messages, attrs.from is the room JID and attrs.type is 'groupchat'.
+        // For 1:1, from_jid is the contact's bare JID (the chatbox key).
+        const chat_jid = attrs.type === 'groupchat' ? Strophe.getBareJidFromJid(attrs.from) : from_jid;
+        const chat = _converse.state.chatboxes?.get(chat_jid);
+        if (!chat) return;
+
+        await sendOMEMOHeartbeat(chat, version);
+        await store.storeHeartbeatKey(address, ratchet_key_b64);
+    } finally {
+        heartbeat_in_flight.delete(address);
+    }
+}
+
+/**
+ * Fire-and-forget wrapper around {@link maybeSendOMEMOHeartbeat}. Logs errors
+ * instead of letting them propagate to the caller.
+ * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @param {string} from_jid - the (real) bare JID identifying the OMEMO session
+ * @param {string|number} device_id - the sender's device id
+ * @param {{counter: number, key: ArrayBuffer}|undefined} ratchet - from the decrypt result
+ * @param {import('./types').OMEMOVersion} version
+ */
+function fireHeartbeat(attrs, from_jid, device_id, ratchet, version) {
+    maybeSendOMEMOHeartbeat(attrs, from_jid, device_id, ratchet, version).catch((e) =>
+        log.error(`Could not send OMEMO heartbeat: ${e}`),
+    );
 }
 
 /**
@@ -134,9 +208,15 @@ async function decryptWhisperMessage(attrs) {
     const session_cipher = await getSessionCipher(from_jid, parseInt(attrs.encrypted.device_id, 10));
     const key = u.base64ToArrayBuffer(attrs.encrypted.key);
     try {
-        const key_and_tag = await session_cipher.decryptWhisperMessage(key, 'binary');
+        const { plaintext: key_and_tag, ratchet } = await session_cipher.decryptWhisperMessage(key, 'binary');
         const plaintext = await handleDecryptedWhisperMessage(attrs, key_and_tag);
-        return Object.assign(attrs, { plaintext });
+        fireHeartbeat(attrs, from_jid, attrs.encrypted.device_id, ratchet, Strophe.NS.OMEMO);
+        if (plaintext) {
+            return Object.assign(attrs, { plaintext });
+        } else {
+            // Empty/heartbeat message (KeyTransportElement with no <payload>).
+            return Object.assign(attrs, { 'is_only_key': true });
+        }
     } catch (e) {
         return handleDecryptionError(attrs, e);
     }
@@ -149,20 +229,13 @@ async function decryptPrekeyWhisperMessage(attrs) {
     const from_jid = getJIDForDecryption(attrs);
     const session_cipher = await getSessionCipher(from_jid, parseInt(attrs.encrypted.device_id, 10));
     const key = u.base64ToArrayBuffer(attrs.encrypted.key);
-    let key_and_tag;
+    let key_and_tag, ratchet;
     try {
-        key_and_tag = await session_cipher.decryptPreKeyWhisperMessage(key, 'binary');
+        ({ plaintext: key_and_tag, ratchet } = await session_cipher.decryptPreKeyWhisperMessage(key, 'binary'));
     } catch (e) {
         return handleDecryptionError(attrs, e);
     }
-    // TODO from the XEP:
-    // When a client receives the first message for a given
-    // ratchet key with a counter of 53 or higher, it MUST send
-    // a heartbeat message. Heartbeat messages are normal OMEMO
-    // encrypted messages where the SCE payload does not include
-    // any elements. These heartbeat messages cause the ratchet
-    // to forward, thus consequent messages will have the
-    // counter restarted from 0.
+    fireHeartbeat(attrs, from_jid, attrs.encrypted.device_id, ratchet, Strophe.NS.OMEMO);
     try {
         const plaintext = await handleDecryptedWhisperMessage(attrs, key_and_tag);
         const { omemo_store } = _converse.state;
@@ -261,20 +334,25 @@ async function decryptOMEMO2Message(stanza, attrs) {
 
     const session_cipher = await getSessionCipher(from_jid, parseInt(sender_device_id, 10), Strophe.NS.OMEMO2);
 
-    let key_and_tag;
+    let key_and_tag, ratchet;
     try {
         if (is_kex) {
-            key_and_tag = await session_cipher.decryptPreKeyWhisperMessage(key_bytes, 'binary');
+            ({ plaintext: key_and_tag, ratchet } = await session_cipher.decryptPreKeyWhisperMessage(
+                key_bytes,
+                'binary',
+            ));
             // After handling a key exchange, regenerate and publish prekeys
             const { omemo_store } = _converse.state;
             await omemo_store.generateMissingPreKeys();
             await omemo_store.publishBundle();
         } else {
-            key_and_tag = await session_cipher.decryptWhisperMessage(key_bytes, 'binary');
+            ({ plaintext: key_and_tag, ratchet } = await session_cipher.decryptWhisperMessage(key_bytes, 'binary'));
         }
     } catch (e) {
         return handleDecryptionError(attrs, e);
     }
+
+    fireHeartbeat(attrs, from_jid, sender_device_id, ratchet, Strophe.NS.OMEMO2);
 
     if (!attrs.encrypted.payload) {
         // Empty/heartbeat message
@@ -282,7 +360,7 @@ async function decryptOMEMO2Message(stanza, attrs) {
     }
 
     try {
-        const is_muc = 'from_real_jid' in attrs;
+        const is_muc = attrs.type === 'groupchat';
         const muc_jid = is_muc ? attrs.from : null;
         const plaintext = await decryptSCE(key_and_tag, attrs.encrypted.payload, {
             sender_jid: from_jid,

--- a/src/headless/plugins/omemo/store.js
+++ b/src/headless/plugins/omemo/store.js
@@ -215,7 +215,31 @@ class OMEMOStore extends Model {
      * @param {string} address
      */
     removeSession(address) {
+        // Drop the heartbeat marker (see {@link loadHeartbeatKey}) together with
+        // the session, so a rebuilt session starts with a clean slate.
+        this.unset('heartbeat:' + address);
         return Promise.resolve(this.unset('session' + address));
+    }
+
+    /**
+     * The ratchet key (base64) for which we last sent an OMEMO heartbeat to this
+     * session, or `undefined`. Used to enforce the XEP-0384 rule of sending at
+     * most one heartbeat per ratchet key, in a way that survives page reloads.
+     * @param {string} address
+     * @returns {string|undefined}
+     */
+    loadHeartbeatKey(address) {
+        return this.get('heartbeat:' + address);
+    }
+
+    /**
+     * Records and persists the ratchet key we just heartbeated for.
+     * @param {string} address
+     * @param {string} key_b64 - base64 of the ratchet key we just heartbeated for
+     * @returns {Promise<void>}
+     */
+    storeHeartbeatKey(address, key_b64) {
+        return this.save('heartbeat:' + address, key_b64, { promise: true });
     }
 
     /**

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -668,6 +668,80 @@ function groupByJID(dicts) {
 }
 
 /**
+ * Encrypt the given key material with the long-standing OMEMO session of each
+ * eligible (trusted + active) recipient device.
+ * @param {ArrayBuffer} key_and_tag
+ * @param {import('./device').default[]} devices
+ * @param {import('./types').OMEMOVersion} version
+ */
+function encryptKeyForDevices(key_and_tag, devices, version) {
+    return Promise.all(
+        devices
+            .filter((d) => d.get('trusted') != UNTRUSTED && d.get('active'))
+            .map((d) => encryptKey(key_and_tag, d, version)),
+    );
+}
+
+/**
+ * Build a legacy (eu.siacs.conversations.axolotl) `<encrypted>` element from
+ * the per-device encrypted keys. When `payload` is null the result is a
+ * KeyTransportElement (the `<payload>` is omitted), as used for heartbeats.
+ * @param {Array<{payload: import('libomemo.js').EncryptResult, device: import('./device.js').default}>} legacy_dicts
+ * @param {string} iv
+ * @param {string|null} payload
+ */
+function buildLegacyEncryptedElement(legacy_dicts, iv, payload) {
+    const sid = _converse.state.omemo_store.get('device_id');
+
+    // An encrypted header is added to the message for each device that is
+    // supposed to receive it. These headers simply contain the key that the
+    // payload message is encrypted with, and they are separately encrypted
+    // using the session corresponding to the counterpart device.
+    return stx`<encrypted xmlns="${Strophe.NS.OMEMO}">
+            <header sid="${sid}">
+                ${legacy_dicts.map(({ payload: p, device }) => {
+                    const prekey = 3 == p.type;
+                    if (prekey) {
+                        return stx`<key rid="${device.get('id')}" prekey="true">${btoa(p.body)}</key>`;
+                    }
+                    return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
+                })}
+                <iv>${iv}</iv>
+            </header>
+            ${payload ? stx`<payload>${payload}</payload>` : ''}
+        </encrypted>`;
+}
+
+/**
+ * Build an OMEMO:2 (urn:xmpp:omemo:2) `<encrypted>` element from the per-device
+ * encrypted keys. When `payload` is null the `<payload>` is omitted, yielding
+ * an empty OMEMO message (used for heartbeats).
+ * @param {Array<{payload: import('libomemo.js').EncryptResult, device: import('./device.js').default}>} v2_dicts
+ * @param {string|null} payload
+ */
+function buildOMEMO2EncryptedElement(v2_dicts, payload) {
+    // Group keys by recipient JID for the v2 <keys jid='...'> structure
+    const by_jid = groupByJID(v2_dicts);
+    const keys_elements = [];
+    for (const [jid, entries] of by_jid) {
+        const key_els = entries.map(({ payload: p, device }) => {
+            if (p.kex) {
+                return stx`<key rid="${device.get('id')}" kex="true">${btoa(p.body)}</key>`;
+            }
+            return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
+        });
+        keys_elements.push(stx`<keys jid="${jid}">${key_els}</keys>`);
+    }
+
+    const sid = _converse.state.omemo_store.get('device_id');
+
+    return stx`<encrypted xmlns="${Strophe.NS.OMEMO2}">
+            <header sid="${sid}">${keys_elements}</header>
+            ${payload ? stx`<payload>${payload}</payload>` : ''}
+        </encrypted>`;
+}
+
+/**
  * @param {import('../../shared/message').default} message
  * @param {import('./device').default[]} devices
  */
@@ -680,33 +754,8 @@ async function getLegacyEncryptedElement(message, devices) {
     // devices associated with the contact, the result of this
     // concatenation is encrypted using the corresponding
     // long-standing OMEMO session.
-    const legacy_dicts = await Promise.all(
-        devices
-            .filter((d) => d.get('trusted') != UNTRUSTED && d.get('active'))
-            .map((d) => encryptKey(key_and_tag, d, Strophe.NS.OMEMO)),
-    );
-
-    const sid = _converse.state.omemo_store.get('device_id');
-
-    // An encrypted header is added to the message for
-    // each device that is supposed to receive it.
-    // These headers simply contain the key that the
-    // payload message is encrypted with,
-    // and they are separately encrypted using the
-    // session corresponding to the counterpart device.
-    return stx`<encrypted xmlns="${Strophe.NS.OMEMO}">
-            <header sid="${sid}">
-                ${legacy_dicts.map(({ payload: p, device }) => {
-                    const prekey = 3 == p.type;
-                    if (prekey) {
-                        return stx`<key rid="${device.get('id')}" prekey="true">${btoa(p.body)}</key>`;
-                    }
-                    return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
-                })}
-                <iv>${iv}</iv>
-            </header>
-            <payload>${payload}</payload>
-        </encrypted>`;
+    const legacy_dicts = await encryptKeyForDevices(key_and_tag, devices, Strophe.NS.OMEMO);
+    return buildLegacyEncryptedElement(legacy_dicts, iv, payload);
 }
 
 /**
@@ -725,31 +774,69 @@ async function getOMEMO2EncryptedElement(chat, message, devices) {
         to_jid: muc_jid,
     });
 
-    const v2_dicts = await Promise.all(
-        devices
-            .filter((d) => d.get('trusted') != UNTRUSTED && d.get('active'))
-            .map((d) => encryptKey(key_and_tag, d, Strophe.NS.OMEMO2)),
-    );
+    const v2_dicts = await encryptKeyForDevices(key_and_tag, devices, Strophe.NS.OMEMO2);
+    return buildOMEMO2EncryptedElement(v2_dicts, payload);
+}
 
-    // Group keys by recipient JID for the v2 <keys jid='...'> structure
-    const by_jid = groupByJID(v2_dicts);
-    const keys_elements = [];
-    for (const [jid, entries] of by_jid) {
-        const key_els = entries.map(({ payload: p, device }) => {
-            if (p.kex) {
-                return stx`<key rid="${device.get('id')}" kex="true">${btoa(p.body)}</key>`;
-            }
-            return stx`<key rid="${device.get('id')}">${btoa(p.body)}</key>`;
-        });
-        keys_elements.push(stx`<keys jid="${jid}">${key_els}</keys>`);
-    }
+/**
+ * Build a legacy heartbeat (KeyTransportElement): a fresh key/IV pair with no
+ * `<payload>` (XEP-0384 0.3.0 §Sending a key). Encrypting an empty plaintext
+ * with AES-GCM yields a valid 16-byte authentication tag and empty ciphertext,
+ * so we reuse {@link encryptMessage} and simply drop the payload.
+ * @param {import('./device').default[]} devices
+ */
+async function getLegacyHeartbeatElement(devices) {
+    const { key_and_tag, iv } = await encryptMessage('');
+    const legacy_dicts = await encryptKeyForDevices(key_and_tag, devices, Strophe.NS.OMEMO);
+    return buildLegacyEncryptedElement(legacy_dicts, iv, null);
+}
 
-    const sid = _converse.state.omemo_store.get('device_id');
+/**
+ * Build an OMEMO:2 heartbeat (empty OMEMO message): per XEP-0384, 32 zero-bytes
+ * are encrypted directly with the Double Ratchet session for each device and the
+ * `<payload>` is omitted altogether.
+ * @param {import('./device').default[]} devices
+ */
+async function getOMEMO2HeartbeatElement(devices) {
+    const zero_bytes = new ArrayBuffer(32);
+    const v2_dicts = await encryptKeyForDevices(zero_bytes, devices, Strophe.NS.OMEMO2);
+    return buildOMEMO2EncryptedElement(v2_dicts, null);
+}
 
-    return stx`<encrypted xmlns="${Strophe.NS.OMEMO2}">
-            <header sid="${sid}">${keys_elements}</header>
-            <payload>${payload}</payload>
-        </encrypted>`;
+/**
+ * Send an OMEMO heartbeat (an empty/payload-less OMEMO message) to `chat` for
+ * the given protocol version. Heartbeats forward the Double Ratchet so a peer's
+ * message counter restarts at 0; see the XEP-0384 "counter of 53 or higher"
+ * rule. The message carries no `<body>`, so it produces no visible/stored chat
+ * message. We reuse the normal send-path session setup so every (trusted,
+ * active) device gets the heartbeat and any missing sessions are (re)built.
+ * @param {import('../../shared/chatbox.js').default} chat
+ * @param {import('./types').OMEMOVersion} version
+ */
+export async function sendOMEMOHeartbeat(chat, version) {
+    const is_v2 = version === Strophe.NS.OMEMO2;
+    const { legacy, v2 } = await getBundlesAndBuildSessions(chat);
+    const devices = is_v2 ? v2 : legacy;
+    if (!devices.length) return;
+
+    const encrypted_el = is_v2
+        ? await getOMEMO2HeartbeatElement(devices)
+        : await getLegacyHeartbeatElement(devices);
+
+    const is_muc = chat instanceof MUC;
+    const connection = api.connection.get();
+    if (!connection) return;
+
+    const stanza = stx`<message xmlns="jabber:client"
+            from="${is_muc ? connection.jid : _converse.session.get('jid')}"
+            to="${chat.get('jid')}"
+            type="${is_muc ? 'groupchat' : 'chat'}"
+            id="${u.getUniqueId()}">
+        ${encrypted_el}
+        <encryption xmlns="${Strophe.NS.EME}" namespace="${is_v2 ? Strophe.NS.OMEMO2 : Strophe.NS.OMEMO}"/>
+        <store xmlns="${Strophe.NS.HINTS}"/>
+    </message>`;
+    api.send(stanza);
 }
 
 /**

--- a/src/headless/plugins/omemo/versioned-store.js
+++ b/src/headless/plugins/omemo/versioned-store.js
@@ -109,6 +109,16 @@ export class VersionedOMEMOStore {
         return this.#base.removeSession(this.#prefix + address);
     }
 
+    /** @param {string} address @returns {string|undefined} */
+    loadHeartbeatKey(address) {
+        return this.#base.loadHeartbeatKey(this.#prefix + address);
+    }
+
+    /** @param {string} address @param {string} key_b64 @returns {Promise<void>} */
+    storeHeartbeatKey(address, key_b64) {
+        return this.#base.storeHeartbeatKey(this.#prefix + address, key_b64);
+    }
+
     /** @param {string} [address=''] */
     removeAllSessions(address = '') {
         // We can't delegate to the base store's removeAllSessions: legacy keys

--- a/src/headless/types/plugins/omemo/store.d.ts
+++ b/src/headless/types/plugins/omemo/store.d.ts
@@ -89,6 +89,21 @@ declare class OMEMOStore extends Model<import("./types").OMEMOStoreAttributes> {
      */
     removeSession(address: string): Promise<Awaited<this>>;
     /**
+     * The ratchet key (base64) for which we last sent an OMEMO heartbeat to this
+     * session, or `undefined`. Used to enforce the XEP-0384 rule of sending at
+     * most one heartbeat per ratchet key, in a way that survives page reloads.
+     * @param {string} address
+     * @returns {string|undefined}
+     */
+    loadHeartbeatKey(address: string): string | undefined;
+    /**
+     * Records and persists the ratchet key we just heartbeated for.
+     * @param {string} address
+     * @param {string} key_b64 - base64 of the ratchet key we just heartbeated for
+     * @returns {Promise<void>}
+     */
+    storeHeartbeatKey(address: string, key_b64: string): Promise<void>;
+    /**
      * @param {string} [address='']
      */
     removeAllSessions(address?: string): Promise<void>;

--- a/src/headless/types/plugins/omemo/utils.d.ts
+++ b/src/headless/types/plugins/omemo/utils.d.ts
@@ -75,6 +75,17 @@ export function getSession(device: import("./device").default, version?: import(
  */
 export function decryptMessage(obj: import("./types").EncryptedMessage): Promise<string>;
 /**
+ * Send an OMEMO heartbeat (an empty/payload-less OMEMO message) to `chat` for
+ * the given protocol version. Heartbeats forward the Double Ratchet so a peer's
+ * message counter restarts at 0; see the XEP-0384 "counter of 53 or higher"
+ * rule. The message carries no `<body>`, so it produces no visible/stored chat
+ * message. We reuse the normal send-path session setup so every (trusted,
+ * active) device gets the heartbeat and any missing sessions are (re)built.
+ * @param {import('../../shared/chatbox.js').default} chat
+ * @param {import('./types').OMEMOVersion} version
+ */
+export function sendOMEMOHeartbeat(chat: import("../../shared/chatbox.js").default, version: import("./types").OMEMOVersion): Promise<void>;
+/**
  * @param {import('../../shared/chatbox').default} chat
  * @param {import('../../shared/types').MessageAndStanza} data
  * @return {Promise<import('../../shared/types').MessageAndStanza>}

--- a/src/headless/types/plugins/omemo/versioned-store.d.ts
+++ b/src/headless/types/plugins/omemo/versioned-store.d.ts
@@ -43,6 +43,10 @@ export class VersionedOMEMOStore {
     storeSession(address: string, record: string): Promise<any>;
     /** @param {string} address */
     removeSession(address: string): Promise<import("./store.js").default>;
+    /** @param {string} address @returns {string|undefined} */
+    loadHeartbeatKey(address: string): string | undefined;
+    /** @param {string} address @param {string} key_b64 @returns {Promise<void>} */
+    storeHeartbeatKey(address: string, key_b64: string): Promise<void>;
     /** @param {string} [address=''] */
     removeAllSessions(address?: string): Promise<void>;
     #private;

--- a/src/plugins/omemo-views/tests/heartbeat.js
+++ b/src/plugins/omemo-views/tests/heartbeat.js
@@ -1,0 +1,445 @@
+/**
+ * Tests for the XEP-0384 OMEMO heartbeat: when we receive the first message for
+ * a given ratchet key whose counter is >= 53, we must send an (empty,
+ * payload-less) OMEMO message to forward the ratchet.
+ *
+ * The ratchet counter/key reported on decryption are driven by
+ * `window.libomemo.mock_ratchet` (see src/shared/tests/mock.js).
+ */
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+import { answerV2DeviceList, answerV2Bundle } from './utils.js';
+
+const { Strophe, sizzle, stx, u } = converse.env;
+
+/**
+ * Open a chat for a contact, turn OMEMO on, send one normal omemo:2 message and
+ * answer the device-list/bundle fetches it triggers. This warms the device-list
+ * and bundle caches and builds sessions, so a subsequently-triggered heartbeat
+ * resolves without needing further IQ round-trips. Returns context for the test.
+ */
+async function setupAndPrewarm(_converse) {
+    await mock.waitForRoster(_converse, 'current', 1);
+    const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+    await mock.initializedOMEMO(_converse);
+    mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+    await mock.openChatBoxFor(_converse, contact_jid);
+
+    const view = _converse.chatboxviews.get(contact_jid);
+    view.model.set('omemo_active', true);
+
+    const rendered = mock.sendMessage(_converse, view, 'prewarm');
+    await mock.deviceListFetched(_converse, contact_jid, ['555']);
+    await answerV2DeviceList(_converse, contact_jid, ['555']);
+    await mock.bundleFetched(_converse, {
+        jid: _converse.bare_jid,
+        device_id: '482886413b977930064a5888b92134fe',
+        identity_key: '300000',
+        signed_prekey_id: '4224',
+        signed_prekey_public: '100000',
+        signed_prekey_sig: '200000',
+        prekeys: ['1991', '1992', '1993'],
+    });
+    await answerV2Bundle(_converse, contact_jid, '555');
+    await rendered;
+
+    return { view, contact_jid, conn: _converse.api.connection.get() };
+}
+
+/**
+ * Build an incoming omemo:2 message from `sender_device_id`, exactly as the
+ * contact would, so decryption succeeds and the heartbeat logic runs with
+ * whatever `window.libomemo.mock_ratchet` currently reports. Returns the stanza
+ * so callers can inject several back-to-back (see the concurrency test).
+ */
+async function buildOMEMO2Message(_converse, contact_jid, sender_device_id, conn) {
+    const our_device_id = _converse.state.omemo_store.get('device_id');
+    const { key_and_tag, payload } = await u.omemo.encryptSCE('hi', { from_jid: contact_jid, to_jid: null });
+    return stx`<message from="${contact_jid}"
+            to="${conn.jid}"
+            type="chat"
+            id="${conn.getUniqueId()}"
+            xmlns="jabber:client">
+        <encrypted xmlns="${Strophe.NS.OMEMO2}">
+            <header sid="${sender_device_id}">
+                <keys jid="${_converse.bare_jid}">
+                    <key rid="${our_device_id}">${u.arrayBufferToBase64(key_and_tag)}</key>
+                </keys>
+            </header>
+            <payload>${payload}</payload>
+        </encrypted>
+        <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+    </message>`;
+}
+
+/** Build and inject a single incoming omemo:2 message. */
+async function receiveOMEMO2Message(_converse, contact_jid, sender_device_id, conn) {
+    const stanza = await buildOMEMO2Message(_converse, contact_jid, sender_device_id, conn);
+    conn._dataRecv(mock.createRequest(_converse, stanza));
+}
+
+/** A sent <encrypted> element (for `ns`) with no <payload> is a heartbeat. */
+function sentHeartbeats(conn, ns = Strophe.NS.OMEMO2) {
+    return conn.sent_stanzas.filter((s) => {
+        const enc = sizzle(`encrypted[xmlns="${ns}"]`, s).pop();
+        return enc && !enc.querySelector('payload');
+    });
+}
+
+/**
+ * Legacy variant of {@link setupAndPrewarm}: the contact has a single legacy
+ * (eu.siacs.conversations.axolotl) device and no omemo:2 device.
+ */
+async function setupAndPrewarmLegacy(_converse) {
+    await mock.waitForRoster(_converse, 'current', 1);
+    const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+    await mock.initializedOMEMO(_converse);
+    await mock.openChatBoxFor(_converse, contact_jid);
+    await u.waitUntil(() => mock.deviceListFetched(_converse, contact_jid, ['555']));
+
+    const view = _converse.chatboxviews.get(contact_jid);
+    view.model.set('omemo_active', true);
+
+    const rendered = mock.sendMessage(_converse, view, 'prewarm');
+    await u.waitUntil(() =>
+        mock.bundleFetched(_converse, {
+            jid: contact_jid,
+            device_id: '555',
+            identity_key: '3333',
+            signed_prekey_id: '4223',
+            signed_prekey_public: '1111',
+            signed_prekey_sig: '2222',
+            prekeys: ['1001', '1002', '1003'],
+        }),
+    );
+    await u.waitUntil(() =>
+        mock.bundleFetched(_converse, {
+            jid: _converse.bare_jid,
+            device_id: '482886413b977930064a5888b92134fe',
+            identity_key: '300000',
+            signed_prekey_id: '4224',
+            signed_prekey_public: '100000',
+            signed_prekey_sig: '200000',
+            prekeys: ['1991', '1992', '1993'],
+        }),
+    );
+    await rendered;
+    return { view, contact_jid, conn: _converse.api.connection.get() };
+}
+
+/** Inject an incoming legacy OMEMO message from `sender_device_id`. */
+async function receiveLegacyMessage(_converse, contact_jid, sender_device_id, conn) {
+    const our_device_id = _converse.state.omemo_store.get('device_id');
+    const obj = await u.omemo.encryptMessage('hi');
+    const stanza = stx`<message from="${contact_jid}"
+            to="${conn.jid}"
+            type="chat"
+            id="${conn.getUniqueId()}"
+            xmlns="jabber:client">
+        <encrypted xmlns="${Strophe.NS.OMEMO}">
+            <header sid="${sender_device_id}">
+                <key rid="${our_device_id}">${u.arrayBufferToBase64(obj.key_and_tag)}</key>
+                <iv>${obj.iv}</iv>
+            </header>
+            <payload>${obj.payload}</payload>
+        </encrypted>
+        <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>
+    </message>`;
+    conn._dataRecv(mock.createRequest(_converse, stanza));
+}
+
+/**
+ * Inject an incoming *payload-less* omemo:2 message — i.e. an empty/heartbeat
+ * message: a `<header>` carrying our `<key>` but no `<payload>`. Per XEP-0384
+ * the sender encrypts 32 zero-bytes directly with the ratchet, so the leading
+ * key byte is 0x00 and the message decrypts via a regular (non-key-exchange)
+ * session, exactly as our own {@link getOMEMO2HeartbeatElement} produces.
+ */
+function receiveOMEMO2Heartbeat(_converse, contact_jid, sender_device_id, conn) {
+    const our_device_id = _converse.state.omemo_store.get('device_id');
+    const key_b64 = u.arrayBufferToBase64(new ArrayBuffer(32));
+    const stanza = stx`<message from="${contact_jid}"
+            to="${conn.jid}"
+            type="chat"
+            id="${conn.getUniqueId()}"
+            xmlns="jabber:client">
+        <encrypted xmlns="${Strophe.NS.OMEMO2}">
+            <header sid="${sender_device_id}">
+                <keys jid="${_converse.bare_jid}">
+                    <key rid="${our_device_id}">${key_b64}</key>
+                </keys>
+            </header>
+        </encrypted>
+        <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+        <store xmlns="${Strophe.NS.HINTS}"/>
+    </message>`;
+    conn._dataRecv(mock.createRequest(_converse, stanza));
+}
+
+/**
+ * Inject an incoming legacy KeyTransportElement: a `<header>` with `<key>`s and
+ * an `<iv>`, but no `<payload>` (XEP-0384 0.3.0 §Sending a key). This is what a
+ * legacy heartbeat looks like on the wire.
+ */
+async function receiveLegacyHeartbeat(_converse, contact_jid, sender_device_id, conn) {
+    const our_device_id = _converse.state.omemo_store.get('device_id');
+    const obj = await u.omemo.encryptMessage('');
+    const stanza = stx`<message from="${contact_jid}"
+            to="${conn.jid}"
+            type="chat"
+            id="${conn.getUniqueId()}"
+            xmlns="jabber:client">
+        <encrypted xmlns="${Strophe.NS.OMEMO}">
+            <header sid="${sender_device_id}">
+                <key rid="${our_device_id}">${u.arrayBufferToBase64(obj.key_and_tag)}</key>
+                <iv>${obj.iv}</iv>
+            </header>
+        </encrypted>
+        <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>
+        <store xmlns="${Strophe.NS.HINTS}"/>
+    </message>`;
+    conn._dataRecv(mock.createRequest(_converse, stanza));
+}
+
+describe('The OMEMO heartbeat', function () {
+    beforeEach(() => (window.libomemo.mock_ratchet = { counter: 0, key: new Uint8Array([5, 1, 2, 3]).buffer }));
+    afterEach(() => (window.libomemo.mock_ratchet = { counter: 0, key: new Uint8Array([5, 1, 2, 3]).buffer }));
+
+    it(
+        'is sent (as a payload-less message) when an incoming message has a ratchet counter >= 53',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { contact_jid, conn } = await setupAndPrewarm(_converse);
+
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            await receiveOMEMO2Message(_converse, contact_jid, '555', conn);
+
+            const heartbeat = await u.waitUntil(() => sentHeartbeats(conn).pop(), 1500);
+            // Addressed to the contact's v2 device, carries the store hint, no payload.
+            const enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, heartbeat).pop();
+            expect(sizzle(`keys[jid="${contact_jid}"] key[rid="555"]`, enc).length).toBe(1);
+            expect(enc.querySelector('payload')).toBe(null);
+            expect(sizzle(`store[xmlns="${Strophe.NS.HINTS}"]`, heartbeat).length).toBe(1);
+        }),
+    );
+
+    it(
+        'is NOT sent when the ratchet counter is below 53',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { contact_jid, conn } = await setupAndPrewarm(_converse);
+
+            window.libomemo.mock_ratchet = { counter: 52, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            await receiveOMEMO2Message(_converse, contact_jid, '555', conn);
+            // Give any (erroneous) heartbeat a chance to be sent.
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            expect(sentHeartbeats(conn).length).toBe(0);
+        }),
+    );
+
+    it(
+        'is sent only once per ratchet key',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { contact_jid, conn } = await setupAndPrewarm(_converse);
+
+            // Two messages on the same ratchet key, both past the threshold.
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            await receiveOMEMO2Message(_converse, contact_jid, '555', conn);
+            await u.waitUntil(() => sentHeartbeats(conn).length === 1, 1500);
+
+            window.libomemo.mock_ratchet = { counter: 54, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            await receiveOMEMO2Message(_converse, contact_jid, '555', conn);
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            expect(sentHeartbeats(conn).length).toBe(1);
+        }),
+    );
+
+    it(
+        'is sent only once even when two messages on the same ratchet key race',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { contact_jid, conn } = await setupAndPrewarm(_converse);
+
+            // Pre-build both stanzas (the expensive encryptSCE work) up front, so
+            // that injecting them is cheap and synchronous.
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            const s1 = await buildOMEMO2Message(_converse, contact_jid, '555', conn);
+            const s2 = await buildOMEMO2Message(_converse, contact_jid, '555', conn);
+
+            // Inject both stanzas synchronously. Both decryption pipelines start in the
+            // same tick and the in-flight Set guard ensures only one heartbeat is sent.
+            conn._dataRecv(mock.createRequest(_converse, s1));
+            conn._dataRecv(mock.createRequest(_converse, s2));
+
+            await u.waitUntil(() => sentHeartbeats(conn).length >= 1, 1500);
+            // Let any erroneous second heartbeat have a chance to be sent.
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            expect(sentHeartbeats(conn).length).toBe(1);
+        }),
+    );
+
+    it(
+        'is sent as a legacy KeyTransportElement (no payload) for legacy OMEMO',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { contact_jid, conn } = await setupAndPrewarmLegacy(_converse);
+
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 7, 7, 7]).buffer };
+            await receiveLegacyMessage(_converse, contact_jid, '555', conn);
+
+            const heartbeat = await u.waitUntil(() => sentHeartbeats(conn, Strophe.NS.OMEMO).pop(), 1500);
+            const enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, heartbeat).pop();
+            // A KeyTransportElement: header with <key>s and an <iv>, but no <payload>.
+            expect(sizzle(`key[rid="555"]`, enc).length).toBe(1);
+            expect(enc.querySelector('iv')).toBeTruthy();
+            expect(enc.querySelector('payload')).toBe(null);
+            expect(sizzle(`store[xmlns="${Strophe.NS.HINTS}"]`, heartbeat).length).toBe(1);
+        }),
+    );
+
+    it(
+        'is sent as a groupchat message to the room for MUC messages',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const features = [
+                'http://jabber.org/protocol/muc',
+                'jabber:iq:register',
+                'muc_membersonly',
+                'muc_nonanonymous',
+            ];
+            const muc_jid = 'lounge@montague.lit';
+            const nick = 'romeo';
+            const sender_jid = 'newguy@montague.lit';
+            const sender_device_id = '555';
+            const conn = _converse.api.connection.get();
+
+            await mock.openAndEnterMUC(_converse, muc_jid, nick, features);
+            const view = _converse.chatboxviews.get(muc_jid);
+            await u.waitUntil(() => mock.initializedOMEMO(_converse));
+
+            // Enable OMEMO
+            const toolbar = await u.waitUntil(() => view.querySelector('.chat-toolbar'));
+            const el = await u.waitUntil(() => toolbar.querySelector('.toggle-omemo'));
+            el.click();
+            expect(view.model.get('omemo_active')).toBe(true);
+
+            // newguy enters the room, so we fetch (and answer) his device list.
+            const presence = stx`
+            <presence to='romeo@montague.lit/orchard' from='${muc_jid}/newguy' xmlns="jabber:client">
+                <x xmlns='${Strophe.NS.MUC_USER}'>
+                    <item affiliation='member' jid='${sender_jid}/_converse.js-290929789' role='participant'/>
+                </x>
+            </presence>`;
+            conn._dataRecv(mock.createRequest(_converse, presence));
+            await mock.deviceListFetched(_converse, sender_jid, [sender_device_id]);
+
+            // Prewarm: send a groupchat message, which builds sessions for the
+            // room's devices (fetching newguy's bundle and our own). This warms
+            // the caches so the subsequently-triggered heartbeat resolves without
+            // needing further IQ round-trips. See setupAndPrewarm for the 1:1 case.
+            const rendered = mock.sendMessage(_converse, view, 'prewarm');
+            await mock.bundleFetched(_converse, {
+                jid: sender_jid,
+                device_id: sender_device_id,
+                identity_key: '3333',
+                signed_prekey_id: '4223',
+                signed_prekey_public: '1111',
+                signed_prekey_sig: '2222',
+                prekeys: ['1001', '1002', '1003'],
+            });
+            await mock.bundleFetched(_converse, {
+                jid: _converse.bare_jid,
+                device_id: '482886413b977930064a5888b92134fe',
+                identity_key: '300000',
+                signed_prekey_id: '4224',
+                signed_prekey_public: '100000',
+                signed_prekey_sig: '200000',
+                prekeys: ['1991', '1992', '1993'],
+            });
+            await rendered;
+
+            // Build and inject an incoming MUC omemo message (type=groupchat, from=room/nick)
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const obj = await u.omemo.encryptMessage('hi');
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 9, 9, 9]).buffer };
+            const incoming = stx`<message from="${muc_jid}/newguy"
+                    to="${conn.jid}"
+                    type="groupchat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <encrypted xmlns="${Strophe.NS.OMEMO}">
+                    <header sid="${sender_device_id}">
+                        <key rid="${our_device_id}">${u.arrayBufferToBase64(obj.key_and_tag)}</key>
+                        <iv>${obj.iv}</iv>
+                    </header>
+                    <payload>${obj.payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, incoming));
+
+            const heartbeat = await u.waitUntil(() => sentHeartbeats(conn, Strophe.NS.OMEMO).pop(), 1500);
+            // The heartbeat must be a groupchat addressed to the room JID.
+            expect(heartbeat.getAttribute('type')).toBe('groupchat');
+            expect(heartbeat.getAttribute('to')).toBe(muc_jid);
+            const enc = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, heartbeat).pop();
+            expect(enc).toBeTruthy();
+            expect(enc.querySelector('payload')).toBe(null);
+            expect(sizzle(`store[xmlns="${Strophe.NS.HINTS}"]`, heartbeat).length).toBe(1);
+        }),
+    );
+});
+
+describe('Receiving an OMEMO heartbeat', function () {
+    beforeEach(() => (window.libomemo.mock_ratchet = { counter: 0, key: new Uint8Array([5, 1, 2, 3]).buffer }));
+    afterEach(() => (window.libomemo.mock_ratchet = { counter: 0, key: new Uint8Array([5, 1, 2, 3]).buffer }));
+
+    it(
+        'decrypts an incoming payload-less omemo:2 message without surfacing a message or error',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { view, contact_jid, conn } = await setupAndPrewarm(_converse);
+            // setupAndPrewarm sent one (visible) outgoing message.
+            expect(view.model.messages.length).toBe(1);
+
+            // Counter stays at 0 (below threshold) so we isolate reception from
+            // the sending logic: receiving a heartbeat must not, by itself, send one.
+            await receiveOMEMO2Heartbeat(_converse, contact_jid, '555', conn);
+            // Give any (erroneous) visible message / error / heartbeat a chance to appear.
+            await new Promise((resolve) => setTimeout(resolve, 500));
+
+            // The empty message decrypted cleanly: no new chat message is stored, no
+            // decryption error is surfaced, and we did not send a heartbeat back.
+            expect(view.model.messages.length).toBe(1);
+            expect(view.model.messages.filter((m) => m.get('is_error')).length).toBe(0);
+            expect(sentHeartbeats(conn).length).toBe(0);
+        }),
+    );
+
+    it(
+        'decrypts an incoming legacy KeyTransportElement (no payload) without surfacing a message or error',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { view, contact_jid, conn } = await setupAndPrewarmLegacy(_converse);
+            const initial = view.model.messages.length;
+
+            await receiveLegacyHeartbeat(_converse, contact_jid, '555', conn);
+            await new Promise((resolve) => setTimeout(resolve, 500));
+
+            expect(view.model.messages.length).toBe(initial);
+            expect(view.model.messages.filter((m) => m.get('is_error')).length).toBe(0);
+            expect(sentHeartbeats(conn, Strophe.NS.OMEMO).length).toBe(0);
+        }),
+    );
+
+    it(
+        'forwards the ratchet (sends a heartbeat back) when an incoming heartbeat has counter >= 53',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { view, contact_jid, conn } = await setupAndPrewarm(_converse);
+            expect(view.model.messages.length).toBe(1);
+
+            // A payload-less incoming message must still be decrypted end-to-end so
+            // its ratchet counter is read; a counter >= 53 then triggers our own
+            // heartbeat. This proves reception runs the full decrypt pipeline.
+            window.libomemo.mock_ratchet = { counter: 53, key: new Uint8Array([5, 6, 6, 6]).buffer };
+            await receiveOMEMO2Heartbeat(_converse, contact_jid, '555', conn);
+
+            await u.waitUntil(() => sentHeartbeats(conn).length === 1, 1500);
+            // Still no visible message for the (empty) incoming heartbeat itself.
+            expect(view.model.messages.length).toBe(1);
+        }),
+    );
+});

--- a/src/shared/tests/mock.js
+++ b/src/shared/tests/mock.js
@@ -221,6 +221,12 @@ window.libomemo.OMEMOAddress.prototype.getDeviceId = function () {
 window.libomemo.OMEMOAddress.prototype.toString = function () {
     return this.name + '.' + this.deviceId;
 };
+// The ratchet metadata that the mocked decrypt methods report alongside the
+// plaintext. Tests can override `counter`/`key` to drive the XEP-0384 heartbeat
+// logic; the default counter is below the heartbeat threshold so ordinary
+// decryption tests never trigger a heartbeat.
+window.libomemo.mock_ratchet = { counter: 0, key: new Uint8Array([5, 1, 2, 3]).buffer };
+
 Object.assign(window.libomemo, {
     // Mock Ed25519 key conversion: just return the input as-is (real impl converts Curve25519 → Ed25519)
     'curvePubKeyToEd25519PubKey': async (curve_key) => new Uint8Array(curve_key).slice(0, 32).buffer,
@@ -267,7 +273,7 @@ Object.assign(window.libomemo, {
                 throw new Error('Identity keypair is missing a private key');
             }
 
-            return key_and_tag;
+            return { plaintext: key_and_tag, ratchet: { ...window.libomemo.mock_ratchet } };
         };
         this.decryptWhisperMessage = async (key_and_tag) => {
             // Mirror libomemo's SessionCipher.doDecryptWhisperMessage, which
@@ -276,7 +282,7 @@ Object.assign(window.libomemo, {
             if (!identity_keypair.privKey) {
                 throw new Error('Identity keypair is missing a private key');
             }
-            return key_and_tag;
+            return { plaintext: key_and_tag, ratchet: { ...window.libomemo.mock_ratchet } };
         };
     },
     'SessionBuilder': function (_storage, _remote_address) {


### PR DESCRIPTION
When we receive the first message for a given ratchet key whose counter is 53 or higher, send an empty/payload-less OMEMO message to forward the Double Ratchet, so the peer's counter restarts at 0. Implemented for both protocols:

  - omemo:2: an empty OMEMO message (32 zero-bytes encrypted, no <payload>).
  - legacy: a `KeyTransportElement` (header with <key>s + <iv>, no <payload>), which the 0.3.0 spec already defines and conforming clients handle.

The heartbeat is encrypted for the full device list (reusing the normal send path, which is self-healing). Dedup is per-ratchet-key and persisted in the versioned OMEMO store, so we send at most one heartbeat per ratchet key even across page reloads.



