### PR TITLE
feat(omemo): encrypt body-coupled metadata via SCE for OMEMO:2

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,6 +60,7 @@ export default function (config) {
             { pattern: 'src/plugins/roomslist/tests/*.js', type: 'module' },
             { pattern: 'src/plugins/rootview/tests/*.js', type: 'module' },
             { pattern: 'src/plugins/rosterview/tests/*.js', type: 'module' },
+            { pattern: 'src/plugins/reactions-views/fallback.js', included: false, served: true },
             { pattern: 'src/plugins/reactions-views/tests/*.js', type: 'module' },
             { pattern: 'src/plugins/rosterview/tests/requesting_contacts.js', type: 'module' },
             { pattern: 'src/shared/components/tests/*.js', type: 'module' },

--- a/src/headless/plugins/chat/model.js
+++ b/src/headless/plugins/chat/model.js
@@ -270,6 +270,9 @@ class ChatBox extends ModelWithVCard(ModelWithMessages(ModelWithContact(ColorAwa
             await u.getMediaURLsMetadata(text),
         );
 
+        // Add the XEP-0461 reply fallback before the hook
+        attrs = this.addReplyFallback(attrs);
+
         // Clear reply state after capturing it
         if (reply_to_id) {
             this.save({ reply_to_id: undefined, reply_to: undefined });

--- a/src/headless/plugins/chat/parsers.js
+++ b/src/headless/plugins/chat/parsers.js
@@ -14,6 +14,7 @@ import {
     getCorrectionAttributes,
     getEncryptionAttributes,
     getErrorAttributes,
+    getFallbackAttributes,
     getOutOfBandAttributes,
     getReceiptId,
     getReferences,
@@ -137,6 +138,7 @@ export async function parseMessage(stanza) {
         getRetractionAttributes(stanza, original_stanza),
         getEncryptionAttributes(stanza),
         getReplyAttributes(stanza),
+        getFallbackAttributes(stanza),
     );
 
     if (attrs.is_archived) {

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -1216,6 +1216,7 @@ class MUC extends ModelWithVCard(ModelWithMessages(ColorAwareModel(ChatBoxBase))
      */
     sendChatState() {
         if (
+            this.get('omemo_active') ||
             !api.settings.get('send_chat_state_notifications') ||
             !this.get('chat_state') ||
             !this.isEntered() ||
@@ -1223,10 +1224,12 @@ class MUC extends ModelWithVCard(ModelWithMessages(ColorAwareModel(ChatBoxBase))
         ) {
             return;
         }
+
         const allowed = api.settings.get('send_chat_state_notifications');
         if (Array.isArray(allowed) && !allowed.includes(this.get('chat_state'))) {
             return;
         }
+
         const chat_state = this.get('chat_state');
         if (chat_state === GONE) return; // <gone/> is not applicable within MUC context
 

--- a/src/headless/plugins/muc/muc.js
+++ b/src/headless/plugins/muc/muc.js
@@ -1182,6 +1182,9 @@ class MUC extends ModelWithVCard(ModelWithMessages(ColorAwareModel(ChatBoxBase))
             await u.getMediaURLsMetadata(text),
         );
 
+        // Add XEP-0461 reply fallback before the hook
+        attrs = this.addReplyFallback(attrs);
+
         // Clear reply state after capturing it
         if (reply_to_id) {
             this.save({ reply_to_id: undefined, reply_to: undefined });

--- a/src/headless/plugins/muc/parsers.js
+++ b/src/headless/plugins/muc/parsers.js
@@ -13,6 +13,7 @@ import {
     getCorrectionAttributes,
     getEncryptionAttributes,
     getErrorAttributes,
+    getFallbackAttributes,
     getOpenGraphMetadata,
     getOutOfBandAttributes,
     getReceiptId,
@@ -290,6 +291,7 @@ export async function parseMUCMessage(original_stanza, chatbox) {
             getModerationAttributes(stanza),
             getEncryptionAttributes(stanza),
             getReplyAttributes(stanza),
+            getFallbackAttributes(stanza),
             getStatusCodes(stanza, 'message'),
         )
     );

--- a/src/headless/plugins/omemo/api.js
+++ b/src/headless/plugins/omemo/api.js
@@ -2,10 +2,11 @@ import { initStorage } from '../../utils/storage.js';
 import _converse from '../../shared/_converse.js';
 import api from '../../shared/api/index.js';
 import converse from '../../shared/api/public.js';
+import MUC from '../../plugins/muc/muc.js';
 import OMEMOStore from './store.js';
-import { generateFingerprint, getDeviceList } from './utils.js';
+import { generateFingerprint, getDeviceList, getEncryptedElements, handleMessageSendError } from './utils.js';
 
-const { Strophe } = converse.env;
+const { Strophe, stx, u } = converse.env;
 
 export default {
     /**
@@ -22,6 +23,44 @@ export default {
         async getDeviceID() {
             await api.waitUntil('OMEMOInitialized');
             return _converse.state.omemo_store.get('device_id');
+        },
+
+        /**
+         * Encrypt and send a message to `chat` for every OMEMO version its
+         * recipients support, without persisting a Message model. This is the
+         * encrypted counterpart of a raw `api.send`.
+         *
+         * On failure (e.g. no reachable devices, or a presence/server error) a
+         * user-facing alert is shown and the error is re-thrown — the same way an
+         * encrypted chat-message send fails — so callers can roll back any
+         * optimistic state. Awaits the encryption; resolves once the stanza is
+         * handed to `api.send`.
+         *
+         * @method _converse.api.omemo.send
+         * @param {import('../../shared/chatbox.js').default} chat
+         * @param {string} plaintext - the message body (may be empty)
+         * @param {import('strophe.js').Builder[]} [extensions] - encrypted SCE `<content>` children
+         */
+        async send(chat, plaintext, extensions = []) {
+            try {
+                const { elements, eme_ns } = await getEncryptedElements(chat, plaintext || null, extensions);
+
+                // `from` is our own full JID (the server stamps/overwrites it
+                // regardless); the authenticated identity is the SCE `<from>`
+                // affix set during encryption.
+                const stanza = stx`<message xmlns="jabber:client"
+                        from="${_converse.session.get('jid')}"
+                        to="${chat.get('jid')}"
+                        type="${chat instanceof MUC ? 'groupchat' : 'chat'}"
+                        id="${u.getUniqueId()}">
+                    ${elements}
+                    <encryption xmlns="${Strophe.NS.EME}" namespace="${eme_ns}"/>
+                    <store xmlns="${Strophe.NS.HINTS}"/>
+                </message>`;
+                api.send(stanza);
+            } catch (e) {
+                handleMessageSendError(e, chat); // surfaces a user-facing alert and re-throws
+            }
         },
 
         session: {

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -443,6 +443,13 @@ async function decryptOMEMO2Message(stanza, attrs, chatbox) {
         // so it isn't shown as a blank message. `reaction_to_id` is added by the
         // reactions plugin via the hook above, so it's not on the base type.
         const has_reaction = !!(/** @type {{reaction_to_id?: string}} */ (attrs)).reaction_to_id;
+        if (has_reaction) {
+            // The emoji body is only a legacy-OMEMO fallback (marked by a
+            // XEP-0428 <fallback for="urn:xmpp:reactions:0">); the structured
+            // <reactions> is what we act on. Drop it so the emoji isn't surfaced
+            // as a standalone message alongside the reaction.
+            delete (/** @type {{plaintext?: string}} */ (attrs)).plaintext;
+        }
         if (!body && !attrs.chat_state && !attrs.is_marker && !attrs.is_markable && !has_reaction) {
             return Object.assign(attrs, { 'is_only_key': true });
         }

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -14,6 +14,12 @@ import { decryptMessage, getSessionCipher, sendOMEMOHeartbeat } from './utils.js
 import { getCrypto } from './crypto.js';
 import { VersionedOMEMOStore } from './versioned-store.js';
 import { decryptSCE } from './sce.js';
+import {
+    getOutOfBandAttributes,
+    getReferences,
+    getReplyAttributes,
+    getSpoilerAttributes,
+} from '../../shared/parsers.js';
 
 const { Strophe } = converse.env;
 
@@ -362,7 +368,7 @@ async function decryptOMEMO2Message(stanza, attrs) {
     try {
         const is_muc = attrs.type === 'groupchat';
         const muc_jid = is_muc ? attrs.from : null;
-        const plaintext = await decryptSCE(key_and_tag, attrs.encrypted.payload, {
+        const { body, content } = await decryptSCE(key_and_tag, attrs.encrypted.payload, {
             sender_jid: from_jid,
             to_jid: muc_jid,
         });
@@ -375,8 +381,18 @@ async function decryptOMEMO2Message(stanza, attrs) {
         }
         device.save('active', true);
 
-        if (plaintext) {
-            return Object.assign(attrs, { plaintext });
+        if (body) {
+            // Body-coupled metadata (references/reply/oob/spoiler) lives encrypted
+            // inside the SCE <content>, so we re-run the normal parsers against the
+            // decrypted content — not the wire stanza — overriding the (empty)
+            // values parsed from the cleartext stanza.
+            return Object.assign(
+                attrs,
+                { plaintext: body, references: getReferences(content) },
+                getReplyAttributes(content),
+                getOutOfBandAttributes(content),
+                getSpoilerAttributes(content),
+            );
         } else {
             return Object.assign(attrs, { 'is_only_key': true });
         }

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -15,6 +15,8 @@ import { getCrypto } from './crypto.js';
 import { VersionedOMEMOStore } from './versioned-store.js';
 import { decryptSCE } from './sce.js';
 import {
+    getChatMarker,
+    getChatState,
     getOutOfBandAttributes,
     getReferences,
     getReplyAttributes,
@@ -293,9 +295,10 @@ async function decryptLegacyOMEMOMessage(stanza, attrs) {
  * Decrypt an OMEMO 2 message.
  * @param {Element} stanza
  * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @param {import('../muc/muc.js').default} [chatbox] - The MUC model (for re-parsing reactions)
  * @returns {Promise<MUCMessageAttributes|MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
  */
-async function decryptOMEMO2Message(stanza, attrs) {
+async function decryptOMEMO2Message(stanza, attrs, chatbox) {
     const encrypted_el = sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"]`, stanza).pop();
     if (!encrypted_el) return attrs;
 
@@ -381,21 +384,65 @@ async function decryptOMEMO2Message(stanza, attrs) {
         }
         device.save('active', true);
 
-        if (body) {
-            // Body-coupled metadata (references/reply/oob/spoiler) lives encrypted
-            // inside the SCE <content>, so we re-run the normal parsers against the
-            // decrypted content — not the wire stanza — overriding the (empty)
-            // values parsed from the cleartext stanza.
-            return Object.assign(
-                attrs,
-                { plaintext: body, references: getReferences(content) },
-                getReplyAttributes(content),
-                getOutOfBandAttributes(content),
-                getSpoilerAttributes(content),
-            );
-        } else {
+        if (!content) {
+            // Payload present but no <content> at all — nothing to surface.
             return Object.assign(attrs, { 'is_only_key': true });
         }
+
+        // A payload-bearing SCE envelope is never a heartbeat (those carry no
+        // <payload> and are handled above). Its <content> may hold a <body>
+        // with body-coupled metadata (references/reply/oob/spoiler), or it may
+        // be a metadata-only message (chat state / marker / reaction) with no
+        // <body>. Either way we re-run the normal parsers against the decrypted,
+        // authenticated <content> — not the wire stanza, which carries none of
+        // this for an encrypted message.
+        Object.assign(
+            attrs,
+            { references: getReferences(content) },
+            getReplyAttributes(content),
+            getOutOfBandAttributes(content),
+            getSpoilerAttributes(content),
+        );
+        if (body) attrs.plaintext = body;
+
+        // Chat state and markers are only overridden when actually present in
+        // the content: the cleartext stanza of an encrypted message always
+        // carries a `<active/>` chat state, which we must not wipe.
+        const chat_state = getChatState(content);
+        if (chat_state) attrs.chat_state = chat_state;
+        const marker = getChatMarker(content);
+        if (marker) {
+            attrs.is_marker = true;
+            attrs.marker_id = marker.getAttribute('id');
+        }
+        if (sizzle(`markable[xmlns="${Strophe.NS.MARKERS}"]`, content).length) {
+            attrs.is_markable = true;
+        }
+
+        /**
+         * *Hook* which lets plugins parse metadata from the decrypted SCE
+         * `<content>` of an OMEMO:2 message, the same way they parse a wire
+         * stanza via `parseMessage`/`parseMUCMessage`. This keeps plugin-specific
+         * parsing (e.g. XEP-0444 reactions) in the plugin instead of coupling it
+         * to OMEMO. The `chatbox` is forwarded so MUC-aware parsers can resolve
+         * room context.
+         * @event _converse#parseEncryptedContent
+         * @param {Element} content - The decrypted SCE `<content>` element
+         * @param {object} attrs - The message attributes parsed so far
+         * @param {import('../muc/muc.js').default} [chatbox] - The MUC model, if any
+         * @example api.listen.on('parseEncryptedContent', parseReactionsMessage);
+         */
+        attrs = await api.hook('parseEncryptedContent', content, attrs, chatbox);
+
+        // A content that surfaced nothing the user acts on (no body and no
+        // chat state / marker / reaction) is treated as a key-transport message
+        // so it isn't shown as a blank message. `reaction_to_id` is added by the
+        // reactions plugin via the hook above, so it's not on the base type.
+        const has_reaction = !!(/** @type {{reaction_to_id?: string}} */ (attrs)).reaction_to_id;
+        if (!body && !attrs.chat_state && !attrs.is_marker && !attrs.is_markable && !has_reaction) {
+            return Object.assign(attrs, { 'is_only_key': true });
+        }
+        return attrs;
     } catch (e) {
         log.error(`SCE decryption failed: ${e.name} ${e.message}`);
         return Object.assign(attrs, getDecryptionErrorAttributes(e));
@@ -417,9 +464,11 @@ async function decryptOMEMO2Message(stanza, attrs) {
  *
  * @param {Element} stanza - The message stanza
  * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @param {import('../muc/muc.js').default} [chatbox] - The MUC model (only for
+ *   `parseMUCMessage`); used to re-parse encrypted reactions from the SCE content.
  * @returns {Promise<MUCMessageAttributes| MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
  */
-export async function parseEncryptedMessage(stanza, attrs) {
+export async function parseEncryptedMessage(stanza, attrs, chatbox) {
     if (api.settings.get('clear_cache_on_logout') || !attrs.is_encrypted) {
         return attrs;
     }
@@ -435,7 +484,7 @@ export async function parseEncryptedMessage(stanza, attrs) {
     const has_legacy_key = !!(legacy_el && device_id) && sizzle(`key[rid="${device_id}"]`, legacy_el).length > 0;
 
     if (has_v2_key) {
-        return await decryptOMEMO2Message(stanza, attrs);
+        return await decryptOMEMO2Message(stanza, attrs, chatbox);
     }
     if (has_legacy_key) {
         return await decryptLegacyOMEMOMessage(stanza, attrs);

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -17,6 +17,7 @@ import { decryptSCE } from './sce.js';
 import {
     getChatMarker,
     getChatState,
+    getFallbackAttributes,
     getOutOfBandAttributes,
     getReferences,
     getReplyAttributes,
@@ -400,6 +401,7 @@ async function decryptOMEMO2Message(stanza, attrs, chatbox) {
             attrs,
             { references: getReferences(content) },
             getReplyAttributes(content),
+            getFallbackAttributes(content),
             getOutOfBandAttributes(content),
             getSpoilerAttributes(content),
         );

--- a/src/headless/plugins/omemo/parsers.js
+++ b/src/headless/plugins/omemo/parsers.js
@@ -405,9 +405,11 @@ async function decryptOMEMO2Message(stanza, attrs, chatbox) {
         );
         if (body) attrs.plaintext = body;
 
-        // Chat state and markers are only overridden when actually present in
-        // the content: the cleartext stanza of an encrypted message always
-        // carries a `<active/>` chat state, which we must not wipe.
+        // The chat state now travels encrypted inside <content> (it's gated out
+        // of the cleartext stanza for encrypted messages), so we read it from
+        // there. Chat state and markers are only applied when actually present,
+        // so a metadata-only message (e.g. a reaction) gets no spurious chat
+        // state and any cleartext one from a non-SCE sender isn't clobbered.
         const chat_state = getChatState(content);
         if (chat_state) attrs.chat_state = chat_state;
         const marker = getChatMarker(content);

--- a/src/headless/plugins/omemo/plugin.js
+++ b/src/headless/plugins/omemo/plugin.js
@@ -9,10 +9,9 @@ import OMEMOStore from './store.js';
 import omemo_api from './api.js';
 import { parseEncryptedMessage } from './parsers.js';
 import {
-    createOMEMOMessageStanza,
+    createMessageStanzaHandler,
     encryptFile,
     getOutgoingMessageAttributes,
-    handleMessageSendError,
     initOMEMO,
     onChatInitialized,
     registerPEPPushHandler,
@@ -51,23 +50,8 @@ converse.plugins.add('converse-omemo', {
         Object.assign(_converse, exports); // DEPRECATED
         Object.assign(_converse.exports, exports);
 
-        api.listen.on(
-            'createMessageStanza',
-            /**
-             * @param {import('../../shared/chatbox.js').default} chat
-             * @param {import('../../shared/types').MessageAndStanza} data
-             */
-            async (chat, data) => {
-                try {
-                    data = await createOMEMOMessageStanza(chat, data);
-                } catch (e) {
-                    handleMessageSendError(e, chat);
-                }
-                return data;
-            },
-        );
-
         api.listen.on('connected', registerPEPPushHandler);
+        api.listen.on('createMessageStanza', createMessageStanzaHandler);
 
         api.listen.on('chatRoomInitialized', onChatInitialized);
         api.listen.on('chatBoxInitialized', onChatInitialized);

--- a/src/headless/plugins/omemo/plugin.js
+++ b/src/headless/plugins/omemo/plugin.js
@@ -15,6 +15,7 @@ import {
     initOMEMO,
     onChatInitialized,
     registerPEPPushHandler,
+    sendOMEMO2Marker,
     setEncryptedFileURL,
 } from './utils.js';
 
@@ -65,6 +66,12 @@ converse.plugins.add('converse-omemo', {
 
         api.listen.on('parseMessage', parseEncryptedMessage);
         api.listen.on('parseMUCMessage', parseEncryptedMessage);
+
+        api.listen.on('sendMarker', async (chatbox, data) => {
+            if (!chatbox?.get('omemo_active')) return data;
+            await sendOMEMO2Marker(chatbox, data.to_jid, data.id, data.type, data.msg_type).catch(() => {});
+            return { ...data, handled: true };
+        });
 
         api.listen.on('afterFileUploaded', setEncryptedFileURL);
         api.listen.on(

--- a/src/headless/plugins/omemo/sce.js
+++ b/src/headless/plugins/omemo/sce.js
@@ -80,7 +80,11 @@ async function deriveKeys(content_key) {
  * cleartext. They live inside the authenticated `<content>` and are therefore
  * covered by the SCE HMAC.
  *
- * @param {string} body - plaintext message body
+ * `body` may be empty/null for a metadata-only message (e.g. an encrypted
+ * chat state, marker or reaction), in which case no `<body>` element is
+ * emitted and `<content>` carries only the `extensions`.
+ *
+ * @param {string|null} body - plaintext message body (omitted when falsy)
  * @param {{from_jid: string, to_jid: string|null}} affixes
  * @param {import('strophe.js').Builder[]} [extensions] - extra <content> children
  * @returns {import('strophe.js').Builder}
@@ -91,7 +95,7 @@ function buildSCEEnvelope(body, { from_jid, to_jid }, extensions = []) {
 
     return stx`
         <envelope xmlns="${Strophe.NS.SCE}">
-            <content><body xmlns="jabber:client">${body}</body>${extensions}</content>
+            <content>${body ? stx`<body xmlns="jabber:client">${body}</body>` : ''}${extensions}</content>
             <rpad>${rpad}</rpad>
             <from xmlns="${Strophe.NS.SCE}" jid="${from_jid}"/>
             ${to_jid ? stx`<to xmlns="${Strophe.NS.SCE}" jid="${to_jid}"/>` : ''}
@@ -105,7 +109,7 @@ function buildSCEEnvelope(body, { from_jid, to_jid }, extensions = []) {
  * ArrayBuffer — this is what gets encrypted with SessionCipher per device —
  * and the base64-encoded AES-256-CBC ciphertext as the <payload> value.
  *
- * @param {string} plaintext - the message body to encrypt
+ * @param {string|null} plaintext - the message body to encrypt (omitted when falsy)
  * @param {{from_jid: string, to_jid: string|null}} affixes
  * @param {import('strophe.js').Builder[]} [extensions] - body-coupled metadata elements
  * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
@@ -142,9 +146,10 @@ export async function encryptSCE(plaintext, affixes, extensions = []) {
  * Decrypt an SCE/OMEMO 2 payload.
  *
  * Returns both the plaintext body string and the decrypted `<content>` element,
- * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler)
- * against the authenticated content. `body`/`content` are `null` for a
- * heartbeat (payload-less / bodyless) message.
+ * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler,
+ * but also chat states / markers / reactions) against the authenticated content.
+ * `content` is `null` only when the envelope carries no `<content>` element;
+ * `body` is `null` when there's no `<body>` — i.e. a metadata-only message.
  *
  * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
  * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext
@@ -217,11 +222,10 @@ function parseSCEEnvelope(envelope_xml, { sender_jid, to_jid }) {
         }
     }
 
-    const content_el = sizzle('> content', envelope).pop();
-    const body_el = content_el ? sizzle('> body', content_el).pop() : null;
-    if (!body_el) {
-        // Empty/heartbeat message — no body
-        return null;
-    }
-    return content_el;
+    // Return the <content> whenever it's present, even without a <body>. A
+    // payload-bearing SCE envelope with no body is a metadata-only message
+    // (chat state / marker / reaction), NOT a heartbeat — true OMEMO:2
+    // heartbeats carry no <payload> at all and never reach this code. The
+    // caller decides what to do with a bodyless content.
+    return sizzle('> content', envelope).pop() ?? null;
 }

--- a/src/headless/plugins/omemo/sce.js
+++ b/src/headless/plugins/omemo/sce.js
@@ -74,17 +74,24 @@ async function deriveKeys(content_key) {
  *   - <to> MUST for MUC (included when muc_jid is provided)
  *   - <time> MAY (omitted for now)
  *
+ * The `extensions` are extra element builders (XEP-0372 references, XEP-0461
+ * reply, OOB url, spoiler) spliced into `<content>` right after `<body>`, so
+ * body-coupled metadata is encrypted alongside the body instead of leaking in
+ * cleartext. They live inside the authenticated `<content>` and are therefore
+ * covered by the SCE HMAC.
+ *
  * @param {string} body - plaintext message body
  * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @param {import('strophe.js').Builder[]} [extensions] - extra <content> children
  * @returns {import('strophe.js').Builder}
  */
-function buildSCEEnvelope(body, { from_jid, to_jid }) {
+function buildSCEEnvelope(body, { from_jid, to_jid }, extensions = []) {
     const rpad_len = 1 + Math.floor(Math.random() * 100);
     const rpad = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(rpad_len))));
 
     return stx`
         <envelope xmlns="${Strophe.NS.SCE}">
-            <content><body xmlns="jabber:client">${body}</body></content>
+            <content><body xmlns="jabber:client">${body}</body>${extensions}</content>
             <rpad>${rpad}</rpad>
             <from xmlns="${Strophe.NS.SCE}" jid="${from_jid}"/>
             ${to_jid ? stx`<to xmlns="${Strophe.NS.SCE}" jid="${to_jid}"/>` : ''}
@@ -100,14 +107,15 @@ function buildSCEEnvelope(body, { from_jid, to_jid }) {
  *
  * @param {string} plaintext - the message body to encrypt
  * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @param {import('strophe.js').Builder[]} [extensions] - body-coupled metadata elements
  * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
  */
-export async function encryptSCE(plaintext, affixes) {
+export async function encryptSCE(plaintext, affixes, extensions = []) {
     // Random 32-byte content key
     const content_key = crypto.getRandomValues(new Uint8Array(32)).buffer;
     const { encKey, authKey, iv } = await deriveKeys(content_key);
 
-    const envelope = buildSCEEnvelope(plaintext, affixes);
+    const envelope = buildSCEEnvelope(plaintext, affixes, extensions);
     const plaintext_bytes = new TextEncoder().encode(envelope.toString());
 
     // AES-256-CBC encryption
@@ -133,10 +141,15 @@ export async function encryptSCE(plaintext, affixes) {
 /**
  * Decrypt an SCE/OMEMO 2 payload.
  *
+ * Returns both the plaintext body string and the decrypted `<content>` element,
+ * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler)
+ * against the authenticated content. `body`/`content` are `null` for a
+ * heartbeat (payload-less / bodyless) message.
+ *
  * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
  * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext
  * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes - for validation
- * @returns {Promise<string|null>} - plaintext message body
+ * @returns {Promise<{body: string|null, content: Element|null}>}
  */
 export async function decryptSCE(key_and_tag, payload_b64, expected_affixes) {
     if (key_and_tag.byteLength !== 48) {
@@ -163,14 +176,17 @@ export async function decryptSCE(key_and_tag, payload_b64, expected_affixes) {
     const plaintext_bytes = await crypto.subtle.decrypt({ name: 'AES-CBC', iv }, aes_key, ciphertext);
     const envelope_xml = new TextDecoder().decode(plaintext_bytes);
 
-    return parseSCEEnvelope(envelope_xml, expected_affixes);
+    const content = parseSCEEnvelope(envelope_xml, expected_affixes);
+    const body = content ? (sizzle('> body', content).pop()?.textContent ?? null) : null;
+    return { body, content };
 }
 
 /**
- * Parse an SCE <envelope> and validate affixes, returning the message body.
+ * Parse an SCE <envelope>, validate its affixes and return the decrypted
+ * `<content>` element (or `null` for a heartbeat with no `<content>`/`<body>`).
  * @param {string} envelope_xml
  * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes
- * @returns {string}
+ * @returns {Element|null}
  */
 function parseSCEEnvelope(envelope_xml, { sender_jid, to_jid }) {
     const parser = new DOMParser();
@@ -207,5 +223,5 @@ function parseSCEEnvelope(envelope_xml, { sender_jid, to_jid }) {
         // Empty/heartbeat message — no body
         return null;
     }
-    return body_el.textContent;
+    return content_el;
 }

--- a/src/headless/plugins/omemo/sce.js
+++ b/src/headless/plugins/omemo/sce.js
@@ -195,7 +195,7 @@ export async function decryptSCE(key_and_tag, payload_b64, expected_affixes) {
  */
 function parseSCEEnvelope(envelope_xml, { sender_jid, to_jid }) {
     const parser = new DOMParser();
-    const doc = parser.parseFromString(envelope_xml, 'application/xml');
+    const doc = parser.parseFromString(envelope_xml, 'text/xml');
 
     const envelope = doc.documentElement;
     if (!envelope || envelope.localName !== 'envelope' || envelope.namespaceURI !== Strophe.NS.SCE) {

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -957,6 +957,60 @@ async function sendOMEMO2ChatState(chatbox) {
 }
 
 /**
+ * Send a XEP-0333 chat marker for an OMEMO-active chat.
+ *
+ * Called from {@link sendMarker} in `shared/actions.js` when `omemo_active` is
+ * set. The cleartext path is suppressed in that case, so this function is solely
+ * responsible for the outgoing marker in encrypted sessions.
+ *
+ * - OMEMO:2 devices present → encrypted SCE stanza.
+ * - Legacy-only session (no v2 devices) → cleartext marker, matching what
+ *   other clients do for legacy OMEMO.
+ * - Mixed session (both v2 and legacy devices) → encrypted only; legacy
+ *   devices in a mixed session do not receive the marker.
+ *
+ * @param {import('../../shared/chatbox.js').default} chatbox
+ * @param {string} to_jid
+ * @param {string} msg_id - the `id` of the message being marked
+ * @param {string} type - marker type ('displayed', 'received', 'acknowledged')
+ * @param {string} [msg_type] - 'chat' or 'groupchat'; defaults to 'chat'
+ */
+export async function sendOMEMO2Marker(chatbox, to_jid, msg_id, type, msg_type) {
+    const stanza_type = msg_type || 'chat';
+    const { v2, legacy } = await getBundlesAndBuildSessions(chatbox);
+
+    if (v2.length) {
+        const el = await getOMEMO2EncryptedElement(
+            chatbox,
+            null,
+            [stx`<${Stanza.unsafeXML(type)} xmlns="${Strophe.NS.MARKERS}" id="${msg_id}"/>`],
+            v2,
+        );
+        api.send(
+            stx`<message xmlns="jabber:client"
+                    from="${_converse.session.get('jid')}"
+                    to="${to_jid}"
+                    type="${stanza_type}"
+                    id="${u.getUniqueId()}">
+                ${el}
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`,
+        );
+    } else if (legacy.length) {
+        // Legacy-only session: send cleartext marker, same as non-OMEMO clients do.
+        api.send(
+            stx`<message from="${_converse.session.get('jid')}"
+                    id="${u.getUniqueId()}"
+                    to="${to_jid}"
+                    type="${stanza_type}"
+                    xmlns="jabber:client">
+                <${Stanza.unsafeXML(type)} xmlns="${Strophe.NS.MARKERS}" id="${msg_id}"/>
+            </message>`,
+        );
+    }
+}
+
+/**
  * Encrypt `plaintext` (and, for omemo:2, `extensions` inside the SCE
  * `<content>`) for every reachable recipient device of `chat`, returning the
  * OMEMO `<encrypted>` element(s) to attach to a message stanza plus the EME

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -759,16 +759,13 @@ async function getLegacyEncryptedElement(message, devices) {
 }
 
 /**
- * Build the metadata elements (XEP-0085 chat state, XEP-0372 references,
- * XEP-0461 reply, OOB url, spoiler) that go inside the OMEMO 2 SCE `<content>`
- * envelope.
+ * Build the metadata elements that go inside the OMEMO 2 SCE `<content>` envelope.
  *
  * These mirror the cleartext builders in `createMessageStanza`
  * ({@link module:headless-shared-model-with-messages}), but for encrypted
- * messages they live encrypted inside `<content>` instead of in cleartext — so
- * we don't leak who you mentioned/replied to, nor an XEP-0085 chat state, on
- * every encrypted message. Legacy OMEMO 1 recipients don't get them (its
- * payload is a string, not an element tree) and degrade gracefully.
+ * messages they live encrypted inside `<content>` instead of in cleartext.
+ * Legacy OMEMO 1 recipients don't get them (its payload is a string, not an element)
+ * and degrade gracefully.
  * @param {import('../../shared/message').default} message
  * @returns {import('strophe.js').Builder[]}
  */
@@ -794,6 +791,14 @@ function getSCEExtensions(message) {
     });
     if (reply_to_id) {
         extensions.push(stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>`);
+        const reply_fallback = message.get('reply_fallback');
+        if (reply_fallback) {
+            extensions.push(
+                stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="${Strophe.NS.REPLY}">
+                    <body start="${reply_fallback.start}" end="${reply_fallback.end}"/>
+                </fallback>`,
+            );
+        }
     }
     return extensions;
 }
@@ -861,9 +866,7 @@ export async function sendOMEMOHeartbeat(chat, version) {
     const devices = is_v2 ? v2 : legacy;
     if (!devices.length) return;
 
-    const encrypted_el = is_v2
-        ? await getOMEMO2HeartbeatElement(devices)
-        : await getLegacyHeartbeatElement(devices);
+    const encrypted_el = is_v2 ? await getOMEMO2HeartbeatElement(devices) : await getLegacyHeartbeatElement(devices);
 
     const is_muc = chat instanceof MUC;
     const connection = api.connection.get();

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -794,7 +794,7 @@ function getSCEExtensions(message) {
     });
     if (reply_to_id) {
         extensions.push(stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>`);
-        const reply_fallback = message.get('reply_fallback');
+        const reply_fallback = message.get('fallback')?.[Strophe.NS.REPLY];
         if (reply_fallback) {
             extensions.push(
                 stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="${Strophe.NS.REPLY}">

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -759,6 +759,40 @@ async function getLegacyEncryptedElement(message, devices) {
 }
 
 /**
+ * Build the body-coupled metadata elements (XEP-0372 references, XEP-0461
+ * reply, OOB url, spoiler) that go inside the OMEMO 2 SCE `<content>` envelope.
+ *
+ * These mirror the cleartext builders in `createMessageStanza`
+ * ({@link module:headless-shared-model-with-messages}), but for encrypted
+ * messages they live encrypted inside `<content>` instead of in cleartext.
+ * Legacy OMEMO 1 recipients don't get them (its payload is a string, not an
+ * element tree) and degrade gracefully.
+ * @param {import('../../shared/message').default} message
+ * @returns {import('strophe.js').Builder[]}
+ */
+function getSCEExtensions(message) {
+    const { oob_url, is_spoiler, spoiler_hint, references, reply_to_id, reply_to } = message.attributes;
+    const extensions = [];
+    if (oob_url) {
+        extensions.push(stx`<x xmlns="${Strophe.NS.OUTOFBAND}"><url>${oob_url}</url></x>`);
+    }
+    if (is_spoiler) {
+        extensions.push(stx`<spoiler xmlns="${Strophe.NS.SPOILER}">${spoiler_hint ?? ''}</spoiler>`);
+    }
+    references?.forEach((ref) => {
+        extensions.push(stx`<reference xmlns="${Strophe.NS.REFERENCE}"
+                begin="${ref.begin}"
+                end="${ref.end}"
+                type="${ref.type}"
+                uri="${ref.uri}"></reference>`);
+    });
+    if (reply_to_id) {
+        extensions.push(stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>`);
+    }
+    return extensions;
+}
+
+/**
  * @param {import('../../shared/chatbox').default} chat
  * @param {import('../../shared/message').default} message
  * @param {import('./device').default[]} devices
@@ -768,11 +802,13 @@ async function getOMEMO2EncryptedElement(chat, message, devices) {
     const muc_jid = is_muc ? chat.get('jid') : null;
     const bare_jid = _converse.session.get('bare_jid');
 
-    // Build SCE envelope and encrypt it
-    const { key_and_tag, payload } = await encryptSCE(message.get('plaintext'), {
-        from_jid: bare_jid,
-        to_jid: muc_jid,
-    });
+    // Build SCE envelope and encrypt it. Body-coupled metadata
+    // (references/reply/oob/spoiler) is encrypted inside <content>.
+    const { key_and_tag, payload } = await encryptSCE(
+        message.get('plaintext'),
+        { from_jid: bare_jid, to_jid: muc_jid },
+        getSCEExtensions(message),
+    );
 
     const v2_dicts = await encryptKeyForDevices(key_and_tag, devices, Strophe.NS.OMEMO2);
     return buildOMEMO2EncryptedElement(v2_dicts, payload);

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -13,7 +13,7 @@ import DeviceLists from './devicelists.js';
 import { VersionedOMEMOStore } from './versioned-store.js';
 import { encryptSCE, decryptSCE } from './sce.js';
 
-const { u, Strophe, stx } = converse.env;
+const { u, Strophe, stx, Stanza } = converse.env;
 const { arrayBufferToHex, base64ToArrayBuffer } = u;
 
 // Affiliations whose members are valid recipients of OMEMO-encrypted MUC
@@ -883,6 +883,80 @@ export async function sendOMEMOHeartbeat(chat, version) {
 }
 
 /**
+ * Send a XEP-0085 chat state notification for an OMEMO-active chat.
+ *
+ * Called from the `change:chat_state` listener added by {@link onChatInitialized}.
+ * The cleartext path in `sendChatState` / `MUC#sendChatState` is suppressed
+ * when `omemo_active`, so this function is solely responsible for the outgoing
+ * notification in encrypted sessions.
+ *
+ * - OMEMO:2 devices present → encrypted SCE stanza with `<no-store>` hints.
+ * - Legacy-only session (no v2 devices) → cleartext stanza, matching what
+ *   other clients do for legacy OMEMO.
+ * - Mixed session (both v2 and legacy devices) → encrypted only; legacy
+ *   devices in a mixed session do not receive a CSN.
+ *
+ * @param {import('../../shared/chatbox.js').default} chatbox
+ */
+async function sendOMEMO2ChatState(chatbox) {
+    if (!chatbox.get('omemo_active')) return;
+
+    const chat_state = chatbox.get('chat_state');
+    if (!chat_state) return;
+
+    const allowed = api.settings.get('send_chat_state_notifications');
+    if (!allowed || (Array.isArray(allowed) && !allowed.includes(chat_state))) {
+        return;
+    }
+
+    const is_muc = chatbox instanceof MUC;
+    if (is_muc) {
+        // Mirror the guards in MUC#sendChatState
+        if (!(/** @type {MUC} */ (chatbox).isEntered())) return;
+        if (
+            /** @type {MUC} */ (chatbox).features?.get('moderated') &&
+            /** @type {MUC} */ (chatbox).getOwnRole() === 'visitor'
+        )
+            return;
+        if (chat_state === 'gone') return; // <gone/> not applicable in MUC
+    }
+
+    const jid = chatbox.get('jid');
+    const type = is_muc ? 'groupchat' : 'chat';
+    const { v2, legacy } = await getBundlesAndBuildSessions(chatbox);
+
+    if (v2.length) {
+        const el = await getOMEMO2EncryptedElement(
+            chatbox,
+            null,
+            [stx`<${Stanza.unsafeXML(chat_state)} xmlns="${Strophe.NS.CHATSTATES}"/>`],
+            v2,
+        );
+        api.send(
+            stx`<message xmlns="jabber:client"
+                    from="${_converse.session.get('jid')}"
+                    to="${jid}"
+                    type="${type}"
+                    id="${u.getUniqueId()}">
+                ${el}
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+                <no-store xmlns="${Strophe.NS.HINTS}"/>
+                <no-permanent-store xmlns="${Strophe.NS.HINTS}"/>
+            </message>`,
+        );
+    } else if (legacy.length) {
+        // Legacy-only session: send cleartext, same as non-OMEMO clients do.
+        api.send(
+            stx`<message to="${jid}" type="${type}" xmlns="jabber:client">
+                <${Stanza.unsafeXML(chat_state)} xmlns="${Strophe.NS.CHATSTATES}"/>
+                <no-store xmlns="${Strophe.NS.HINTS}"/>
+                <no-permanent-store xmlns="${Strophe.NS.HINTS}"/>
+            </message>`,
+        );
+    }
+}
+
+/**
  * Encrypt `plaintext` (and, for omemo:2, `extensions` inside the SCE
  * `<content>`) for every reachable recipient device of `chat`, returning the
  * OMEMO `<encrypted>` element(s) to attach to a message stanza plus the EME
@@ -1037,6 +1111,9 @@ async function onOccupantAdded(chatroom, occupant) {
  */
 export function onChatInitialized(chatbox) {
     checkOMEMOSupported(chatbox, true);
+
+    chatbox.on('change:chat_state', () => sendOMEMO2ChatState(chatbox));
+
     if (chatbox.get('type') === constants.CHATROOMS_TYPE) {
         /** @type {MUC} */ (chatbox).occupants.on(
             'add',

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -759,20 +759,26 @@ async function getLegacyEncryptedElement(message, devices) {
 }
 
 /**
- * Build the body-coupled metadata elements (XEP-0372 references, XEP-0461
- * reply, OOB url, spoiler) that go inside the OMEMO 2 SCE `<content>` envelope.
+ * Build the metadata elements (XEP-0085 chat state, XEP-0372 references,
+ * XEP-0461 reply, OOB url, spoiler) that go inside the OMEMO 2 SCE `<content>`
+ * envelope.
  *
  * These mirror the cleartext builders in `createMessageStanza`
  * ({@link module:headless-shared-model-with-messages}), but for encrypted
- * messages they live encrypted inside `<content>` instead of in cleartext.
- * Legacy OMEMO 1 recipients don't get them (its payload is a string, not an
- * element tree) and degrade gracefully.
+ * messages they live encrypted inside `<content>` instead of in cleartext — so
+ * we don't leak who you mentioned/replied to, nor an XEP-0085 chat state, on
+ * every encrypted message. Legacy OMEMO 1 recipients don't get them (its
+ * payload is a string, not an element tree) and degrade gracefully.
  * @param {import('../../shared/message').default} message
  * @returns {import('strophe.js').Builder[]}
  */
 function getSCEExtensions(message) {
     const { oob_url, is_spoiler, spoiler_hint, references, reply_to_id, reply_to } = message.attributes;
-    const extensions = [];
+    // The `<active/>` chat state that `createMessageStanza` would otherwise add
+    // in cleartext is carried here instead (it's gated out of the cleartext
+    // stanza for encrypted messages), so it still clears the recipient's typing
+    // indicator without leaking activity metadata to the server.
+    const extensions = [stx`<active xmlns="${Strophe.NS.CHATSTATES}"/>`];
     if (oob_url) {
         extensions.push(stx`<x xmlns="${Strophe.NS.OUTOFBAND}"><url>${oob_url}</url></x>`);
     }

--- a/src/headless/plugins/omemo/utils.js
+++ b/src/headless/plugins/omemo/utils.js
@@ -305,8 +305,11 @@ export async function generateFingerprint(device) {
 }
 
 /**
+ * Surface a user-facing alert for a failed encrypted send and re-throw, so the
+ * send pipeline (the `createMessageStanza` handler) aborts. Always throws.
  * @param {Error|errors.IQError|errors.UserFacingError} e
  * @param {import('../../shared/chatbox.js').default} chat
+ * @returns {never}
  */
 export function handleMessageSendError(e, chat) {
     const { __ } = _converse;
@@ -742,11 +745,11 @@ function buildOMEMO2EncryptedElement(v2_dicts, payload) {
 }
 
 /**
- * @param {import('../../shared/message').default} message
+ * @param {string} plaintext - the message body to encrypt (the legacy payload)
  * @param {import('./device').default[]} devices
  */
-async function getLegacyEncryptedElement(message, devices) {
-    const { key_and_tag, iv, payload } = await encryptMessage(message.get('plaintext'));
+async function getLegacyEncryptedElement(plaintext, devices) {
+    const { key_and_tag, iv, payload } = await encryptMessage(plaintext);
 
     // The 16 bytes key and the GCM authentication tag (The tag
     // SHOULD have at least 128 bit) are concatenated and for each
@@ -805,21 +808,18 @@ function getSCEExtensions(message) {
 
 /**
  * @param {import('../../shared/chatbox').default} chat
- * @param {import('../../shared/message').default} message
+ * @param {string|null} plaintext - the SCE `<body>` (omitted when falsy, e.g. a metadata-only message)
+ * @param {import('strophe.js').Builder[]} extensions - extra elements for the SCE `<content>`
  * @param {import('./device').default[]} devices
  */
-async function getOMEMO2EncryptedElement(chat, message, devices) {
+async function getOMEMO2EncryptedElement(chat, plaintext, extensions, devices) {
     const is_muc = chat instanceof MUC;
     const muc_jid = is_muc ? chat.get('jid') : null;
     const bare_jid = _converse.session.get('bare_jid');
 
     // Build SCE envelope and encrypt it. Body-coupled metadata
-    // (references/reply/oob/spoiler) is encrypted inside <content>.
-    const { key_and_tag, payload } = await encryptSCE(
-        message.get('plaintext'),
-        { from_jid: bare_jid, to_jid: muc_jid },
-        getSCEExtensions(message),
-    );
+    // (references/reply/oob/spoiler/reactions) is encrypted inside <content>.
+    const { key_and_tag, payload } = await encryptSCE(plaintext, { from_jid: bare_jid, to_jid: muc_jid }, extensions);
 
     const v2_dicts = await encryptKeyForDevices(key_and_tag, devices, Strophe.NS.OMEMO2);
     return buildOMEMO2EncryptedElement(v2_dicts, payload);
@@ -869,11 +869,9 @@ export async function sendOMEMOHeartbeat(chat, version) {
     const encrypted_el = is_v2 ? await getOMEMO2HeartbeatElement(devices) : await getLegacyHeartbeatElement(devices);
 
     const is_muc = chat instanceof MUC;
-    const connection = api.connection.get();
-    if (!connection) return;
 
     const stanza = stx`<message xmlns="jabber:client"
-            from="${is_muc ? connection.jid : _converse.session.get('jid')}"
+            from="${_converse.session.get('jid')}"
             to="${chat.get('jid')}"
             type="${is_muc ? 'groupchat' : 'chat'}"
             id="${u.getUniqueId()}">
@@ -885,35 +883,65 @@ export async function sendOMEMOHeartbeat(chat, version) {
 }
 
 /**
+ * Encrypt `plaintext` (and, for omemo:2, `extensions` inside the SCE
+ * `<content>`) for every reachable recipient device of `chat`, returning the
+ * OMEMO `<encrypted>` element(s) to attach to a message stanza plus the EME
+ * (XEP-0380) namespace to advertise.
+ *
+ * @param {import('../../shared/chatbox').default} chat
+ * @param {string|null} plaintext - the body (legacy payload / omemo:2 SCE `<body>`)
+ * @param {import('strophe.js').Builder[]} [extensions] - encrypted SCE `<content>` children
+ * @returns {Promise<{elements: import('strophe.js').Builder[], eme_ns: string}>}
+ */
+export async function getEncryptedElements(chat, plaintext, extensions = []) {
+    const { legacy, v2 } = await getBundlesAndBuildSessions(chat);
+
+    const elements = [];
+    if (legacy.length > 0) {
+        elements.push(await getLegacyEncryptedElement(plaintext, legacy));
+    }
+    if (v2.length > 0) {
+        elements.push(await getOMEMO2EncryptedElement(chat, plaintext, extensions, v2));
+    }
+    // Advertise the newest method present (v2 if any device uses it). If both
+    // device sets are empty getBundlesAndBuildSessions has already thrown.
+    const eme_ns = v2.length > 0 ? Strophe.NS.OMEMO2 : Strophe.NS.OMEMO;
+    return { elements, eme_ns };
+}
+
+/**
+ * Handler for the `createMessageStanza` hook: for an encrypted outgoing chat
+ * message, attach the OMEMO `<encrypted>` element(s) (plus store + EME hints) to
+ * the stanza that was built from the Message model. Non-encrypted messages pass
+ * through untouched. A send failure is surfaced to the user via
+ * {@link handleMessageSendError} (which re-throws to abort the send).
+ *
  * @param {import('../../shared/chatbox').default} chat
  * @param {import('../../shared/types').MessageAndStanza} data
  * @return {Promise<import('../../shared/types').MessageAndStanza>}
  */
-export async function createOMEMOMessageStanza(chat, data) {
-    const { stanza } = data;
-    const { message } = data;
+export async function createMessageStanzaHandler(chat, data) {
+    const { stanza, message } = data;
 
     if (!message.get('is_encrypted')) return data;
-    if (!message.get('body')) throw new Error('No message body to encrypt!');
 
-    const { legacy, v2 } = await getBundlesAndBuildSessions(chat);
+    try {
+        if (!message.get('body')) throw new Error('No message body to encrypt!');
 
-    if (legacy.length > 0) {
-        stanza.cnode(await getLegacyEncryptedElement(message, legacy)).root();
+        const { elements, eme_ns } = await getEncryptedElements(
+            chat,
+            message.get('plaintext'),
+            getSCEExtensions(message),
+        );
+        for (const el of elements) {
+            stanza.cnode(el).root();
+        }
+        stanza.cnode(stx`<store xmlns="${Strophe.NS.HINTS}"/>`).root();
+        stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${eme_ns}"/>`).root();
+        return { message, stanza };
+    } catch (e) {
+        handleMessageSendError(e, chat); // surfaces a user-facing alert and re-throws
     }
-
-    if (v2.length > 0) {
-        stanza.cnode(await getOMEMO2EncryptedElement(chat, message, v2)).root();
-    }
-
-    stanza.cnode(stx`<store xmlns="${Strophe.NS.HINTS}"/>`).root();
-
-    if (v2.length > 0) {
-        stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>`).root();
-    } else if (legacy.length > 0) {
-        stanza.cnode(stx`<encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO}"/>`).root();
-    }
-    return { message, stanza };
 }
 
 /**

--- a/src/headless/plugins/reactions/plugin.js
+++ b/src/headless/plugins/reactions/plugin.js
@@ -26,6 +26,7 @@ converse.plugins.add('converse-reactions', {
     initialize() {
         api.listen.on('parseMessage', parseReactionsMessage);
         api.listen.on('parseMUCMessage', parseReactionsMessage);
+        api.listen.on('parseEncryptedContent', parseReactionsMessage);
 
         api.listen.on('getDuplicateMessageQueries', getDuplicateMessageQueries);
         api.listen.on('getUpdatedMessageAttributes', getUpdatedMessageAttributes);

--- a/src/headless/shared/actions.js
+++ b/src/headless/shared/actions.js
@@ -1,5 +1,6 @@
 import log from '@converse/log';
 import { Strophe } from 'strophe.js';
+import _converse from './_converse.js';
 import api from './api/index.js';
 import converse from './api/public.js';
 import { CHAT_STATES, MARKER_TYPES } from './constants.js';
@@ -22,25 +23,48 @@ export function rejectMessage(stanza, text) {
                     <not-allowed xmlns="${Strophe.NS.STANZAS}"/>
                     <text xmlns="${Strophe.NS.STANZAS}">${text}</text>
                 </error>
-            </message>`
+            </message>`,
     );
     log.warn(`Rejecting message stanza with the following reason: ${text}`);
     log.warn(stanza);
 }
 
 /**
- * Send out a XEP-0333 chat marker
+ * Send out a XEP-0333 chat marker.
+ * @fires sendMarker
  * @param {string} to_jid
  * @param {string} id - The id of the message being marked
  * @param {import("./types").MessageMarkerType} type - The marker type
  * @param {string} [msg_type]
- * @return void
  */
-export function sendMarker(to_jid, id, type, msg_type) {
+export async function sendMarker(to_jid, id, type, msg_type) {
     if (!MARKER_TYPES.includes(type)) {
         log.error(`Invalid marker type: ${type}`);
         return;
     }
+    const bare_jid = Strophe.getBareJidFromJid(to_jid);
+    const chatbox = _converse.state.chatboxes?.get(bare_jid);
+
+    /**
+     * Hook which lets plugins handle sending a chat marker (such as OMEMO
+     * which sends an encrypted version). If any hook listener returns
+     * `{ handled: true }` the cleartext stanza is suppressed.
+     *
+     * Context: the {@link ChatBox} / {@link MUC} model for `to_jid`, or
+     * `undefined` if not found.
+     *
+     * Hook data: `{ to_jid, id, type, msg_type, handled: false }`
+     *
+     * @example
+     *  api.listen.on('sendMarker', async (chatbox, data) => {
+     *      if (!chatbox?.get('omemo_active')) return data;
+     *      await sendEncryptedMarker(chatbox, data);
+     *      return { ...data, handled: true };
+     *  });
+     */
+    const { handled } = await api.hook('sendMarker', chatbox, { to_jid, id, type, msg_type, handled: false });
+    if (handled) return;
+
     const stanza = stx`
         <message from="${api.connection.get().jid}"
                 id="${u.getUniqueId()}"
@@ -89,12 +113,15 @@ export function sendChatState(jid, chat_state) {
         if (Array.isArray(allowed) && !allowed.includes(chat_state)) {
             return;
         }
+        // When OMEMO is active the OMEMO plugin sends an encrypted SCE version;
+        // suppress the cleartext stanza so only one notification goes out.
+        if (_converse.state.chatboxes?.get(jid)?.get('omemo_active')) return;
         api.send(
             stx`<message id="${u.getUniqueId()}" to="${jid}" type="chat" xmlns="jabber:client">
                 <${Stanza.unsafeXML(chat_state)} xmlns="${Strophe.NS.CHATSTATES}"/>
                 <no-store xmlns="${Strophe.NS.HINTS}"/>
                 <no-permanent-store xmlns="${Strophe.NS.HINTS}"/>
-            </message>`
+            </message>`,
         );
     }
 }

--- a/src/headless/shared/message.js
+++ b/src/headless/shared/message.js
@@ -174,14 +174,32 @@ class BaseMessage extends ModelWithVCard(ModelWithContact(ColorAwareModel(Model)
     }
 
     getMessageText() {
+        let text;
         if (this.get('is_encrypted')) {
             const { __ } = _converse;
-            return this.get('plaintext') || this.get('body') || __('Undecryptable OMEMO message');
+            text = this.get('plaintext') || this.get('body') || __('Undecryptable OMEMO message');
         } else if (['groupchat', 'chat', 'normal'].includes(this.get('type'))) {
-            return this.get('body');
+            text = this.get('body');
         } else {
-            return this.get('message');
+            text = this.get('message');
         }
+        return this.stripReplyFallback(text);
+    }
+
+    /**
+     * Strip the XEP-0461 compatibility fallback — the `>`-quoted copy of the
+     * replied-to message — from `text`. Converse renders the reply context from
+     * the structured `<reply>`, so per XEP-0461 it must not also show the quoted
+     * fallback. Offsets are XEP-0426 Unicode code points, so we slice on the
+     * code-point array rather than UTF-16 units.
+     * @param {string} text
+     * @returns {string}
+     */
+    stripReplyFallback(text) {
+        const fallback = this.get('reply_fallback');
+        if (!text || !fallback || !this.get('reply_to_id')) return text;
+        const chars = [...text];
+        return chars.slice(0, fallback.start).join('') + chars.slice(fallback.end).join('');
     }
 
     /**
@@ -215,7 +233,7 @@ class BaseMessage extends ModelWithVCard(ModelWithContact(ColorAwareModel(Model)
         // to be manually set via document.cookie, so we're leaving it out here.
         return {
             headers: headers
-                .map((h) => ({ 'name': h.getAttribute('name'), 'value': h.textContent }))
+                .map((h) => ({ name: h.getAttribute('name'), value: h.textContent }))
                 .filter((h) => ['Authorization', 'Expires'].includes(h.name)),
         };
     }

--- a/src/headless/shared/message.js
+++ b/src/headless/shared/message.js
@@ -196,7 +196,7 @@ class BaseMessage extends ModelWithVCard(ModelWithContact(ColorAwareModel(Model)
      * @returns {string}
      */
     stripReplyFallback(text) {
-        const fallback = this.get('reply_fallback');
+        const fallback = this.get('fallback')?.[Strophe.NS.REPLY];
         if (!text || !fallback || !this.get('reply_to_id')) return text;
         const chars = [...text];
         return chars.slice(0, fallback.start).join('') + chars.slice(fallback.end).join('');

--- a/src/headless/shared/model-with-messages.js
+++ b/src/headless/shared/model-with-messages.js
@@ -341,7 +341,7 @@ export default function ModelWithMessages(BaseModel) {
             }
 
             // XEP-0426/0428 count fallback offsets in Unicode code points.
-            attrs.reply_fallback = { start: 0, end: [...quote].length };
+            attrs.fallback = { [Strophe.NS.REPLY]: { start: 0, end: [...quote].length } };
             return attrs;
         }
 
@@ -816,10 +816,12 @@ export default function ModelWithMessages(BaseModel) {
                     from: attrs.from,
                     msgid: attrs.msgid,
                 };
-                // XXX: Need to take XEP-428 <fallback> into consideration
-                if (!attrs.is_encrypted && attrs.body) {
-                    // We can't match the message if it's a reflected
-                    // encrypted message (e.g. via MAM or in a MUC)
+                if (!attrs.is_encrypted && !attrs.fallback && attrs.body) {
+                    // Skip body matching for encrypted messages (body is ciphertext /
+                    // EME fallback, not the plaintext) and for messages with a XEP-0428
+                    // <fallback> body marker (body includes display-only content such as
+                    // quoted text or reaction emoji — msgid + from is sufficient for
+                    // identity in those cases).
                     query['body'] = attrs.body;
                 }
                 return query;
@@ -1032,10 +1034,10 @@ export default function ModelWithMessages(BaseModel) {
                 references,
                 reply_to_id,
                 reply_to,
-                reply_fallback,
                 spoiler_hint,
                 type,
             } = message.attributes;
+            const reply_fallback = message.get('fallback')?.[Strophe.NS.REPLY];
 
             const stanza = stx`
                 <message xmlns="jabber:client"

--- a/src/headless/shared/model-with-messages.js
+++ b/src/headless/shared/model-with-messages.js
@@ -16,6 +16,11 @@ import { parseMessage } from '../plugins/chat/parsers.js';
 
 const { Strophe, stx, u } = converse.env;
 
+// How many code points of the replied-to message to quote in the XEP-0461
+// compatibility fallback. Matches the preview length shown by the reply-context
+// UI (shared/chat/reply-context.js), so we never quote more than we'd display.
+const REPLY_FALLBACK_QUOTE_LENGTH = 80;
+
 /**
  * Adds a messages collection to a model and various methods related to sending
  * and receiving chat messages.
@@ -273,6 +278,71 @@ export default function ModelWithMessages(BaseModel) {
          */
         async getOutgoingMessageAttributes(_attrs) {
             throw new errors.MethodNotImplementedError('getOutgoingMessageAttributes is not implemented');
+        }
+
+        /**
+         * Look up the message being replied to (XEP-0461). For groupchat the
+         * `reply_to_id` is a XEP-0359 stanza_id; otherwise it's the origin_id or msgid.
+         * @param {string} reply_to_id
+         * @returns {BaseMessage|undefined}
+         */
+        getReferencedMessage(reply_to_id) {
+            if (!reply_to_id) return undefined;
+
+            if (this.get('message_type') === 'groupchat') {
+                const muc_jid = this.get('jid');
+                return this.messages.models.find((m) => m.get(`stanza_id ${muc_jid}`) === reply_to_id);
+            }
+            return this.messages.models.find(
+                (m) => m.get('origin_id') === reply_to_id || m.get('msgid') === reply_to_id,
+            );
+        }
+
+        /**
+         * XEP-0461 compatibility fallback. When sending a reply, prepend a
+         * XEP-0393 `>`-quoted copy of the replied-to text to the body, so clients
+         * that don't support structured replies still see the context.
+         * @param {MessageAttributes} attrs
+         * @returns {MessageAttributes}
+         */
+        addReplyFallback(attrs) {
+            if (!attrs.reply_to_id || !attrs.body) return attrs;
+            const replied = this.getReferencedMessage(attrs.reply_to_id);
+            const quoted = replied?.getMessageText();
+            if (!quoted) return attrs;
+
+            // Truncate the quoted original (by code points, XEP-0426) so replying
+            // to a long message doesn't prepend the whole thing to the body. Only
+            // the quote is truncated — never the user's own reply text.
+            const chars = [...quoted];
+            const truncated =
+                chars.length > REPLY_FALLBACK_QUOTE_LENGTH
+                    ? chars.slice(0, REPLY_FALLBACK_QUOTE_LENGTH).join('') + '…'
+                    : quoted;
+
+            const quote =
+                `> ${replied.getDisplayName()}:\n` +
+                truncated
+                    .split('\n')
+                    .map((line) => `> ${line}`)
+                    .join('\n') +
+                '\n';
+            attrs.body = quote + attrs.body;
+            attrs.message = attrs.body;
+
+            // References use UTF-16 offsets (match.index); shift by the same unit.
+            if (attrs.references?.length) {
+                const shift = quote.length;
+                attrs.references = attrs.references.map((r) => ({
+                    ...r,
+                    begin: r.begin + shift,
+                    end: r.end + shift,
+                }));
+            }
+
+            // XEP-0426/0428 count fallback offsets in Unicode code points.
+            attrs.reply_fallback = { start: 0, end: [...quote].length };
+            return attrs;
         }
 
         /**
@@ -962,6 +1032,7 @@ export default function ModelWithMessages(BaseModel) {
                 references,
                 reply_to_id,
                 reply_to,
+                reply_fallback,
                 spoiler_hint,
                 type,
             } = message.attributes;
@@ -989,6 +1060,13 @@ export default function ModelWithMessages(BaseModel) {
                             : ''
                     }
                     ${!is_encrypted && reply_to_id ? stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>` : ''}
+                    ${
+                        !is_encrypted && reply_to_id && reply_fallback
+                            ? stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="${Strophe.NS.REPLY}">
+                                    <body start="${reply_fallback.start}" end="${reply_fallback.end}"/>
+                                </fallback>`
+                            : ''
+                    }
                     ${edited ? stx`<replace xmlns="${Strophe.NS.MESSAGE_CORRECT}" id="${msgid}"></replace>` : ''}
                     ${origin_id ? stx`<origin-id xmlns="${Strophe.NS.SID}" id="${origin_id}"></origin-id>` : ''}
                 </message>`;

--- a/src/headless/shared/model-with-messages.js
+++ b/src/headless/shared/model-with-messages.js
@@ -973,7 +973,7 @@ export default function ModelWithMessages(BaseModel) {
                         type="${this.get('message_type')}"
                         id="${(edited && u.getUniqueId()) || msgid}">
                     ${body ? stx`<body>${body}</body>` : ''}
-                    <active xmlns="${Strophe.NS.CHATSTATES}"/>
+                    ${!is_encrypted ? stx`<active xmlns="${Strophe.NS.CHATSTATES}"/>` : ''}
                     ${type === 'chat' ? stx`<request xmlns="${Strophe.NS.RECEIPTS}"></request>` : ''}
                     ${!is_encrypted && oob_url ? stx`<x xmlns="${Strophe.NS.OUTOFBAND}"><url>${oob_url}</url></x>` : ''}
                     ${!is_encrypted && is_spoiler ? stx`<spoiler xmlns="${Strophe.NS.SPOILER}">${spoiler_hint ?? ''}</spoiler>` : ''}

--- a/src/headless/shared/model-with-messages.js
+++ b/src/headless/shared/model-with-messages.js
@@ -988,7 +988,7 @@ export default function ModelWithMessages(BaseModel) {
                               )
                             : ''
                     }
-                    ${reply_to_id ? stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>` : ''}
+                    ${!is_encrypted && reply_to_id ? stx`<reply xmlns="${Strophe.NS.REPLY}" id="${reply_to_id}" to="${reply_to || ''}"></reply>` : ''}
                     ${edited ? stx`<replace xmlns="${Strophe.NS.MESSAGE_CORRECT}" id="${msgid}"></replace>` : ''}
                     ${origin_id ? stx`<origin-id xmlns="${Strophe.NS.SID}" id="${origin_id}"></origin-id>` : ''}
                 </message>`;

--- a/src/headless/shared/parsers.js
+++ b/src/headless/shared/parsers.js
@@ -3,11 +3,11 @@
  */
 import sizzle from 'sizzle';
 import { Strophe } from 'strophe.js';
-import log from "@converse/log";
+import log from '@converse/log';
 import { decodeHTMLEntities } from '../utils/html.js';
 import { getAttributes } from '../utils/stanza.js';
 import { rejectMessage } from './actions.js';
-import { XFORM_TYPE_MAP,  XFORM_VALIDATE_TYPE_MAP } from './constants.js';
+import { XFORM_TYPE_MAP, XFORM_VALIDATE_TYPE_MAP } from './constants.js';
 import * as errors from './errors.js';
 import _converse from './_converse.js';
 import api from './api/index.js';
@@ -96,7 +96,7 @@ export async function parseErrorStanza(stanza) {
  *      the message stanza.
  * @returns {Object}
  */
-export function getStanzaIDs (stanza, original_stanza) {
+export function getStanzaIDs(stanza, original_stanza) {
     // Generic stanza ids
     const sids = sizzle(`stanza-id[xmlns="${Strophe.NS.SID}"]`, stanza);
     const sid_attrs = sids.reduce((acc, s) => {
@@ -128,7 +128,7 @@ export function getStanzaIDs (stanza, original_stanza) {
  * @param {Element} stanza
  * @returns {import('./types').EncryptionAttrs}
  */
-export function getEncryptionAttributes (stanza) {
+export function getEncryptionAttributes(stanza) {
     const eme_tag = sizzle(`encryption[xmlns="${Strophe.NS.EME}"]`, stanza).pop();
     const namespace = eme_tag?.getAttribute('namespace');
     const attrs = {};
@@ -151,7 +151,7 @@ export function getEncryptionAttributes (stanza) {
  *  message stanza, if it was contained, otherwise it's the message stanza itself.
  * @returns {import('./types').RetractionAttrs | {}}
  */
-export function getDeprecatedRetractionAttributes (stanza, original_stanza) {
+export function getDeprecatedRetractionAttributes(stanza, original_stanza) {
     const fastening = sizzle(`> apply-to[xmlns="${Strophe.NS.FASTEN}"]`, stanza).pop();
     if (fastening) {
         const applies_to_id = fastening.getAttribute('id');
@@ -162,7 +162,7 @@ export function getDeprecatedRetractionAttributes (stanza, original_stanza) {
             return {
                 editable: false,
                 retracted: time,
-                retracted_id: applies_to_id
+                retracted_id: applies_to_id,
             };
         }
     }
@@ -175,7 +175,7 @@ export function getDeprecatedRetractionAttributes (stanza, original_stanza) {
  *  message stanza, if it was contained, otherwise it's the message stanza itself.
  * @returns {import('./types').RetractionAttrs | {}}
  */
-export function getRetractionAttributes (stanza, original_stanza) {
+export function getRetractionAttributes(stanza, original_stanza) {
     const retraction = sizzle(`> retract[xmlns="${Strophe.NS.RETRACT}"]`, stanza).pop();
     if (retraction) {
         const delay = sizzle(`> delay[xmlns="${Strophe.NS.DELAY}"]`, original_stanza).pop();
@@ -183,7 +183,7 @@ export function getRetractionAttributes (stanza, original_stanza) {
         return {
             editable: false,
             retracted: time,
-            retracted_id: retraction.getAttribute('id')
+            retracted_id: retraction.getAttribute('id'),
         };
     } else {
         const tombstone =
@@ -194,7 +194,7 @@ export function getRetractionAttributes (stanza, original_stanza) {
                 editable: false,
                 is_tombstone: true,
                 retracted: tombstone.getAttribute('stamp'),
-                retraction_id: tombstone.getAttribute('id')
+                retraction_id: tombstone.getAttribute('id'),
             };
         }
     }
@@ -205,7 +205,7 @@ export function getRetractionAttributes (stanza, original_stanza) {
  * @param {Element} stanza
  * @param {Element} original_stanza
  */
-export function getCorrectionAttributes (stanza, original_stanza) {
+export function getCorrectionAttributes(stanza, original_stanza) {
     const el = sizzle(`replace[xmlns="${Strophe.NS.MESSAGE_CORRECT}"]`, stanza).pop();
     if (el) {
         const replace_id = el.getAttribute('id');
@@ -214,7 +214,7 @@ export function getCorrectionAttributes (stanza, original_stanza) {
             const time = delay ? dayjs(delay.getAttribute('stamp')).toISOString() : new Date().toISOString();
             return {
                 replace_id,
-                'edited': time
+                'edited': time,
             };
         }
     }
@@ -224,33 +224,36 @@ export function getCorrectionAttributes (stanza, original_stanza) {
 /**
  * @param {Element} stanza
  */
-export function getOpenGraphMetadata (stanza) {
+export function getOpenGraphMetadata(stanza) {
     const fastening = sizzle(`> apply-to[xmlns="${Strophe.NS.FASTEN}"]`, stanza).pop();
     if (fastening) {
         const applies_to_id = fastening.getAttribute('id');
         const meta = sizzle(`> meta[xmlns="${Strophe.NS.XHTML}"]`, fastening);
         if (meta.length) {
             const msg_limit = api.settings.get('message_limit');
-            const data = meta.reduce((acc, el) => {
-                const property = el.getAttribute('property');
-                if (property) {
-                    let value = decodeHTMLEntities(el.getAttribute('content') || '');
-                    if (msg_limit && property === 'og:description' && value.length >= msg_limit) {
-                        value = `${value.slice(0, msg_limit)}${decodeHTMLEntities('&#8230;')}`;
+            const data = meta.reduce(
+                (acc, el) => {
+                    const property = el.getAttribute('property');
+                    if (property) {
+                        let value = decodeHTMLEntities(el.getAttribute('content') || '');
+                        if (msg_limit && property === 'og:description' && value.length >= msg_limit) {
+                            value = `${value.slice(0, msg_limit)}${decodeHTMLEntities('&#8230;')}`;
+                        }
+                        acc[property] = value;
                     }
-                    acc[property] = value;
-                }
-                return acc;
-            }, {
-                ogp_for_id: applies_to_id,
-            });
+                    return acc;
+                },
+                {
+                    ogp_for_id: applies_to_id,
+                },
+            );
 
             const url = data['og:url'];
             if (url?.startsWith('/') && data['og:site_name']?.toLowerCase() === 'github') {
                 data['og:url'] = `https://github.com${url}`;
             }
 
-            if ("og:description" in data || "og:title" in data || "og:image" in data) {
+            if ('og:description' in data || 'og:title' in data || 'og:image' in data) {
                 return data;
             }
         }
@@ -258,27 +261,26 @@ export function getOpenGraphMetadata (stanza) {
     return {};
 }
 
-
 /**
  * @param {Element} stanza
  */
-export function getSpoilerAttributes (stanza) {
+export function getSpoilerAttributes(stanza) {
     const spoiler = sizzle(`spoiler[xmlns="${Strophe.NS.SPOILER}"]`, stanza).pop();
     return {
         'is_spoiler': !!spoiler,
-        'spoiler_hint': spoiler?.textContent
+        'spoiler_hint': spoiler?.textContent,
     };
 }
 
 /**
  * @param {Element} stanza
  */
-export function getOutOfBandAttributes (stanza) {
+export function getOutOfBandAttributes(stanza) {
     const xform = sizzle(`x[xmlns="${Strophe.NS.OUTOFBAND}"]`, stanza).pop();
     if (xform) {
         return {
             'oob_url': xform.querySelector('url')?.textContent,
-            'oob_desc': xform.querySelector('desc')?.textContent
+            'oob_desc': xform.querySelector('desc')?.textContent,
         };
     }
     return {};
@@ -288,7 +290,7 @@ export function getOutOfBandAttributes (stanza) {
  * Returns the human readable error message contained in a `groupchat` message stanza of type `error`.
  * @param {Element} stanza - The message stanza
  */
-export function getErrorAttributes (stanza) {
+export function getErrorAttributes(stanza) {
     if (stanza.getAttribute('type') === 'error') {
         const error = stanza.querySelector('error');
         const text = sizzle(`text[xmlns="${Strophe.NS.STANZAS}"]`, error).pop();
@@ -308,15 +310,34 @@ export function getErrorAttributes (stanza) {
  * @param {Element} stanza - The message stanza
  * @returns {Object} An object containing reply_to_id and reply_to if present
  */
-export function getReplyAttributes (stanza) {
+export function getReplyAttributes(stanza) {
     const reply = sizzle(`reply[xmlns="${Strophe.NS.REPLY}"]`, stanza).pop();
     if (reply) {
         return {
             reply_to_id: reply.getAttribute('id'),
-            reply_to: reply.getAttribute('to')
+            reply_to: reply.getAttribute('to'),
         };
     }
     return {};
+}
+
+/**
+ * Parse the XEP-0428 fallback indication for the XEP-0461 reply fallback body,
+ * i.e. the code-point range of the `>`-quoted text that supporting clients
+ * strip from the displayed body.
+ * @param {Element} stanza - The message stanza (or decrypted SCE `<content>`)
+ * @returns {{reply_fallback?: {start: number, end: number}}}
+ */
+export function getFallbackAttributes(stanza) {
+    const fallback = sizzle(`fallback[xmlns="${Strophe.NS.FALLBACK}"][for="${Strophe.NS.REPLY}"]`, stanza).pop();
+    const body = fallback ? sizzle('> body', fallback).pop() : null;
+    if (!body) return {};
+    return {
+        reply_fallback: {
+            start: Number(body.getAttribute('start')),
+            end: Number(body.getAttribute('end')),
+        },
+    };
 }
 
 /**
@@ -324,29 +345,32 @@ export function getReplyAttributes (stanza) {
  * @param {Element} stanza - The message stanza
  * @returns {import('./types').XEP372Reference[]}
  */
-export function getReferences (stanza) {
-    return sizzle(`reference[xmlns="${Strophe.NS.REFERENCE}"]`, stanza).map(ref => {
-        const anchor = ref.getAttribute('anchor');
-        const text = stanza.querySelector(anchor ? `#${anchor}` : 'body')?.textContent;
-        if (!text) {
-            log.warn(`Could not find referenced text for ${ref}`);
-            return null;
-        }
-        const begin = Number(ref.getAttribute('begin'));
-        const end = Number(ref.getAttribute('end'));
-        return {
-            begin, end,
-            type: ref.getAttribute('type'),
-            value: text.slice(begin, end),
-            uri: ref.getAttribute('uri')
-        };
-    }).filter(r => r);
+export function getReferences(stanza) {
+    return sizzle(`reference[xmlns="${Strophe.NS.REFERENCE}"]`, stanza)
+        .map((ref) => {
+            const anchor = ref.getAttribute('anchor');
+            const text = stanza.querySelector(anchor ? `#${anchor}` : 'body')?.textContent;
+            if (!text) {
+                log.warn(`Could not find referenced text for ${ref}`);
+                return null;
+            }
+            const begin = Number(ref.getAttribute('begin'));
+            const end = Number(ref.getAttribute('end'));
+            return {
+                begin,
+                end,
+                type: ref.getAttribute('type'),
+                value: text.slice(begin, end),
+                uri: ref.getAttribute('uri'),
+            };
+        })
+        .filter((r) => r);
 }
 
 /**
  * @param {Element} stanza
  */
-export function getReceiptId (stanza) {
+export function getReceiptId(stanza) {
     const receipt = sizzle(`received[xmlns="${Strophe.NS.RECEIPTS}"]`, stanza).pop();
     return receipt?.getAttribute('id');
 }
@@ -356,7 +380,7 @@ export function getReceiptId (stanza) {
  * @param {Element} stanza - The message stanza
  * @returns {Boolean}
  */
-export function isCarbon (stanza) {
+export function isCarbon(stanza) {
     const xmlns = Strophe.NS.CARBONS;
     return (
         sizzle(`message > received[xmlns="${xmlns}"]`, stanza).length > 0 ||
@@ -368,7 +392,7 @@ export function isCarbon (stanza) {
  * Returns the XEP-0085 chat state contained in a message stanza
  * @param {Element} stanza - The message stanza
  */
-export function getChatState (stanza) {
+export function getChatState(stanza) {
     return sizzle(
         `
         composing[xmlns="${NS.CHATSTATES}"],
@@ -376,7 +400,7 @@ export function getChatState (stanza) {
         inactive[xmlns="${NS.CHATSTATES}"],
         active[xmlns="${NS.CHATSTATES}"],
         gone[xmlns="${NS.CHATSTATES}"]`,
-        stanza
+        stanza,
     ).pop()?.nodeName;
 }
 
@@ -384,7 +408,7 @@ export function getChatState (stanza) {
  * @param {Element} stanza
  * @param {Object} attrs
  */
-export function isValidReceiptRequest (stanza, attrs) {
+export function isValidReceiptRequest(stanza, attrs) {
     return (
         attrs.sender !== 'me' &&
         !attrs.is_carbon &&
@@ -398,7 +422,7 @@ export function isValidReceiptRequest (stanza, attrs) {
  * i.e. it's not forwarded as part of a larger protocol, like MAM.
  * @param { Element } stanza
  */
-export function throwErrorIfInvalidForward (stanza) {
+export function throwErrorIfInvalidForward(stanza) {
     const bare_forward = sizzle(`message > forwarded[xmlns="${Strophe.NS.FORWARD}"]`, stanza).length;
     if (bare_forward) {
         rejectMessage(stanza, 'Forwarded messages not part of an encapsulating protocol are not supported');
@@ -413,14 +437,15 @@ export function throwErrorIfInvalidForward (stanza) {
  * @param {Element} stanza - The message stanza
  * @returns {Element}
  */
-export function getChatMarker (stanza) {
+export function getChatMarker(stanza) {
     // If we receive more than one marker (which shouldn't happen), we take
     // the highest level of acknowledgement.
-    return sizzle(`
+    return sizzle(
+        `
         acknowledged[xmlns="${Strophe.NS.MARKERS}"],
         displayed[xmlns="${Strophe.NS.MARKERS}"],
         received[xmlns="${Strophe.NS.MARKERS}"]`,
-        stanza
+        stanza,
     ).pop();
 }
 
@@ -428,7 +453,7 @@ export function getChatMarker (stanza) {
  * @param {Element} stanza
  * @returns {boolean}
  */
-export function isHeadline (stanza) {
+export function isHeadline(stanza) {
     return stanza.getAttribute('type') === 'headline';
 }
 
@@ -436,7 +461,7 @@ export function isHeadline (stanza) {
  * @param {Element} stanza
  * @returns {Promise<boolean>}
  */
-export async function isMUCPrivateMessage (stanza) {
+export async function isMUCPrivateMessage(stanza) {
     const bare_jid = Strophe.getBareJidFromJid(stanza.getAttribute('from'));
     return !!(await api.rooms.get(bare_jid));
 }
@@ -445,7 +470,7 @@ export async function isMUCPrivateMessage (stanza) {
  * @param {Element} stanza
  * @returns {boolean}
  */
-export function isServerMessage (stanza) {
+export function isServerMessage(stanza) {
     if (sizzle(`mentions[xmlns="${Strophe.NS.MENTIONS}"]`, stanza).pop()) {
         return false;
     }
@@ -466,7 +491,7 @@ export function isServerMessage (stanza) {
  * @param {Element} original_stanza - The message stanza
  * @returns {boolean}
  */
-export function isArchived (original_stanza) {
+export function isArchived(original_stanza) {
     return !!sizzle(`message > result[xmlns="${Strophe.NS.MAM}"]`, original_stanza).pop();
 }
 
@@ -495,7 +520,7 @@ function parseXFormField(field, readonly, stanza) {
                     required: !!field.querySelector('required'),
                     ...result,
                 };
-            }
+            },
         );
         return {
             type,
@@ -551,7 +576,8 @@ function parseXFormField(field, readonly, stanza) {
             required: !!field.querySelector('required'),
             ...result,
         };
-    } else if (v === 'ocr') { // Captcha
+    } else if (v === 'ocr') {
+        // Captcha
         const uri = field.querySelector('uri');
         const el = sizzle('data[cid="' + uri.textContent.replace(/^cid:/, '') + '"]', stanza)[0];
         return {
@@ -580,11 +606,11 @@ function parseXFormField(field, readonly, stanza) {
  * @param {Element} field
  */
 export function getInputType(field) {
-    const type = XFORM_TYPE_MAP[field.getAttribute('type')]
+    const type = XFORM_TYPE_MAP[field.getAttribute('type')];
     if (type == 'text') {
-        const datatypes = field.getElementsByTagNameNS("http://jabber.org/protocol/xdata-validate", "validate");
+        const datatypes = field.getElementsByTagNameNS('http://jabber.org/protocol/xdata-validate', 'validate');
         if (datatypes.length === 1) {
-            const datatype = datatypes[0].getAttribute("datatype");
+            const datatype = datatypes[0].getAttribute('datatype');
             return XFORM_VALIDATE_TYPE_MAP[datatype] || type;
         }
     }
@@ -616,7 +642,7 @@ export function parseXForm(stanza) {
         if (reported) {
             const reported_fields = reported ? Array.from(reported.querySelectorAll(':scope > field')) : [];
             const items = Array.from(x.querySelectorAll(':scope > item'));
-            return /** @type {import('./types').XForm} */({
+            return /** @type {import('./types').XForm} */ ({
                 ...result,
                 reported: /** @type {import('./types').XFormReportedField[]} */ (reported_fields.map(getAttributes)),
                 items: items.map((item) => {

--- a/src/headless/shared/parsers.js
+++ b/src/headless/shared/parsers.js
@@ -322,22 +322,35 @@ export function getReplyAttributes(stanza) {
 }
 
 /**
- * Parse the XEP-0428 fallback indication for the XEP-0461 reply fallback body,
- * i.e. the code-point range of the `>`-quoted text that supporting clients
- * strip from the displayed body.
+ * Parse all XEP-0428 `<fallback>` elements and return them as a
+ * namespace-keyed map.
+ *
+ * The value for each namespace is:
+ *  - `{ start, end }` when `<body start="…" end="…"/>` provides a code-point
+ *    range (XEP-0461 reply fallback), so the range can be stripped from display.
+ *  - `null` when there is no range — either a bare `<body/>` or no `<body>`
+ *    child at all (XEP-0444 reaction fallback, XEP-0424 retraction fallback),
+ *    meaning the whole body is a fallback for clients that lack the feature.
+ *
  * @param {Element} stanza - The message stanza (or decrypted SCE `<content>`)
- * @returns {{reply_fallback?: {start: number, end: number}}}
+ * @returns {{ fallback?: Record<string, {start: number, end: number}|null> }}
  */
 export function getFallbackAttributes(stanza) {
-    const fallback = sizzle(`fallback[xmlns="${Strophe.NS.FALLBACK}"][for="${Strophe.NS.REPLY}"]`, stanza).pop();
-    const body = fallback ? sizzle('> body', fallback).pop() : null;
-    if (!body) return {};
-    return {
-        reply_fallback: {
-            start: Number(body.getAttribute('start')),
-            end: Number(body.getAttribute('end')),
-        },
-    };
+    /** @type {Record<string, {start: number, end: number}|null>} */
+    const fallback = {};
+
+    for (const el of sizzle(`fallback[xmlns="${Strophe.NS.FALLBACK}"]`, stanza)) {
+        const ns = el.getAttribute('for');
+        if (!ns) continue;
+        const body = sizzle('> body', el).pop();
+        const start = body?.getAttribute('start');
+        const end = body?.getAttribute('end');
+        fallback[ns] = start != null && end != null
+            ? { start: Number(start), end: Number(end) }
+            : null;
+    }
+
+    return Object.keys(fallback).length ? { fallback } : {};
 }
 
 /**

--- a/src/headless/shared/types.ts
+++ b/src/headless/shared/types.ts
@@ -237,6 +237,7 @@ export type MessageAttributes = EncryptionAttrs &
         replace_id: string; // The `id` attribute of a XEP-0308 <replace> element
         reply_to_id: string; // The `id` attribute of a XEP-0461 <reply> element (message being replied to)
         reply_to: string; // The `to` attribute of a XEP-0461 <reply> element (JID of the original message sender)
+        reply_fallback: { start: number; end: number }; // XEP-0428 code-point range of the XEP-0461 reply fallback (quoted body) to strip on display
         retracted: string; // An ISO8601 string recording the time that the message was retracted
         retracted_id: string; // The `id` attribute of a XEP-424 <retracted> element
         sender: 'me' | 'them'; // Whether the message was sent by the current user or someone else

--- a/src/headless/shared/types.ts
+++ b/src/headless/shared/types.ts
@@ -237,7 +237,7 @@ export type MessageAttributes = EncryptionAttrs &
         replace_id: string; // The `id` attribute of a XEP-0308 <replace> element
         reply_to_id: string; // The `id` attribute of a XEP-0461 <reply> element (message being replied to)
         reply_to: string; // The `to` attribute of a XEP-0461 <reply> element (JID of the original message sender)
-        reply_fallback: { start: number; end: number }; // XEP-0428 code-point range of the XEP-0461 reply fallback (quoted body) to strip on display
+        fallback: Record<string, { start: number; end: number } | null>; // XEP-0428 fallback map keyed by feature namespace; ranged ({start,end}) for XEP-0461 replies, null for whole-body fallbacks (e.g. XEP-0444 reactions)
         retracted: string; // An ISO8601 string recording the time that the message was retracted
         retracted_id: string; // The `id` attribute of a XEP-424 <retracted> element
         sender: 'me' | 'them'; // Whether the message was sent by the current user or someone else

--- a/src/headless/types/plugins/chat/model.d.ts
+++ b/src/headless/types/plugins/chat/model.d.ts
@@ -99,6 +99,8 @@ declare const ChatBox_base: {
         queueMessage(attrs: import("../../shared/types").MessageAttributes): any;
         msg_chain: any;
         getOutgoingMessageAttributes(_attrs?: import("../../shared/types").MessageAttributes): Promise<import("../../shared/types").MessageAttributes>;
+        getReferencedMessage(reply_to_id: string): import("../../shared/message").default | undefined;
+        addReplyFallback(attrs: import("../../shared/types").MessageAttributes): import("../../shared/types").MessageAttributes;
         sendMessage(attrs?: any): Promise<import("../../shared/message").default>;
         retractOwnMessage(message: import("../../shared/message").default): void;
         sendFiles(files: File[]): Promise<void>;

--- a/src/headless/types/plugins/muc/muc.d.ts
+++ b/src/headless/types/plugins/muc/muc.d.ts
@@ -99,6 +99,8 @@ declare const MUC_base: {
         queueMessage(attrs: import("../../shared/types").MessageAttributes): any;
         msg_chain: any;
         getOutgoingMessageAttributes(_attrs?: import("../../shared/types").MessageAttributes): Promise<import("../../shared/types").MessageAttributes>;
+        getReferencedMessage(reply_to_id: string): import("../../shared/message.js").default | undefined;
+        addReplyFallback(attrs: import("../../shared/types").MessageAttributes): import("../../shared/types").MessageAttributes;
         sendMessage(attrs?: any): Promise<import("../../shared/message.js").default>;
         retractOwnMessage(message: import("../../shared/message.js").default): void;
         sendFiles(files: File[]): Promise<void>;

--- a/src/headless/types/plugins/muc/occupant.d.ts
+++ b/src/headless/types/plugins/muc/occupant.d.ts
@@ -99,6 +99,8 @@ declare const MUCOccupant_base: {
         queueMessage(attrs: import("../../shared/types").MessageAttributes): any;
         msg_chain: any;
         getOutgoingMessageAttributes(_attrs?: import("../../shared/types").MessageAttributes): Promise<import("../../shared/types").MessageAttributes>;
+        getReferencedMessage(reply_to_id: string): import("../../shared/message").default | undefined;
+        addReplyFallback(attrs: import("../../shared/types").MessageAttributes): import("../../shared/types").MessageAttributes;
         sendMessage(attrs?: any): Promise<import("../../shared/message").default>;
         retractOwnMessage(message: import("../../shared/message").default): void;
         sendFiles(files: File[]): Promise<void>;

--- a/src/headless/types/plugins/omemo/api.d.ts
+++ b/src/headless/types/plugins/omemo/api.d.ts
@@ -4,6 +4,23 @@ declare namespace _default {
          * Returns the device ID of the current device.
          */
         function getDeviceID(): Promise<any>;
+        /**
+         * Encrypt and send a message to `chat` for every OMEMO version its
+         * recipients support, without persisting a Message model. This is the
+         * encrypted counterpart of a raw `api.send`.
+         *
+         * On failure (e.g. no reachable devices, or a presence/server error) a
+         * user-facing alert is shown and the error is re-thrown — the same way an
+         * encrypted chat-message send fails — so callers can roll back any
+         * optimistic state. Awaits the encryption; resolves once the stanza is
+         * handed to `api.send`.
+         *
+         * @method _converse.api.omemo.send
+         * @param {import('../../shared/chatbox.js').default} chat
+         * @param {string} plaintext - the message body (may be empty)
+         * @param {import('strophe.js').Builder[]} [extensions] - encrypted SCE `<content>` children
+         */
+        function send(chat: import("../../shared/chatbox.js").default, plaintext: string, extensions?: import("strophe.js").Builder[]): Promise<void>;
         namespace session {
             function restore(): Promise<void>;
         }

--- a/src/headless/types/plugins/omemo/parsers.d.ts
+++ b/src/headless/types/plugins/omemo/parsers.d.ts
@@ -13,9 +13,11 @@
  *
  * @param {Element} stanza - The message stanza
  * @param {MUCMessageAttributes|MessageAttributes} attrs
+ * @param {import('../muc/muc.js').default} [chatbox] - The MUC model (only for
+ *   `parseMUCMessage`); used to re-parse encrypted reactions from the SCE content.
  * @returns {Promise<MUCMessageAttributes| MessageAttributes|MUCMessageAttrsWithEncryption|MessageAttrsWithEncryption>}
  */
-export function parseEncryptedMessage(stanza: Element, attrs: MUCMessageAttributes | MessageAttributes): Promise<MUCMessageAttributes | MessageAttributes | MUCMessageAttrsWithEncryption | MessageAttrsWithEncryption>;
+export function parseEncryptedMessage(stanza: Element, attrs: MUCMessageAttributes | MessageAttributes, chatbox?: import("../muc/muc.js").default): Promise<MUCMessageAttributes | MessageAttributes | MUCMessageAttrsWithEncryption | MessageAttrsWithEncryption>;
 /**
  * Given an XML element representing a legacy OMEMO bundle, parse it
  * and return a map.

--- a/src/headless/types/plugins/omemo/sce.d.ts
+++ b/src/headless/types/plugins/omemo/sce.d.ts
@@ -7,25 +7,34 @@
  *
  * @param {string} plaintext - the message body to encrypt
  * @param {{from_jid: string, to_jid: string|null}} affixes
+ * @param {import('strophe.js').Builder[]} [extensions] - body-coupled metadata elements
  * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
  */
 export function encryptSCE(plaintext: string, affixes: {
     from_jid: string;
     to_jid: string | null;
-}): Promise<{
+}, extensions?: import('strophe.js').Builder[]): Promise<{
     key_and_tag: ArrayBuffer;
     payload: string;
 }>;
 /**
  * Decrypt an SCE/OMEMO 2 payload.
  *
+ * Returns both the plaintext body string and the decrypted `<content>` element,
+ * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler)
+ * against the authenticated content. `body`/`content` are `null` for a
+ * heartbeat (payload-less / bodyless) message.
+ *
  * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
  * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext
  * @param {{sender_jid: string, to_jid?: string|null}} expected_affixes - for validation
- * @returns {Promise<string|null>} - plaintext message body
+ * @returns {Promise<{body: string|null, content: Element|null}>}
  */
 export function decryptSCE(key_and_tag: ArrayBuffer, payload_b64: string, expected_affixes: {
     sender_jid: string;
     to_jid?: string | null;
-}): Promise<string | null>;
+}): Promise<{
+    body: string | null;
+    content: Element | null;
+}>;
 //# sourceMappingURL=sce.d.ts.map

--- a/src/headless/types/plugins/omemo/sce.d.ts
+++ b/src/headless/types/plugins/omemo/sce.d.ts
@@ -5,15 +5,15 @@
  * ArrayBuffer — this is what gets encrypted with SessionCipher per device —
  * and the base64-encoded AES-256-CBC ciphertext as the <payload> value.
  *
- * @param {string} plaintext - the message body to encrypt
+ * @param {string|null} plaintext - the message body to encrypt (omitted when falsy)
  * @param {{from_jid: string, to_jid: string|null}} affixes
  * @param {import('strophe.js').Builder[]} [extensions] - body-coupled metadata elements
  * @returns {Promise<{key_and_tag: ArrayBuffer, payload: string}>}
  */
-export function encryptSCE(plaintext: string, affixes: {
+export function encryptSCE(plaintext: string | null, affixes: {
     from_jid: string;
     to_jid: string | null;
-}, extensions?: import('strophe.js').Builder[]): Promise<{
+}, extensions?: import("strophe.js").Builder[]): Promise<{
     key_and_tag: ArrayBuffer;
     payload: string;
 }>;
@@ -21,9 +21,10 @@ export function encryptSCE(plaintext: string, affixes: {
  * Decrypt an SCE/OMEMO 2 payload.
  *
  * Returns both the plaintext body string and the decrypted `<content>` element,
- * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler)
- * against the authenticated content. `body`/`content` are `null` for a
- * heartbeat (payload-less / bodyless) message.
+ * so callers can re-run the normal stanza parsers (references/reply/oob/spoiler,
+ * but also chat states / markers / reactions) against the authenticated content.
+ * `content` is `null` only when the envelope carries no `<content>` element;
+ * `body` is `null` when there's no `<body>` — i.e. a metadata-only message.
  *
  * @param {ArrayBuffer} key_and_tag - 48-byte tuple: content_key(32) ‖ HMAC(16)
  * @param {string} payload_b64 - base64-encoded AES-256-CBC ciphertext

--- a/src/headless/types/plugins/omemo/utils.d.ts
+++ b/src/headless/types/plugins/omemo/utils.d.ts
@@ -45,10 +45,13 @@ export function getDeviceList(jid: string, create?: boolean, version?: import(".
  */
 export function generateFingerprint(device: import("./device.js").default): Promise<void>;
 /**
+ * Surface a user-facing alert for a failed encrypted send and re-throw, so the
+ * send pipeline (the `createMessageStanza` handler) aborts. Always throws.
  * @param {Error|errors.IQError|errors.UserFacingError} e
  * @param {import('../../shared/chatbox.js').default} chat
+ * @returns {never}
  */
-export function handleMessageSendError(e: Error | errors.IQError | errors.UserFacingError, chat: import("../../shared/chatbox.js").default): void;
+export function handleMessageSendError(e: Error | errors.IQError | errors.UserFacingError, chat: import("../../shared/chatbox.js").default): never;
 /**
  * Returns the device collection for a contact and OMEMO version.
  * Doesn't throw on any failure, instead logs and returns an empty collection.
@@ -86,11 +89,32 @@ export function decryptMessage(obj: import("./types").EncryptedMessage): Promise
  */
 export function sendOMEMOHeartbeat(chat: import("../../shared/chatbox.js").default, version: import("./types").OMEMOVersion): Promise<void>;
 /**
+ * Encrypt `plaintext` (and, for omemo:2, `extensions` inside the SCE
+ * `<content>`) for every reachable recipient device of `chat`, returning the
+ * OMEMO `<encrypted>` element(s) to attach to a message stanza plus the EME
+ * (XEP-0380) namespace to advertise.
+ *
+ * @param {import('../../shared/chatbox').default} chat
+ * @param {string|null} plaintext - the body (legacy payload / omemo:2 SCE `<body>`)
+ * @param {import('strophe.js').Builder[]} [extensions] - encrypted SCE `<content>` children
+ * @returns {Promise<{elements: import('strophe.js').Builder[], eme_ns: string}>}
+ */
+export function getEncryptedElements(chat: import("../../shared/chatbox").default, plaintext: string | null, extensions?: import("strophe.js").Builder[]): Promise<{
+    elements: import("strophe.js").Builder[];
+    eme_ns: string;
+}>;
+/**
+ * Handler for the `createMessageStanza` hook: for an encrypted outgoing chat
+ * message, attach the OMEMO `<encrypted>` element(s) (plus store + EME hints) to
+ * the stanza that was built from the Message model. Non-encrypted messages pass
+ * through untouched. A send failure is surfaced to the user via
+ * {@link handleMessageSendError} (which re-throws to abort the send).
+ *
  * @param {import('../../shared/chatbox').default} chat
  * @param {import('../../shared/types').MessageAndStanza} data
  * @return {Promise<import('../../shared/types').MessageAndStanza>}
  */
-export function createOMEMOMessageStanza(chat: import("../../shared/chatbox").default, data: import("../../shared/types").MessageAndStanza): Promise<import("../../shared/types").MessageAndStanza>;
+export function createMessageStanzaHandler(chat: import("../../shared/chatbox").default, data: import("../../shared/types").MessageAndStanza): Promise<import("../../shared/types").MessageAndStanza>;
 /**
  * @param {import('../../shared/chatbox.js').default} chat
  * @param {import('../../shared/types').MessageAttributes} attrs

--- a/src/headless/types/plugins/omemo/utils.d.ts
+++ b/src/headless/types/plugins/omemo/utils.d.ts
@@ -89,6 +89,26 @@ export function decryptMessage(obj: import("./types").EncryptedMessage): Promise
  */
 export function sendOMEMOHeartbeat(chat: import("../../shared/chatbox.js").default, version: import("./types").OMEMOVersion): Promise<void>;
 /**
+ * Send a XEP-0333 chat marker for an OMEMO-active chat.
+ *
+ * Called from {@link sendMarker} in `shared/actions.js` when `omemo_active` is
+ * set. The cleartext path is suppressed in that case, so this function is solely
+ * responsible for the outgoing marker in encrypted sessions.
+ *
+ * - OMEMO:2 devices present → encrypted SCE stanza.
+ * - Legacy-only session (no v2 devices) → cleartext marker, matching what
+ *   other clients do for legacy OMEMO.
+ * - Mixed session (both v2 and legacy devices) → encrypted only; legacy
+ *   devices in a mixed session do not receive the marker.
+ *
+ * @param {import('../../shared/chatbox.js').default} chatbox
+ * @param {string} to_jid
+ * @param {string} msg_id - the `id` of the message being marked
+ * @param {string} type - marker type ('displayed', 'received', 'acknowledged')
+ * @param {string} [msg_type] - 'chat' or 'groupchat'; defaults to 'chat'
+ */
+export function sendOMEMO2Marker(chatbox: import("../../shared/chatbox.js").default, to_jid: string, msg_id: string, type: string, msg_type?: string): Promise<void>;
+/**
  * Encrypt `plaintext` (and, for omemo:2, `extensions` inside the SCE
  * `<content>`) for every reachable recipient device of `chat`, returning the
  * OMEMO `<encrypted>` element(s) to attach to a message stanza plus the EME

--- a/src/headless/types/shared/actions.d.ts
+++ b/src/headless/types/shared/actions.d.ts
@@ -6,14 +6,14 @@
  */
 export function rejectMessage(stanza: Element, text: string): void;
 /**
- * Send out a XEP-0333 chat marker
+ * Send out a XEP-0333 chat marker.
+ * @fires sendMarker
  * @param {string} to_jid
  * @param {string} id - The id of the message being marked
  * @param {import("./types").MessageMarkerType} type - The marker type
  * @param {string} [msg_type]
- * @return void
  */
-export function sendMarker(to_jid: string, id: string, type: import("./types").MessageMarkerType, msg_type?: string): void;
+export function sendMarker(to_jid: string, id: string, type: import("./types").MessageMarkerType, msg_type?: string): Promise<void>;
 /**
  * @param {string} to_jid
  * @param {string} id

--- a/src/headless/types/shared/chatbox.d.ts
+++ b/src/headless/types/shared/chatbox.d.ts
@@ -24,6 +24,8 @@ declare const ChatBoxBase_base: {
         queueMessage(attrs: import("./types.js").MessageAttributes): any;
         msg_chain: any;
         getOutgoingMessageAttributes(_attrs?: import("./types.js").MessageAttributes): Promise<import("./types.js").MessageAttributes>;
+        getReferencedMessage(reply_to_id: string): import("./message.js").default | undefined;
+        addReplyFallback(attrs: import("./types.js").MessageAttributes): import("./types.js").MessageAttributes;
         sendMessage(attrs?: any): Promise<import("./message.js").default>;
         retractOwnMessage(message: import("./message.js").default): void;
         sendFiles(files: File[]): Promise<void>;

--- a/src/headless/types/shared/message.d.ts
+++ b/src/headless/types/shared/message.d.ts
@@ -58,7 +58,17 @@ declare class BaseMessage extends Model<import("@converse/skeletor").ModelAttrib
      * @returns { Boolean }
      */
     mayBeRetracted(): boolean;
-    getMessageText(): any;
+    getMessageText(): string;
+    /**
+     * Strip the XEP-0461 compatibility fallback — the `>`-quoted copy of the
+     * replied-to message — from `text`. Converse renders the reply context from
+     * the structured `<reply>`, so per XEP-0461 it must not also show the quoted
+     * fallback. Offsets are XEP-0426 Unicode code points, so we slice on the
+     * code-point array rather than UTF-16 units.
+     * @param {string} text
+     * @returns {string}
+     */
+    stripReplyFallback(text: string): string;
     /**
      * Send out an IQ stanza to request a file upload slot.
      * https://xmpp.org/extensions/xep-0363.html#request

--- a/src/headless/types/shared/model-with-messages.d.ts
+++ b/src/headless/types/shared/model-with-messages.d.ts
@@ -74,6 +74,21 @@ export default function ModelWithMessages<T extends import("./types").ModelExten
          */
         getOutgoingMessageAttributes(_attrs?: import("./types").MessageAttributes): Promise<import("./types").MessageAttributes>;
         /**
+         * Look up the message being replied to (XEP-0461). For groupchat the
+         * `reply_to_id` is a XEP-0359 stanza_id; otherwise it's the origin_id or msgid.
+         * @param {string} reply_to_id
+         * @returns {BaseMessage|undefined}
+         */
+        getReferencedMessage(reply_to_id: string): import("./message").default | undefined;
+        /**
+         * XEP-0461 compatibility fallback. When sending a reply, prepend a
+         * XEP-0393 `>`-quoted copy of the replied-to text to the body, so clients
+         * that don't support structured replies still see the context.
+         * @param {MessageAttributes} attrs
+         * @returns {MessageAttributes}
+         */
+        addReplyFallback(attrs: import("./types").MessageAttributes): import("./types").MessageAttributes;
+        /**
          * Responsible for sending off a text message inside an ongoing chat conversation.
          * @param {Object} [attrs] - A map of attributes to be saved on the message
          * @returns {Promise<BaseMessage>}

--- a/src/headless/types/shared/parsers.d.ts
+++ b/src/headless/types/shared/parsers.d.ts
@@ -93,17 +93,24 @@ export function getErrorAttributes(stanza: Element): {
  */
 export function getReplyAttributes(stanza: Element): any;
 /**
- * Parse the XEP-0428 fallback indication for the XEP-0461 reply fallback body,
- * i.e. the code-point range of the `>`-quoted text that supporting clients
- * strip from the displayed body.
+ * Parse all XEP-0428 `<fallback>` elements and return them as a
+ * namespace-keyed map.
+ *
+ * The value for each namespace is:
+ *  - `{ start, end }` when `<body start="…" end="…"/>` provides a code-point
+ *    range (XEP-0461 reply fallback), so the range can be stripped from display.
+ *  - `null` when there is no range — either a bare `<body/>` or no `<body>`
+ *    child at all (XEP-0444 reaction fallback, XEP-0424 retraction fallback),
+ *    meaning the whole body is a fallback for clients that lack the feature.
+ *
  * @param {Element} stanza - The message stanza (or decrypted SCE `<content>`)
- * @returns {{reply_fallback?: {start: number, end: number}}}
+ * @returns {{ fallback?: Record<string, {start: number, end: number}|null> }}
  */
 export function getFallbackAttributes(stanza: Element): {
-    reply_fallback?: {
+    fallback?: Record<string, {
         start: number;
         end: number;
-    };
+    } | null>;
 };
 /**
  * Given a message stanza, find and return any XEP-0372 references

--- a/src/headless/types/shared/parsers.d.ts
+++ b/src/headless/types/shared/parsers.d.ts
@@ -93,6 +93,19 @@ export function getErrorAttributes(stanza: Element): {
  */
 export function getReplyAttributes(stanza: Element): any;
 /**
+ * Parse the XEP-0428 fallback indication for the XEP-0461 reply fallback body,
+ * i.e. the code-point range of the `>`-quoted text that supporting clients
+ * strip from the displayed body.
+ * @param {Element} stanza - The message stanza (or decrypted SCE `<content>`)
+ * @returns {{reply_fallback?: {start: number, end: number}}}
+ */
+export function getFallbackAttributes(stanza: Element): {
+    reply_fallback?: {
+        start: number;
+        end: number;
+    };
+};
+/**
  * Given a message stanza, find and return any XEP-0372 references
  * @param {Element} stanza - The message stanza
  * @returns {import('./types').XEP372Reference[]}

--- a/src/headless/types/shared/types.d.ts
+++ b/src/headless/types/shared/types.d.ts
@@ -172,10 +172,10 @@ export type MessageAttributes = EncryptionAttrs & MessageErrorAttributes & {
     replace_id: string;
     reply_to_id: string;
     reply_to: string;
-    reply_fallback: {
+    fallback: Record<string, {
         start: number;
         end: number;
-    };
+    } | null>;
     retracted: string;
     retracted_id: string;
     sender: 'me' | 'them';

--- a/src/headless/types/shared/types.d.ts
+++ b/src/headless/types/shared/types.d.ts
@@ -172,6 +172,10 @@ export type MessageAttributes = EncryptionAttrs & MessageErrorAttributes & {
     replace_id: string;
     reply_to_id: string;
     reply_to: string;
+    reply_fallback: {
+        start: number;
+        end: number;
+    };
     retracted: string;
     retracted_id: string;
     sender: 'me' | 'them';

--- a/src/headless/types/utils/index.d.ts
+++ b/src/headless/types/utils/index.d.ts
@@ -8,7 +8,7 @@ export function isEmptyMessage(attrs: any): boolean;
  * inserted before the mentioned nicknames.
  * @param {import('../shared/message').default} message
  */
-export function prefixMentions(message: import("../shared/message").default): any;
+export function prefixMentions(message: import("../shared/message").default): string;
 export function getRandomInt(max: any): number;
 /**
  * @param {string} [suffix]

--- a/src/headless/types/utils/index.d.ts
+++ b/src/headless/types/utils/index.d.ts
@@ -44,6 +44,7 @@ declare const _default: {
     getLongestSubstring(string: string, candidates: string[]): string;
     isString(s: any): boolean;
     getDefaultStorageType(): import("./types").StorageType;
+    isPersistentStorageAvailable(): boolean;
     createStore(id: string, type: import("./types").StorageType): import("@converse/skeletor").BrowserStorage;
     initStorage(model: import("./types").StorageModel, id: string, type?: import("./types").StorageType): void;
     isErrorStanza(stanza: Element): boolean;

--- a/src/headless/types/utils/storage.d.ts
+++ b/src/headless/types/utils/storage.d.ts
@@ -3,6 +3,10 @@
  */
 export function getDefaultStorageType(): import("./types").StorageType;
 /**
+ * @returns {boolean}
+ */
+export function isPersistentStorageAvailable(): boolean;
+/**
  * @param {string} id
  * @param {import('./types').StorageType} type
  * @returns {BrowserStorage}

--- a/src/plugins/chatview/tests/markers.js
+++ b/src/plugins/chatview/tests/markers.js
@@ -53,9 +53,10 @@ describe('A XEP-0333 Chat Marker', function () {
             const sent_stanzas = [];
             spyOn(_converse.api.connection.get(), 'send').and.callFake((s) => sent_stanzas.push(s));
             await _converse.handleMessageStanza(stanza);
-            const sent_messages = sent_stanzas.map((s) => s?.nodeTree ?? s).filter((e) => e.nodeName === 'message');
 
-            await u.waitUntil(() => sent_messages.length === 2);
+            const getMessages = () => sent_stanzas.map((s) => s?.nodeTree ?? s).filter((e) => e.nodeName === 'message');
+            await u.waitUntil(() => getMessages().length === 2);
+            const sent_messages = getMessages();
             expect(sent_messages[0]).toEqualStanza(stx`
             <message id="${sent_messages[0].getAttribute('id')}" to="${contact_jid}" type="chat" xmlns="jabber:client">
                 <active xmlns="http://jabber.org/protocol/chatstates"/>

--- a/src/plugins/chatview/tests/replies.js
+++ b/src/plugins/chatview/tests/replies.js
@@ -186,5 +186,146 @@ describe('XEP-0461 Message Replies', function () {
                 expect(replyContext).not.toBeNull();
             }),
         );
+
+        it(
+            'includes a XEP-0461 fallback body quoting the original message',
+            mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+                const { api } = _converse;
+                await mock.waitForRoster(_converse, 'current', 1);
+                await mock.openControlBox(_converse);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+                await mock.openChatBoxFor(_converse, contact_jid);
+                const view = _converse.chatboxviews.get(contact_jid);
+                const textarea = view.querySelector('textarea.chat-textarea');
+                const message_form = view.querySelector('converse-message-form');
+
+                textarea.value = 'Original message';
+                message_form.onKeyDown({ target: textarea, preventDefault() {}, key: 'Enter' });
+                await u.waitUntil(() => view.querySelectorAll('.chat-msg__text').length === 1);
+
+                view.querySelector('.chat-msg__action-reply').click();
+                await u.waitUntil(() => view.querySelector('.reply-preview'));
+
+                const sent_stanzas = [];
+                const send = api.connection.get().send;
+                spyOn(api.connection.get(), 'send').and.callFake((stanza) => {
+                    sent_stanzas.push(stanza);
+                    return send.call(api.connection.get(), stanza);
+                });
+
+                const reply_text = 'This is my reply';
+                textarea.value = reply_text;
+                message_form.onKeyDown({ target: textarea, preventDefault() {}, key: 'Enter' });
+                await u.waitUntil(() => sent_stanzas.length === 1);
+
+                const sent_stanza = sent_stanzas[0];
+                // The body carries the quoted original as a XEP-0393 quote, then the reply text.
+                const body = sent_stanza.querySelector('body').textContent;
+                expect(body.startsWith('> ')).toBe(true);
+                expect(body).toContain('> Original message');
+                expect(body.endsWith(reply_text)).toBe(true);
+
+                // The structured <reply> is still sent...
+                expect(sent_stanza.querySelector('reply').getAttribute('xmlns')).toBe('urn:xmpp:reply:0');
+                // ...and a XEP-0428 <fallback> marks the quoted code-point range.
+                const fallback = sent_stanza.querySelector('fallback');
+                expect(fallback.getAttribute('xmlns')).toBe('urn:xmpp:fallback:0');
+                expect(fallback.getAttribute('for')).toBe('urn:xmpp:reply:0');
+                const fb_body = fallback.querySelector('body');
+                expect(Number(fb_body.getAttribute('start'))).toBe(0);
+                expect(Number(fb_body.getAttribute('end'))).toBe([...body].length - [...reply_text].length);
+
+                // The stored message strips the fallback for display.
+                expect(view.model.messages.last().getMessageText()).toBe(reply_text);
+            }),
+        );
+
+        it(
+            'truncates a long quoted original in the XEP-0461 fallback body',
+            mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+                const { api } = _converse;
+                await mock.waitForRoster(_converse, 'current', 1);
+                await mock.openControlBox(_converse);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+                await mock.openChatBoxFor(_converse, contact_jid);
+                const view = _converse.chatboxviews.get(contact_jid);
+                const textarea = view.querySelector('textarea.chat-textarea');
+                const message_form = view.querySelector('converse-message-form');
+
+                const long_original =
+                    'But soft, what light through yonder airlock breaks? It is the east and Juliet is the sun, arise fair sun';
+                textarea.value = long_original;
+                message_form.onKeyDown({ target: textarea, preventDefault() {}, key: 'Enter' });
+                await u.waitUntil(() => view.querySelectorAll('.chat-msg__text').length === 1);
+
+                view.querySelector('.chat-msg__action-reply').click();
+                await u.waitUntil(() => view.querySelector('.reply-preview'));
+
+                const sent_stanzas = [];
+                const send = api.connection.get().send;
+                spyOn(api.connection.get(), 'send').and.callFake((stanza) => {
+                    sent_stanzas.push(stanza);
+                    return send.call(api.connection.get(), stanza);
+                });
+
+                const reply_text = 'Indeed it does';
+                textarea.value = reply_text;
+                message_form.onKeyDown({ target: textarea, preventDefault() {}, key: 'Enter' });
+                await u.waitUntil(() => sent_stanzas.length === 1);
+
+                const sent_stanza = sent_stanzas[0];
+                const body = sent_stanza.querySelector('body').textContent;
+
+                // The quoted original is truncated to 80 code points + an ellipsis;
+                // the tail beyond that is dropped, but the reply text is intact.
+                expect(body).toContain('> But soft, what light through yonder');
+                expect(body).toContain('…');
+                expect(body).not.toContain('arise fair sun');
+                expect(body.endsWith(reply_text)).toBe(true);
+
+                // The XEP-0428 marker covers exactly the (truncated) quote range,
+                // and the displayed text strips it.
+                const fb_body = sent_stanza.querySelector('fallback body');
+                expect(Number(fb_body.getAttribute('end'))).toBe([...body].length - [...reply_text].length);
+                expect(view.model.messages.last().getMessageText()).toBe(reply_text);
+            }),
+        );
+
+        it(
+            'strips the reply fallback from the displayed body on receive',
+            mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+                const { api } = _converse;
+                await mock.waitForRoster(_converse, 'current', 1);
+                await mock.openControlBox(_converse);
+                const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+                await mock.openChatBoxFor(_converse, contact_jid);
+                const view = _converse.chatboxviews.get(contact_jid);
+
+                const original_id = u.getUniqueId();
+                _converse.handleMessageStanza(stx`<message xmlns="jabber:client"
+                        from="${contact_jid}" to="${api.connection.get().jid}" type="chat" id="${original_id}">
+                    <body>Original message</body>
+                </message>`);
+                await u.waitUntil(() => view.querySelectorAll('.chat-msg__text').length === 1);
+
+                const quote = '> Juliet:\n> Original message\n';
+                const reply_body = quote + 'This is a reply';
+                _converse.handleMessageStanza(stx`<message xmlns="jabber:client"
+                        from="${contact_jid}" to="${api.connection.get().jid}" type="chat" id="${u.getUniqueId()}">
+                    <body>${reply_body}</body>
+                    <reply xmlns="urn:xmpp:reply:0" id="${original_id}" to="${api.connection.get().jid}"/>
+                    <fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:reply:0"><body start="0" end="${[...quote].length}"/></fallback>
+                </message>`);
+                await u.waitUntil(() => view.querySelectorAll('.chat-msg__text').length === 2);
+
+                // The reply context is rendered, and the quoted fallback is stripped from the body.
+                await u.waitUntil(() => view.querySelector('converse-reply-context'));
+                const reply_msg = view.model.messages.last();
+                expect(reply_msg.getMessageText()).toBe('This is a reply');
+                const text_el = Array.from(view.querySelectorAll('.chat-msg__text')).pop();
+                expect(text_el.textContent.includes('Original message')).toBe(false);
+                expect(text_el.textContent).toContain('This is a reply');
+            }),
+        );
     });
 });

--- a/src/plugins/omemo-views/tests/corrections.js
+++ b/src/plugins/omemo-views/tests/corrections.js
@@ -93,7 +93,6 @@ describe('An OMEMO encrypted message', function () {
                 to="mercutio@montague.lit" type="chat"
                 xmlns="jabber:client">
                     <body>${fallback_text}</body>
-                    <active xmlns="http://jabber.org/protocol/chatstates"/>
                     <request xmlns="urn:xmpp:receipts"/>
                     <replace id="${first_msg.get('msgid')}" xmlns="urn:xmpp:message-correct:0"/>
                     <origin-id id="${msg.querySelector('origin-id').getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
@@ -328,7 +327,6 @@ describe('An OMEMO encrypted MUC message', function () {
                      type="groupchat"
                      xmlns="jabber:client">
                 <body>This is an OMEMO encrypted message which your client doesn’t seem to support. Find more information on https://conversations.im/omemo</body>
-                <active xmlns="http://jabber.org/protocol/chatstates"/>
                 <origin-id id="${sent_stanza.getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
                 <encrypted xmlns="eu.siacs.conversations.axolotl">
                     <header sid="123456789">
@@ -383,7 +381,6 @@ describe('An OMEMO encrypted MUC message', function () {
             expect(msg).toEqualStanza(stx`
             <message from="${own_jid}" id="${msg.getAttribute('id')}" to="${muc_jid}" type="groupchat" xmlns="jabber:client">
                 <body>${fallback_text}</body>
-                <active xmlns="http://jabber.org/protocol/chatstates"/>
                 <replace id="${first_msg.get('msgid')}" xmlns="urn:xmpp:message-correct:0"/>
                 <origin-id id="${msg.querySelector('origin-id').getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
                 <encrypted xmlns="eu.siacs.conversations.axolotl">

--- a/src/plugins/omemo-views/tests/media-sharing.js
+++ b/src/plugins/omemo-views/tests/media-sharing.js
@@ -340,7 +340,6 @@ describe('The OMEMO module', function () {
                 type="chat"
                 xmlns="jabber:client">
                     <body>${fallback}</body>
-                    <active xmlns="http://jabber.org/protocol/chatstates"/>
                     <request xmlns="urn:xmpp:receipts"/>
                     <origin-id id="${sent_stanza.getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
                     <encrypted xmlns="eu.siacs.conversations.axolotl">

--- a/src/plugins/omemo-views/tests/muc.js
+++ b/src/plugins/omemo-views/tests/muc.js
@@ -120,7 +120,6 @@ describe('The OMEMO module', function () {
                      type="groupchat"
                      xmlns="jabber:client">
                 <body>This is an OMEMO encrypted message which your client doesn’t seem to support. Find more information on https://conversations.im/omemo</body>
-                <active xmlns="http://jabber.org/protocol/chatstates"/>
                 <origin-id id="${sent_stanza.getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
                 <encrypted xmlns="eu.siacs.conversations.axolotl">
                     <header sid="123456789">

--- a/src/plugins/omemo-views/tests/omemo.js
+++ b/src/plugins/omemo-views/tests/omemo.js
@@ -73,7 +73,6 @@ describe('The OMEMO module', function () {
                         type="chat"
                         xmlns="jabber:client">
                 <body>This is an OMEMO encrypted message which your client doesn’t seem to support. Find more information on https://conversations.im/omemo</body>
-                <active xmlns="http://jabber.org/protocol/chatstates"/>
                 <request xmlns="urn:xmpp:receipts"/>
                 <origin-id id="${sent_stanza.getAttribute('id')}" xmlns="urn:xmpp:sid:0"/>
                 <encrypted xmlns="eu.siacs.conversations.axolotl">

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -122,6 +122,7 @@ describe('OMEMO 2 message reception', function () {
             const extensions = [
                 stx`<reference xmlns="${Strophe.NS.REFERENCE}" begin="3" end="9" type="mention" uri="xmpp:juliet@capulet.lit"></reference>`,
                 stx`<reply xmlns="${Strophe.NS.REPLY}" id="replied-to-id" to="${contact_jid}"></reply>`,
+                stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="${Strophe.NS.REPLY}"><body start="0" end="7"/></fallback>`,
                 stx`<x xmlns="${Strophe.NS.OUTOFBAND}"><url>https://example.org/file.txt</url></x>`,
                 stx`<spoiler xmlns="${Strophe.NS.SPOILER}">a spoiler</spoiler>`,
             ];
@@ -188,6 +189,8 @@ describe('OMEMO 2 message reception', function () {
             expect(references[0].value).toBe('juliet');
 
             expect(message.get('reply_to_id')).toBe('replied-to-id');
+            // The XEP-0428 fallback marker is parsed from the decrypted SCE content.
+            expect(message.get('reply_fallback')).toEqual({ start: 0, end: 7 });
             expect(message.get('reply_to')).toBe(contact_jid);
             expect(message.get('oob_url')).toBe('https://example.org/file.txt');
             expect(message.get('is_spoiler')).toBe(true);
@@ -595,6 +598,8 @@ describe('OMEMO 2 sending', function () {
             // ...but the body-coupled <reply> must NOT appear in cleartext — it
             // now lives encrypted inside the SCE <content> instead.
             expect(sizzle(`> reply[xmlns="${Strophe.NS.REPLY}"]`, sent_stanza).length).toBe(0);
+            // Nor may the XEP-0461/0428 reply fallback marker leak in cleartext.
+            expect(sizzle(`> fallback[xmlns="${Strophe.NS.FALLBACK}"]`, sent_stanza).length).toBe(0);
             // The XEP-0085 chat state must not leak in cleartext either; it's
             // carried encrypted inside the SCE <content>.
             expect(sizzle(`> active[xmlns="${Strophe.NS.CHATSTATES}"]`, sent_stanza).length).toBe(0);

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -595,6 +595,9 @@ describe('OMEMO 2 sending', function () {
             // ...but the body-coupled <reply> must NOT appear in cleartext — it
             // now lives encrypted inside the SCE <content> instead.
             expect(sizzle(`> reply[xmlns="${Strophe.NS.REPLY}"]`, sent_stanza).length).toBe(0);
+            // The XEP-0085 chat state must not leak in cleartext either; it's
+            // carried encrypted inside the SCE <content>.
+            expect(sizzle(`> active[xmlns="${Strophe.NS.CHATSTATES}"]`, sent_stanza).length).toBe(0);
         }),
     );
 

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -103,6 +103,99 @@ describe('OMEMO 2 message reception', function () {
     );
 
     it(
+        'extracts body-coupled metadata (references/reply/oob/spoiler) from the SCE content',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const sender_device_id = '555';
+            const plaintext = 'Hi juliet, look here';
+
+            // The contact builds the SCE payload with body-coupled metadata
+            // encrypted inside <content>.
+            const extensions = [
+                stx`<reference xmlns="${Strophe.NS.REFERENCE}" begin="3" end="9" type="mention" uri="xmpp:juliet@capulet.lit"></reference>`,
+                stx`<reply xmlns="${Strophe.NS.REPLY}" id="replied-to-id" to="${contact_jid}"></reply>`,
+                stx`<x xmlns="${Strophe.NS.OUTOFBAND}"><url>https://example.org/file.txt</url></x>`,
+                stx`<spoiler xmlns="${Strophe.NS.SPOILER}">a spoiler</spoiler>`,
+            ];
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(
+                plaintext,
+                { from_jid: contact_jid, to_jid: null },
+                extensions,
+            );
+
+            // Answer the contact's v2 device-list IQ fetched during decryption.
+            const conn = api.connection.get();
+            const v2_dl_selector = `iq[to="${contact_jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+            const interval = setInterval(() => {
+                const iq = Array.from(conn.IQ_stanzas)
+                    .filter((i) => i.querySelector(v2_dl_selector) && !i.dataset_handled)
+                    .pop();
+                if (!iq) return;
+                iq.dataset_handled = true;
+                const result = stx`<iq from="${contact_jid}"
+                                       id="${iq.getAttribute('id')}"
+                                       to="${conn.jid}"
+                                       xmlns="jabber:server"
+                                       type="result">
+                    <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                        <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                            <item>
+                                <devices xmlns="${Strophe.NS.OMEMO2}">
+                                    <device id="${sender_device_id}"/>
+                                </devices>
+                            </item>
+                        </items>
+                    </pubsub>
+                </iq>`;
+                conn._dataRecv(mock.createRequest(_converse, result));
+            }, 50);
+
+            const stanza = stx`<message from="${contact_jid}"
+                    to="${conn.jid}"
+                    type="chat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <body>This is a fallback message</body>
+                <encrypted xmlns="${Strophe.NS.OMEMO2}">
+                    <header sid="${sender_device_id}">
+                        <keys jid="${_converse.bare_jid}">
+                            <key rid="${our_device_id}">${u.arrayBufferToBase64(key_and_tag)}</key>
+                        </keys>
+                    </header>
+                    <payload>${payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, stanza));
+
+            await new Promise((resolve) => view.model.messages.once('rendered', resolve));
+            clearInterval(interval);
+
+            const message = view.model.messages.at(0);
+            expect(message.get('plaintext')).toBe(plaintext);
+
+            const references = message.get('references');
+            expect(references.length).toBe(1);
+            expect(references[0].uri).toBe('xmpp:juliet@capulet.lit');
+            expect(references[0].value).toBe('juliet');
+
+            expect(message.get('reply_to_id')).toBe('replied-to-id');
+            expect(message.get('reply_to')).toBe(contact_jid);
+            expect(message.get('oob_url')).toBe('https://example.org/file.txt');
+            expect(message.get('is_spoiler')).toBe(true);
+            expect(message.get('spoiler_hint')).toBe('a spoiler');
+        }),
+    );
+
+    it(
         'shows an error for an undecryptable message that has no fallback body',
         // Regression test for https://github.com/conversejs/converse.js/issues/2097
         // An OMEMO message that we can't decrypt (here: not encrypted for this
@@ -366,6 +459,54 @@ describe('OMEMO 2 sending', function () {
             expect(legacy_enc).toBeTruthy();
             expect(sizzle(`key[rid="482886413b977930064a5888b92134fe"]`, legacy_enc).length).toBe(1);
             expect(sizzle(`key[rid="555"]`, legacy_enc).length).toBe(0);
+        }),
+    );
+
+    it(
+        'does not leak the reply in cleartext for an encrypted message',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+            // Reply state is read by getOutgoingMessageAttributes for the next send.
+            view.model.set({ reply_to_id: 'replied-to-id', reply_to: contact_jid });
+
+            const rendered = mock.sendMessage(_converse, view, 'This is an encrypted reply');
+
+            await mock.deviceListFetched(_converse, contact_jid, ['555']);
+            await answerV2DeviceList(_converse, contact_jid, ['555']);
+            await mock.bundleFetched(_converse, {
+                jid: _converse.bare_jid,
+                device_id: '482886413b977930064a5888b92134fe',
+                identity_key: '300000',
+                signed_prekey_id: '4224',
+                signed_prekey_public: '100000',
+                signed_prekey_sig: '200000',
+                prekeys: ['1991', '1992', '1993'],
+            });
+            await answerV2Bundle(_converse, contact_jid, '555');
+
+            await rendered;
+
+            const sent_stanza = await u.waitUntil(
+                () =>
+                    _converse.api.connection
+                        .get()
+                        .sent_stanzas.filter((s) => s.querySelector('encrypted'))
+                        .pop(),
+                1000,
+            );
+
+            // The encrypted message must be sent (omemo:2 payload present)...
+            expect(sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"] payload`, sent_stanza).length).toBe(1);
+            // ...but the body-coupled <reply> must NOT appear in cleartext — it
+            // now lives encrypted inside the SCE <content> instead.
+            expect(sizzle(`> reply[xmlns="${Strophe.NS.REPLY}"]`, sent_stanza).length).toBe(0);
         }),
     );
 

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -190,7 +190,7 @@ describe('OMEMO 2 message reception', function () {
 
             expect(message.get('reply_to_id')).toBe('replied-to-id');
             // The XEP-0428 fallback marker is parsed from the decrypted SCE content.
-            expect(message.get('reply_fallback')).toEqual({ start: 0, end: 7 });
+            expect(message.get('fallback')?.[Strophe.NS.REPLY]).toEqual({ start: 0, end: 7 });
             expect(message.get('reply_to')).toBe(contact_jid);
             expect(message.get('oob_url')).toBe('https://example.org/file.txt');
             expect(message.get('is_spoiler')).toBe(true);

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -287,6 +287,99 @@ describe('OMEMO 2 message reception', function () {
     );
 
     it(
+        'suppresses the emoji fallback body of an encrypted reaction',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            const conn = api.connection.get();
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const sender_device_id = '555';
+
+            // A (cleartext) message for the reaction to target.
+            await _converse.handleMessageStanza(
+                stx`<message xmlns="jabber:client" from="${contact_jid}" to="${conn.jid}" type="chat" id="omemo-react-fb-target">
+                    <body>React to me with a fallback</body>
+                </message>`,
+            );
+            await u.waitUntil(() => view.model.messages.findWhere({ msgid: 'omemo-react-fb-target' }));
+            const msg_model = view.model.messages.findWhere({ msgid: 'omemo-react-fb-target' });
+
+            // The contact sends an SCE-encrypted XEP-0444 reaction whose body
+            // carries a quote of the reacted-to message plus the emoji as a
+            // legacy fallback, marked by a whole-body XEP-0428
+            // <fallback for="urn:xmpp:reactions:0">.
+            const extensions = [
+                stx`<reactions xmlns="urn:xmpp:reactions:0" id="omemo-react-fb-target"><reaction>👍</reaction></reactions>`,
+                stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="urn:xmpp:reactions:0"><body/></fallback>`,
+            ];
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(
+                '> React to me with a fallback\n👍',
+                { from_jid: contact_jid, to_jid: null },
+                extensions,
+            );
+
+            // Answer the contact's v2 device-list IQ fetched during decryption.
+            const v2_dl_selector = `iq[to="${contact_jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+            const interval = setInterval(() => {
+                const iq = Array.from(conn.IQ_stanzas)
+                    .filter((i) => i.querySelector(v2_dl_selector) && !i.dataset_handled)
+                    .pop();
+                if (!iq) return;
+                iq.dataset_handled = true;
+                const result = stx`<iq from="${contact_jid}"
+                                       id="${iq.getAttribute('id')}"
+                                       to="${conn.jid}"
+                                       xmlns="jabber:server"
+                                       type="result">
+                    <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                        <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                            <item>
+                                <devices xmlns="${Strophe.NS.OMEMO2}">
+                                    <device id="${sender_device_id}"/>
+                                </devices>
+                            </item>
+                        </items>
+                    </pubsub>
+                </iq>`;
+                conn._dataRecv(mock.createRequest(_converse, result));
+            }, 50);
+
+            const stanza = stx`<message from="${contact_jid}"
+                    to="${conn.jid}"
+                    type="chat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <encrypted xmlns="${Strophe.NS.OMEMO2}">
+                    <header sid="${sender_device_id}">
+                        <keys jid="${_converse.bare_jid}">
+                            <key rid="${our_device_id}">${u.arrayBufferToBase64(key_and_tag)}</key>
+                        </keys>
+                    </header>
+                    <payload>${payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, stanza));
+
+            await u.waitUntil(() => msg_model.get('reactions')?.[contact_jid]?.includes('👍'));
+            clearInterval(interval);
+
+            expect(msg_model.get('reactions')[contact_jid]).toContain('👍');
+            // The emoji fallback body must NOT be surfaced as a standalone
+            // message, and must not clobber the target message's body/plaintext.
+            expect(view.model.messages.length).toBe(1);
+            expect(msg_model.get('body')).toBe('React to me with a fallback');
+            expect(msg_model.get('plaintext')).toBeFalsy();
+        }),
+    );
+
+    it(
         'shows an error for an undecryptable message that has no fallback body',
         // Regression test for https://github.com/conversejs/converse.js/issues/2097
         // An OMEMO message that we can't decrypt (here: not encrypted for this
@@ -603,6 +696,193 @@ describe('OMEMO 2 sending', function () {
             // The XEP-0085 chat state must not leak in cleartext either; it's
             // carried encrypted inside the SCE <content>.
             expect(sizzle(`> active[xmlns="${Strophe.NS.CHATSTATES}"]`, sent_stanza).length).toBe(0);
+        }),
+    );
+
+    it(
+        'encrypts an outgoing reaction instead of sending it in cleartext',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+
+            const conn = api.connection.get();
+
+            // A received message for us to react to.
+            await _converse.handleMessageStanza(
+                stx`<message xmlns="jabber:client" from="${contact_jid}" to="${conn.jid}" type="chat" id="omemo-react-send-target">
+                    <body>React to me</body>
+                </message>`,
+            );
+            await u.waitUntil(() => view.querySelector('.chat-msg[data-msgid="omemo-react-send-target"]'));
+
+            // Open the reaction picker for the target message and select an emoji.
+            // This kicks off the (async, encrypted) reaction send.
+            const msg_el = view.querySelector('.chat-msg[data-msgid="omemo-react-send-target"]');
+            const toggle_el = await u.waitUntil(() =>
+                msg_el.querySelector('converse-message-actions converse-dropdown .dropdown-toggle'),
+            );
+            toggle_el.click();
+            const action_el = await u.waitUntil(() => msg_el.querySelector('.chat-msg__action-reaction'));
+            action_el.click();
+            const picker_el = await u.waitUntil(() => msg_el.querySelector('converse-reaction-picker'));
+            picker_el.onEmojiSelected('👍');
+
+            // The encrypted send fetches recipient devices/bundles for both
+            // versions, exactly like a normal message send.
+            await mock.deviceListFetched(_converse, contact_jid, ['555']);
+            await answerV2DeviceList(_converse, contact_jid, ['555']);
+            await mock.bundleFetched(_converse, {
+                jid: _converse.bare_jid,
+                device_id: '482886413b977930064a5888b92134fe',
+                identity_key: '300000',
+                signed_prekey_id: '4224',
+                signed_prekey_public: '100000',
+                signed_prekey_sig: '200000',
+                prekeys: ['1991', '1992', '1993'],
+            });
+            await answerV2Bundle(_converse, contact_jid, '555');
+
+            const sent_stanza = await u.waitUntil(
+                () => conn.sent_stanzas.filter((s) => s.querySelector('encrypted')).pop(),
+                1000,
+            );
+
+            // The reaction is encrypted: an omemo:2 <encrypted> payload is sent
+            // (the structured <reactions> lives inside the SCE <content>)...
+            expect(sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO2}"] payload`, sent_stanza).length).toBe(1);
+            // ...and our own legacy device is addressed via the legacy element.
+            expect(sizzle(`encrypted[xmlns="${Strophe.NS.OMEMO}"]`, sent_stanza).length).toBe(1);
+            // The EME hint advertises omemo:2 (the newest method present).
+            const eme = sizzle(`encryption[xmlns="${Strophe.NS.EME}"]`, sent_stanza).pop();
+            expect(eme.getAttribute('namespace')).toBe(Strophe.NS.OMEMO2);
+
+            // Crucially, neither the structured <reactions> nor the emoji body
+            // may leak in cleartext.
+            expect(sizzle(`> reactions[xmlns="${Strophe.NS.REACTIONS}"]`, sent_stanza).length).toBe(0);
+            expect(sizzle(`> body`, sent_stanza).length).toBe(0);
+
+            // The optimistic local update still applies our reaction.
+            const msg_model = view.model.messages.findWhere({ msgid: 'omemo-react-send-target' });
+            await u.waitUntil(() => msg_model.get('reactions')?.[_converse.bare_jid]?.includes('👍'));
+            expect(msg_model.get('reactions')[_converse.bare_jid]).toContain('👍');
+        }),
+    );
+
+    it(
+        'quotes the reacted-to message in the encrypted reaction fallback body',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+            const conn = api.connection.get();
+
+            const target_text =
+                'But soft, what light through yonder airlock breaks, and who on earth goes there in the dead of night?';
+            await _converse.handleMessageStanza(
+                stx`<message xmlns="jabber:client" from="${contact_jid}" to="${conn.jid}" type="chat" id="omemo-react-quote-target">
+                    <body>${target_text}</body>
+                </message>`,
+            );
+            await u.waitUntil(() => view.querySelector('.chat-msg[data-msgid="omemo-react-quote-target"]'));
+
+            // Intercept the encrypted send before any crypto/IQ work, so we can
+            // inspect the (otherwise encrypted) fallback body and SCE extensions.
+            const send_spy = spyOn(api.omemo, 'send');
+
+            const msg_el = view.querySelector('.chat-msg[data-msgid="omemo-react-quote-target"]');
+            const toggle_el = await u.waitUntil(() =>
+                msg_el.querySelector('converse-message-actions converse-dropdown .dropdown-toggle'),
+            );
+            toggle_el.click();
+            const action_el = await u.waitUntil(() => msg_el.querySelector('.chat-msg__action-reaction'));
+            action_el.click();
+            const picker_el = await u.waitUntil(() => msg_el.querySelector('converse-reaction-picker'));
+            picker_el.onEmojiSelected('👍');
+
+            await u.waitUntil(() => send_spy.calls.count() > 0);
+            const [chat_arg, body_arg, extensions_arg] = send_spy.calls.mostRecent().args;
+
+            expect(chat_arg).toBe(view.model);
+
+            // The body is a `>`-quote of the reacted-to text (truncated to the
+            // first 80 code points + an ellipsis) followed by the emoji.
+            const [quote_line, emoji_line] = body_arg.split('\n');
+            expect(quote_line.startsWith('> But soft, what light through yonder')).toBe(true);
+            expect(quote_line.endsWith('…')).toBe(true);
+            expect(quote_line).not.toContain('dead of night');
+            expect([...quote_line].length).toBe(2 + 80 + 1); // "> " + 80 code points + "…"
+            expect(emoji_line).toBe('👍');
+
+            // The structured <reactions> and a whole-body XEP-0428 fallback
+            // marker travel as encrypted SCE extensions (not in the body).
+            const ext_els = extensions_arg.map((e) => (e instanceof Element ? e : e.tree()));
+            expect(ext_els.some((el) => el.localName === 'reactions')).toBe(true);
+            const fallback = ext_els.find((el) => el.localName === 'fallback');
+            expect(fallback.getAttribute('for')).toBe('urn:xmpp:reactions:0');
+            // Whole-body marker: no start/end range.
+            expect(fallback.querySelector('body').getAttribute('start')).toBe(null);
+        }),
+    );
+
+    it(
+        'rolls back the optimistic reaction when the encrypted send fails',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+
+            const view = _converse.chatboxviews.get(contact_jid);
+            view.model.set('omemo_active', true);
+            const conn = api.connection.get();
+
+            await _converse.handleMessageStanza(
+                stx`<message xmlns="jabber:client" from="${contact_jid}" to="${conn.jid}" type="chat" id="omemo-react-fail-target">
+                    <body>React to me</body>
+                </message>`,
+            );
+            await u.waitUntil(() => view.querySelector('.chat-msg[data-msgid="omemo-react-fail-target"]'));
+            const msg_model = view.model.messages.findWhere({ msgid: 'omemo-react-fail-target' });
+
+            // Make the encrypted send fail (e.g. no reachable devices). The real
+            // api.omemo.send would have already alerted the user before rejecting.
+            // Reject from a callFake (not a pre-built rejected promise) so the
+            // rejection is created at call time and awaited immediately.
+            spyOn(api.omemo, 'send').and.callFake(async () => {
+                throw new Error('no devices');
+            });
+            spyOn(converse.env.log, 'error');
+
+            const msg_el = view.querySelector('.chat-msg[data-msgid="omemo-react-fail-target"]');
+            const toggle_el = await u.waitUntil(() =>
+                msg_el.querySelector('converse-message-actions converse-dropdown .dropdown-toggle'),
+            );
+            toggle_el.click();
+            const action_el = await u.waitUntil(() => msg_el.querySelector('.chat-msg__action-reaction'));
+            action_el.click();
+            const picker_el = await u.waitUntil(() => msg_el.querySelector('converse-reaction-picker'));
+            picker_el.onEmojiSelected('👍');
+
+            // The optimistic reaction is applied, then rolled back once the send
+            // rejects — so we end up with no reaction from ourselves.
+            await u.waitUntil(() => converse.env.log.error.calls.count() > 0);
+            await u.waitUntil(() => !msg_model.get('reactions')?.[_converse.bare_jid]?.length);
+            expect(msg_model.get('reactions')?.[_converse.bare_jid]).toBeFalsy();
         }),
     );
 

--- a/src/plugins/omemo-views/tests/omemo2.js
+++ b/src/plugins/omemo-views/tests/omemo2.js
@@ -196,6 +196,94 @@ describe('OMEMO 2 message reception', function () {
     );
 
     it(
+        'applies an incoming encrypted (omemo:2) reaction to its target message',
+        mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
+            const { api } = _converse;
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.initializedOMEMO(_converse);
+            mock.deferV2DeviceList(contact_jid); // we answer this contact's v2 list ourselves
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+
+            const conn = api.connection.get();
+            const our_device_id = _converse.state.omemo_store.get('device_id');
+            const sender_device_id = '555';
+
+            // A (cleartext) message for the reaction to target.
+            await _converse.handleMessageStanza(
+                stx`<message xmlns="jabber:client" from="${contact_jid}" to="${conn.jid}" type="chat" id="omemo-react-target">
+                    <body>React to me</body>
+                </message>`,
+            );
+            await u.waitUntil(() => view.model.messages.findWhere({ msgid: 'omemo-react-target' }));
+            const msg_model = view.model.messages.findWhere({ msgid: 'omemo-react-target' });
+
+            // The contact sends a bodyless, SCE-encrypted XEP-0444 reaction.
+            const extensions = [
+                stx`<reactions xmlns="urn:xmpp:reactions:0" id="omemo-react-target"><reaction>👍</reaction></reactions>`,
+            ];
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(
+                null,
+                { from_jid: contact_jid, to_jid: null },
+                extensions,
+            );
+
+            // Answer the contact's v2 device-list IQ fetched during decryption.
+            const v2_dl_selector = `iq[to="${contact_jid}"] items[node="${Strophe.NS.OMEMO2_DEVICELIST}"]`;
+            const interval = setInterval(() => {
+                const iq = Array.from(conn.IQ_stanzas)
+                    .filter((i) => i.querySelector(v2_dl_selector) && !i.dataset_handled)
+                    .pop();
+                if (!iq) return;
+                iq.dataset_handled = true;
+                const result = stx`<iq from="${contact_jid}"
+                                       id="${iq.getAttribute('id')}"
+                                       to="${conn.jid}"
+                                       xmlns="jabber:server"
+                                       type="result">
+                    <pubsub xmlns="${Strophe.NS.PUBSUB}">
+                        <items node="${Strophe.NS.OMEMO2_DEVICELIST}">
+                            <item>
+                                <devices xmlns="${Strophe.NS.OMEMO2}">
+                                    <device id="${sender_device_id}"/>
+                                </devices>
+                            </item>
+                        </items>
+                    </pubsub>
+                </iq>`;
+                conn._dataRecv(mock.createRequest(_converse, result));
+            }, 50);
+
+            const stanza = stx`<message from="${contact_jid}"
+                    to="${conn.jid}"
+                    type="chat"
+                    id="${conn.getUniqueId()}"
+                    xmlns="jabber:client">
+                <encrypted xmlns="${Strophe.NS.OMEMO2}">
+                    <header sid="${sender_device_id}">
+                        <keys jid="${_converse.bare_jid}">
+                            <key rid="${our_device_id}">${u.arrayBufferToBase64(key_and_tag)}</key>
+                        </keys>
+                    </header>
+                    <payload>${payload}</payload>
+                </encrypted>
+                <encryption xmlns="${Strophe.NS.EME}" namespace="${Strophe.NS.OMEMO2}"/>
+            </message>`;
+            conn._dataRecv(mock.createRequest(_converse, stanza));
+
+            await u.waitUntil(() => msg_model.get('reactions')?.[contact_jid]?.includes('👍'));
+            clearInterval(interval);
+
+            expect(msg_model.get('reactions')[contact_jid]).toContain('👍');
+            // The reaction must not create a separate visible message, and must
+            // not clobber the target message's body.
+            expect(view.model.messages.length).toBe(1);
+            expect(msg_model.get('body')).toBe('React to me');
+        }),
+    );
+
+    it(
         'shows an error for an undecryptable message that has no fallback body',
         // Regression test for https://github.com/conversejs/converse.js/issues/2097
         // An OMEMO message that we can't decrypt (here: not encrypted for this

--- a/src/plugins/omemo-views/tests/sce.js
+++ b/src/plugins/omemo-views/tests/sce.js
@@ -21,7 +21,7 @@ describe('OMEMO 2 SCE encryption', function () {
             const decrypted = await u.omemo.decryptSCE(key_and_tag, payload, {
                 sender_jid: 'romeo@montague.lit',
             });
-            expect(decrypted).toBe(plaintext);
+            expect(decrypted.body).toBe(plaintext);
         }),
     );
 
@@ -35,7 +35,33 @@ describe('OMEMO 2 SCE encryption', function () {
             const decrypted = await u.omemo.decryptSCE(key_and_tag, payload, {
                 sender_jid: 'romeo@montague.lit',
             });
-            expect(decrypted).toBe(plaintext);
+            expect(decrypted.body).toBe(plaintext);
+        }),
+    );
+
+    it(
+        'encrypts body-coupled metadata extensions inside <content> and exposes them on decryption',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const { stx } = converse.env;
+            const { Strophe } = converse.env;
+            const plaintext = 'Hello @juliet, see the airlock';
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: null };
+            const extensions = [
+                stx`<reference xmlns="${Strophe.NS.REFERENCE}" begin="6" end="13" type="mention" uri="xmpp:juliet@capulet.lit"></reference>`,
+                stx`<reply xmlns="${Strophe.NS.REPLY}" id="some-msg-id" to="juliet@capulet.lit"></reply>`,
+            ];
+
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(plaintext, affixes, extensions);
+
+            // The metadata must not leak in cleartext (the payload is ciphertext)
+            expect(atob(payload).includes('juliet@capulet.lit')).toBe(false);
+
+            const { body, content } = await u.omemo.decryptSCE(key_and_tag, payload, {
+                sender_jid: 'romeo@montague.lit',
+            });
+            expect(body).toBe(plaintext);
+            expect(content.querySelector('reference').getAttribute('uri')).toBe('xmpp:juliet@capulet.lit');
+            expect(content.querySelector('reply').getAttribute('id')).toBe('some-msg-id');
         }),
     );
 
@@ -53,7 +79,7 @@ describe('OMEMO 2 SCE encryption', function () {
                 sender_jid: 'romeo@montague.lit',
                 to_jid: muc_jid,
             });
-            expect(decrypted).toBe(plaintext);
+            expect(decrypted.body).toBe(plaintext);
 
             // Wrong to_jid is rejected
             let error;

--- a/src/plugins/omemo-views/tests/sce.js
+++ b/src/plugins/omemo-views/tests/sce.js
@@ -66,6 +66,32 @@ describe('OMEMO 2 SCE encryption', function () {
     );
 
     it(
+        'round-trips a metadata-only (bodyless) message such as a reaction',
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const { stx } = converse.env;
+            const affixes = { from_jid: 'romeo@montague.lit', to_jid: null };
+            const extensions = [
+                stx`<reactions xmlns="urn:xmpp:reactions:0" id="target-msg-id"><reaction>👍</reaction></reactions>`,
+            ];
+
+            // No body — this is a metadata-only stanza.
+            const { key_and_tag, payload } = await u.omemo.encryptSCE(null, affixes, extensions);
+
+            const { body, content } = await u.omemo.decryptSCE(key_and_tag, payload, {
+                sender_jid: 'romeo@montague.lit',
+            });
+            // A bodyless content must NOT be mistaken for a heartbeat: content is
+            // surfaced, body is null.
+            expect(body).toBe(null);
+            expect(content).toBeTruthy();
+            expect(content.querySelector('body')).toBe(null);
+            const reactions = content.getElementsByTagNameNS('urn:xmpp:reactions:0', 'reactions')[0];
+            expect(reactions.getAttribute('id')).toBe('target-msg-id');
+            expect(reactions.querySelector('reaction').textContent).toBe('👍');
+        }),
+    );
+
+    it(
         'includes a <to> affix for MUC messages and validates it on decryption',
         mock.initConverse(converse, [], {}, async function (_converse) {
             const plaintext = 'This is a groupchat message';

--- a/src/plugins/reactions-views/fallback.js
+++ b/src/plugins/reactions-views/fallback.js
@@ -1,0 +1,37 @@
+// How many code points of the reacted-to message to quote in the fallback body.
+// Kept in sync with the XEP-0461 reply fallback (model-with-messages.js), which
+// matches the reply-context preview length.
+export const REACTION_FALLBACK_QUOTE_LENGTH = 80;
+
+/**
+ * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
+ * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
+ * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
+ * points + an ellipsis) followed by the emoji(s), e.g.:
+ *
+ *     > But soft, what light through yonder…
+ *     👍
+ *
+ * so a legacy recipient — who can't carry the structured `<reactions>` — sees
+ * both what is being reacted to and with what. The quote is omitted when the
+ * reacted-to message has no displayable text (e.g. a media-only message); the
+ * whole thing is empty for a retraction (no emojis).
+ *
+ * @param {string} text - the reacted-to message's text
+ * @param {string[]} emojis - the reaction emoji(s)
+ * @returns {string}
+ */
+export function buildReactionFallbackBody(text, emojis) {
+    const reaction = emojis.join('');
+    const snippet = (text ?? '').replace(/\s+/g, ' ').trim();
+    if (!snippet || !reaction) return reaction;
+
+    // Truncate by code points (XEP-0426), not UTF-16 units, so multi-byte
+    // characters aren't split.
+    const chars = [...snippet];
+    const quote =
+        chars.length > REACTION_FALLBACK_QUOTE_LENGTH
+            ? chars.slice(0, REACTION_FALLBACK_QUOTE_LENGTH).join('') + '…'
+            : snippet;
+    return `> ${quote}\n${reaction}`;
+}

--- a/src/plugins/reactions-views/tests/reactions.js
+++ b/src/plugins/reactions-views/tests/reactions.js
@@ -1,7 +1,58 @@
 import mock from '../../../shared/tests/mock.js';
 import converse from '../../../../dist/converse.js';
+import { buildReactionFallbackBody } from '../fallback.js';
 
 const { Strophe, sizzle, stx, u } = converse.env;
+
+describe('buildReactionFallbackBody', function () {
+    it('prefixes the text with "> " and appends the emoji on a new line', function () {
+        expect(buildReactionFallbackBody('Hello world', ['👍'])).toBe('> Hello world\n👍');
+    });
+
+    it('joins multiple emojis without a separator', function () {
+        expect(buildReactionFallbackBody('Hello', ['👍', '❤️'])).toBe('> Hello\n👍❤️');
+    });
+
+    it('truncates to 80 code points and appends an ellipsis', function () {
+        const long_text = 'a'.repeat(90);
+        const result = buildReactionFallbackBody(long_text, ['👍']);
+        const [quote] = result.split('\n');
+        expect(quote).toBe('> ' + 'a'.repeat(80) + '…');
+    });
+
+    it('does not truncate text that is exactly 80 code points', function () {
+        const exact = 'a'.repeat(80);
+        expect(buildReactionFallbackBody(exact, ['👍'])).toBe(`> ${exact}\n👍`);
+    });
+
+    it('counts code points, not UTF-16 units, when truncating', function () {
+        // Each '𝄞' (U+1D11E MUSICAL SYMBOL G CLEF) is 1 code point but 2 UTF-16 units.
+        const musical = '𝄞'.repeat(81);
+        const result = buildReactionFallbackBody(musical, ['👍']);
+        const [quote] = result.split('\n');
+        expect([...quote].length).toBe(2 + 80 + 1); // "> " + 80 code points + "…"
+    });
+
+    it('collapses internal whitespace to a single space', function () {
+        expect(buildReactionFallbackBody('Hello   world\nand\tthere', ['👍'])).toBe('> Hello world and there\n👍');
+    });
+
+    it('returns bare emoji when the text is empty', function () {
+        expect(buildReactionFallbackBody('', ['👍'])).toBe('👍');
+    });
+
+    it('returns bare emoji when the text is null', function () {
+        expect(buildReactionFallbackBody(null, ['👍'])).toBe('👍');
+    });
+
+    it('returns bare emoji when the text is whitespace-only', function () {
+        expect(buildReactionFallbackBody('   ', ['👍'])).toBe('👍');
+    });
+
+    it('returns an empty string when the emoji set is empty (retraction)', function () {
+        expect(buildReactionFallbackBody('Hello world', [])).toBe('');
+    });
+});
 
 describe('Message Reactions (XEP-0444)', function () {
     const popular_emojis = [':thumbsup:', ':heart:', ':tada:', ':joy:', ':open_mouth:'];

--- a/src/plugins/reactions-views/tests/reactions.js
+++ b/src/plugins/reactions-views/tests/reactions.js
@@ -2261,7 +2261,6 @@ function getReactionCounts(view) {
 }
 
 async function chooseReactionViaUI(view, msgid, emoji) {
-    debugger;
     const msg_el = await u.waitUntil(() => view.querySelector(`.chat-msg[data-msgid="${msgid}"]`));
     const dropdown_el = await u.waitUntil(() => msg_el?.querySelector('converse-message-actions converse-dropdown'));
     const toggle_el = await u.waitUntil(() => dropdown_el?.querySelector('.dropdown-toggle'));

--- a/src/plugins/reactions-views/utils.js
+++ b/src/plugins/reactions-views/utils.js
@@ -53,10 +53,16 @@ export function updateMessageReactions(message, emojis) {
 /**
  * Send a XEP-0444 reaction stanza and optimistically update the message.
  *
+ * The message's `reactions` are updated optimistically (so the UI is
+ * responsive); for the OMEMO-encrypted path, if the send fails the optimistic
+ * update is rolled back (`api.omemo.send` has already surfaced the error to the
+ * user). The cleartext path stays fire-and-forget — a bounced reaction stanza is
+ * rolled back later via the `getErrorAttributesForMessage` hook.
+ *
  * @param {BaseMessage} message - The message model to update
  * @param {string} emoji - The selected emoji or shortname
  */
-export function sendReaction(message, emoji) {
+export async function sendReaction(message, emoji) {
     if (!emoji) return;
 
     /** @type {ChatBoxOrMUC} */
@@ -82,7 +88,9 @@ export function sendReaction(message, emoji) {
 
     const my_jid = u.reactions.getOwnReactionJID(chatbox);
     const current_reactions = message.get('reactions') || {};
-    const my_reactions = new Set(current_reactions[my_jid] || []);
+    // Snapshot our current reaction set so we can roll back if the send fails.
+    const previous_emojis = [...(current_reactions[my_jid] || [])];
+    const my_reactions = new Set(previous_emojis);
 
     if (my_reactions.has(emoji_unicode)) {
         my_reactions.delete(emoji_unicode);
@@ -90,22 +98,106 @@ export function sendReaction(message, emoji) {
         my_reactions.add(emoji_unicode);
     }
 
-    api.send(stx`
-        <message to="${to_jid}" type="${type}" id="${u.getUniqueId('reaction')}" xmlns="jabber:client">
-            <reactions xmlns="${Strophe.NS.REACTIONS}" id="${msg_id}">
-                ${Array.from(my_reactions).map((reaction) => stx`<reaction>${reaction}</reaction>`)}
-            </reactions>
-            <store xmlns="${Strophe.NS.HINTS}"/>
-        </message>
-    `);
+    const new_emojis = Array.from(my_reactions);
 
-    updateMessageReactions(message, Array.from(my_reactions));
+    // Optimistic update — keeps the UI responsive while the send is in flight.
+    updateMessageReactions(message, new_emojis);
 
     // When adding a reaction (not removing), bump it to the front of the popular
     // emojis list and schedule a debounced publish to the user's PEP node.
     if (my_reactions.has(emoji_unicode)) {
         _converse.state.popular_emojis?.recordUsage([emoji_unicode]);
     }
+
+    // Reactions are body-coupled metadata: when the chat is OMEMO-encrypted we
+    // must not leak them in cleartext, so route them through OMEMO. Otherwise
+    // send the plain XEP-0444 stanza.
+    if (chatbox.get('omemo_active')) {
+        try {
+            await sendEncryptedReaction(chatbox, message, msg_id, new_emojis);
+        } catch (e) {
+            // api.omemo.send already alerted the user; undo the optimistic update.
+            log.error(e);
+            updateMessageReactions(message, previous_emojis);
+        }
+    } else {
+        api.send(stx`
+            <message to="${to_jid}" type="${type}" id="${u.getUniqueId('reaction')}" xmlns="jabber:client">
+                <reactions xmlns="${Strophe.NS.REACTIONS}" id="${msg_id}">
+                    ${new_emojis.map((reaction) => stx`<reaction>${reaction}</reaction>`)}
+                </reactions>
+                <store xmlns="${Strophe.NS.HINTS}"/>
+            </message>
+        `);
+    }
+}
+
+// How many code points of the reacted-to message to quote in the fallback body.
+// Kept in sync with the XEP-0461 reply fallback (model-with-messages.js), which
+// matches the reply-context preview length.
+const REACTION_FALLBACK_QUOTE_LENGTH = 80;
+
+/**
+ * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
+ * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
+ * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
+ * points + an ellipsis) followed by the emoji(s), e.g.:
+ *
+ *     > But soft, what light through yonder…
+ *     👍
+ *
+ * so a legacy recipient — who can't carry the structured `<reactions>` — sees
+ * both what is being reacted to and with what. The quote is omitted when the
+ * reacted-to message has no displayable text (e.g. a media-only message); the
+ * whole thing is empty for a retraction (no emojis).
+ *
+ * @param {string} text - the reacted-to message's text
+ * @param {string[]} emojis - the reaction emoji(s)
+ * @returns {string}
+ */
+export function buildReactionFallbackBody(text, emojis) {
+    const reaction = emojis.join('');
+    const snippet = (text ?? '').replace(/\s+/g, ' ').trim();
+    if (!snippet || !reaction) return reaction;
+
+    // Truncate by code points (XEP-0426), not UTF-16 units, so multi-byte
+    // characters aren't split.
+    const chars = [...snippet];
+    const quote =
+        chars.length > REACTION_FALLBACK_QUOTE_LENGTH
+            ? chars.slice(0, REACTION_FALLBACK_QUOTE_LENGTH).join('') + '…'
+            : snippet;
+    return `> ${quote}\n${reaction}`;
+}
+
+/**
+ * Send a XEP-0444 reaction encrypted via OMEMO.
+ *
+ * The structured `<reactions>` element travels encrypted inside the omemo:2 SCE
+ * `<content>`; the body — a quote of the reacted-to message plus the emoji(s)
+ * (see {@link buildReactionFallbackBody}) — doubles as the fallback for
+ * legacy-OMEMO recipients, whose payload can't carry structured metadata. A
+ * XEP-0428 `<fallback for="urn:xmpp:reactions:0">` marks the whole body so
+ * XEP-0444-aware clients strip it and render the reaction natively instead.
+ *
+ * @param {ChatBoxOrMUC} chatbox
+ * @param {BaseMessage} message - the message being reacted to (for its text)
+ * @param {string} msg_id - the id of the message being reacted to
+ * @param {string[]} emojis - the user's current reaction set (empty on retraction)
+ * @returns {Promise<void>} rejects if the encrypted send fails
+ */
+function sendEncryptedReaction(chatbox, message, msg_id, emojis) {
+    const extensions = [
+        stx`<reactions xmlns="${Strophe.NS.REACTIONS}" id="${msg_id}">
+            ${emojis.map((reaction) => stx`<reaction>${reaction}</reaction>`)}
+        </reactions>`,
+    ];
+    const body = buildReactionFallbackBody(message.getMessageText(), emojis);
+    // A retraction (empty set) has no body, so there's nothing to mark.
+    if (body) {
+        extensions.push(stx`<fallback xmlns="${Strophe.NS.FALLBACK}" for="${Strophe.NS.REACTIONS}"><body/></fallback>`);
+    }
+    return api.omemo.send(chatbox, body, extensions);
 }
 
 /**

--- a/src/plugins/reactions-views/utils.js
+++ b/src/plugins/reactions-views/utils.js
@@ -4,7 +4,7 @@
  */
 import { _converse, api, converse, log, u } from '@converse/headless';
 import { __ } from 'i18n';
-
+import { buildReactionFallbackBody } from './fallback.js';
 const { Strophe, sizzle, stx } = converse.env;
 
 /**
@@ -132,43 +132,7 @@ export async function sendReaction(message, emoji) {
     }
 }
 
-// How many code points of the reacted-to message to quote in the fallback body.
-// Kept in sync with the XEP-0461 reply fallback (model-with-messages.js), which
-// matches the reply-context preview length.
-const REACTION_FALLBACK_QUOTE_LENGTH = 80;
-
-/**
- * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
- * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
- * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
- * points + an ellipsis) followed by the emoji(s), e.g.:
- *
- *     > But soft, what light through yonder…
- *     👍
- *
- * so a legacy recipient — who can't carry the structured `<reactions>` — sees
- * both what is being reacted to and with what. The quote is omitted when the
- * reacted-to message has no displayable text (e.g. a media-only message); the
- * whole thing is empty for a retraction (no emojis).
- *
- * @param {string} text - the reacted-to message's text
- * @param {string[]} emojis - the reaction emoji(s)
- * @returns {string}
- */
-export function buildReactionFallbackBody(text, emojis) {
-    const reaction = emojis.join('');
-    const snippet = (text ?? '').replace(/\s+/g, ' ').trim();
-    if (!snippet || !reaction) return reaction;
-
-    // Truncate by code points (XEP-0426), not UTF-16 units, so multi-byte
-    // characters aren't split.
-    const chars = [...snippet];
-    const quote =
-        chars.length > REACTION_FALLBACK_QUOTE_LENGTH
-            ? chars.slice(0, REACTION_FALLBACK_QUOTE_LENGTH).join('') + '…'
-            : snippet;
-    return `> ${quote}\n${reaction}`;
-}
+export { buildReactionFallbackBody };
 
 /**
  * Send a XEP-0444 reaction encrypted via OMEMO.

--- a/src/shared/chat/reply-context.js
+++ b/src/shared/chat/reply-context.js
@@ -27,29 +27,10 @@ export default class ReplyContext extends CustomElement {
 
     /**
      * Get the message being replied to, if this message is a reply.
-     * According to XEP-0461, for groupchat messages the stanza_id is used,
-     * for other messages we check origin_id first, then msgid.
      * @returns {import('@converse/headless/types/shared/message').default|undefined}
      */
     getRepliedMessage() {
-        const reply_to_id = this.model.get('reply_to_id');
-        if (!reply_to_id) return undefined;
-
-        const message_type = this.model.get('type');
-        if (message_type === 'groupchat') {
-            // For groupchat, the reply_to_id is a stanza_id
-            // We need to find a message where the stanza_id matches
-            const muc_jid = this.model_with_messages?.get('jid');
-            if (muc_jid) {
-                return this.model_with_messages.messages.models.find(
-                    (m) => m.get(`stanza_id ${muc_jid}`) === reply_to_id,
-                );
-            }
-        }
-        // For non-groupchat, check origin_id first, then msgid (per XEP-0359)
-        return this.model_with_messages.messages.models.find(
-            (m) => m.get('origin_id') === reply_to_id || m.get('msgid') === reply_to_id,
-        );
+        return this.model_with_messages?.getReferencedMessage(this.model.get('reply_to_id'));
     }
 
     /**

--- a/src/types/plugins/reactions-views/fallback.d.ts
+++ b/src/types/plugins/reactions-views/fallback.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
+ * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
+ * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
+ * points + an ellipsis) followed by the emoji(s), e.g.:
+ *
+ *     > But soft, what light through yonder…
+ *     👍
+ *
+ * so a legacy recipient — who can't carry the structured `<reactions>` — sees
+ * both what is being reacted to and with what. The quote is omitted when the
+ * reacted-to message has no displayable text (e.g. a media-only message); the
+ * whole thing is empty for a retraction (no emojis).
+ *
+ * @param {string} text - the reacted-to message's text
+ * @param {string[]} emojis - the reaction emoji(s)
+ * @returns {string}
+ */
+export function buildReactionFallbackBody(text: string, emojis: string[]): string;
+export const REACTION_FALLBACK_QUOTE_LENGTH: 80;
+//# sourceMappingURL=fallback.d.ts.map

--- a/src/types/plugins/reactions-views/utils.d.ts
+++ b/src/types/plugins/reactions-views/utils.d.ts
@@ -31,25 +31,6 @@ export function updateMessageReactions(message: BaseMessage, emojis: string[]): 
  */
 export function sendReaction(message: BaseMessage, emoji: string): Promise<void>;
 /**
- * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
- * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
- * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
- * points + an ellipsis) followed by the emoji(s), e.g.:
- *
- *     > But soft, what light through yonder…
- *     👍
- *
- * so a legacy recipient — who can't carry the structured `<reactions>` — sees
- * both what is being reacted to and with what. The quote is omitted when the
- * reacted-to message has no displayable text (e.g. a media-only message); the
- * whole thing is empty for a retraction (no emojis).
- *
- * @param {string} text - the reacted-to message's text
- * @param {string[]} emojis - the reaction emoji(s)
- * @returns {string}
- */
-export function buildReactionFallbackBody(text: string, emojis: string[]): string;
-/**
  * Convert JID-keyed reactions to emoji-keyed format for display.
  *
  * Input:  `{ jid1: ['👍', '❤️'], jid2: ['👍'] }`
@@ -81,6 +62,8 @@ export function getReactorNames(jids: string[], chatbox: ChatBoxOrMUC): Promise<
  * Registers a handler for disco#info result stanzas to check for restricted reactions support.
  */
 export function registerRestrictedReactionsHandler(): void;
+export { buildReactionFallbackBody };
 export type BaseMessage = import("@converse/headless/types/shared/message").default;
 export type ChatBoxOrMUC = import("@converse/headless/types/shared/types").ChatBoxOrMUC;
+import { buildReactionFallbackBody } from './fallback.js';
 //# sourceMappingURL=utils.d.ts.map

--- a/src/types/plugins/reactions-views/utils.d.ts
+++ b/src/types/plugins/reactions-views/utils.d.ts
@@ -20,10 +20,35 @@ export function updateMessageReactions(message: BaseMessage, emojis: string[]): 
 /**
  * Send a XEP-0444 reaction stanza and optimistically update the message.
  *
+ * The message's `reactions` are updated optimistically (so the UI is
+ * responsive); for the OMEMO-encrypted path, if the send fails the optimistic
+ * update is rolled back (`api.omemo.send` has already surfaced the error to the
+ * user). The cleartext path stays fire-and-forget — a bounced reaction stanza is
+ * rolled back later via the `getErrorAttributesForMessage` hook.
+ *
  * @param {BaseMessage} message - The message model to update
  * @param {string} emoji - The selected emoji or shortname
  */
-export function sendReaction(message: BaseMessage, emoji: string): void;
+export function sendReaction(message: BaseMessage, emoji: string): Promise<void>;
+/**
+ * Build the human-readable body that doubles as the legacy-OMEMO fallback for a
+ * reaction: a XEP-0393 `>`-quote of the reacted-to text (collapsed to a single
+ * line and truncated to the first {@link REACTION_FALLBACK_QUOTE_LENGTH} code
+ * points + an ellipsis) followed by the emoji(s), e.g.:
+ *
+ *     > But soft, what light through yonder…
+ *     👍
+ *
+ * so a legacy recipient — who can't carry the structured `<reactions>` — sees
+ * both what is being reacted to and with what. The quote is omitted when the
+ * reacted-to message has no displayable text (e.g. a media-only message); the
+ * whole thing is empty for a retraction (no emojis).
+ *
+ * @param {string} text - the reacted-to message's text
+ * @param {string[]} emojis - the reaction emoji(s)
+ * @returns {string}
+ */
+export function buildReactionFallbackBody(text: string, emojis: string[]): string;
 /**
  * Convert JID-keyed reactions to emoji-keyed format for display.
  *

--- a/src/types/shared/chat/reply-context.d.ts
+++ b/src/types/shared/chat/reply-context.d.ts
@@ -14,8 +14,6 @@ export default class ReplyContext extends CustomElement {
     model_with_messages: any;
     /**
      * Get the message being replied to, if this message is a reply.
-     * According to XEP-0461, for groupchat messages the stanza_id is used,
-     * for other messages we check origin_id first, then msgid.
      * @returns {import('@converse/headless/types/shared/message').default|undefined}
      */
     getRepliedMessage(): import("@converse/headless/types/shared/message").default | undefined;

--- a/src/types/shared/texture/utils.d.ts
+++ b/src/types/shared/texture/utils.d.ts
@@ -89,12 +89,8 @@ declare const _default: {
     getLongestSubstring(string: string, candidates: string[]): string;
     isString(s: any): boolean;
     getDefaultStorageType(): import("headless/types/utils/types.js").StorageType;
-    createStore(id: string, type: import(
-    /**
-     * @param {{uri: string, mention: string}} o
-     * @returns {import('lit').TemplateResult}
-     */
-    "headless/types/utils/types.js").StorageType): import("@converse/skeletor").BrowserStorage;
+    isPersistentStorageAvailable(): boolean;
+    createStore(id: string, type: import("headless/types/utils/types.js").StorageType): import("@converse/skeletor").BrowserStorage;
     initStorage(model: import("headless/types/utils/types.js").StorageModel, id: string, type?: import("headless/types/utils/types.js").StorageType): void;
     isErrorStanza(stanza: Element): boolean;
     isForbiddenError(stanza: Element): boolean;

--- a/src/types/utils/index.d.ts
+++ b/src/types/utils/index.d.ts
@@ -27,6 +27,7 @@ declare const _default: {
     getLongestSubstring(string: string, candidates: string[]): string;
     isString(s: any): boolean;
     getDefaultStorageType(): import("headless/types/utils/types.js").StorageType;
+    isPersistentStorageAvailable(): boolean;
     createStore(id: string, type: import("headless/types/utils/types.js").StorageType): import("@converse/skeletor").BrowserStorage;
     initStorage(model: import("headless/types/utils/types.js").StorageModel, id: string, type?: import("headless/types/utils/types.js").StorageType): void;
     isErrorStanza(stanza: Element): boolean;
@@ -139,6 +140,7 @@ declare const _default: {
         getLongestSubstring(string: string, candidates: string[]): string;
         isString(s: any): boolean;
         getDefaultStorageType(): import("headless/types/utils/types.js").StorageType;
+        isPersistentStorageAvailable(): boolean;
         createStore(id: string, type: import("headless/types/utils/types.js").StorageType): import("@converse/skeletor").BrowserStorage;
         initStorage(model: import("headless/types/utils/types.js").StorageModel, id: string, type?: import("headless/types/utils/types.js").StorageType): void;
         isErrorStanza(stanza: Element): boolean;


### PR DESCRIPTION
Body-coupled message metadata now lives **inside the OMEMO:2 SCE `<content>` envelope**, encrypted alongside the body.

Previously, for encrypted messages this metadata was either dropped entirely (references/oob/spoiler, gated behind `!is_encrypted` in `createMessageStanza`) or leaked in cleartext (reply). References in particular are positional offsets into the body, so placing them in the cleartext stanza (which only carries the OMEMO fallback string) made them meaningless; replies/mentions are exactly the metadata SCE exists to protect.

It is intentionally **omitted for legacy OMEMO 1** recipients, their payload is an encrypted string with no envelope for sibling elements, who degrade gracefully and still decrypt the body. Nothing is duplicated across zones, and nothing body-coupled stays in cleartext. This is a migration bridge until OMEMO 1 is sunset.

