### PR TITLE
Clear the background class list before setting theme attributes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 14.0.0-beta.2 (2026-06-18)
 
 - Remove `client-compress` and use browser APIs
+- fix: Prior theme CSS class is not removed when changing the theme dynamically.
 
 ## 14.0.0-beta.1 (2026-06-18)
 

--- a/src/plugins/rootview/background.js
+++ b/src/plugins/rootview/background.js
@@ -30,6 +30,7 @@ class ConverseBackground extends CustomElement {
 
     setThemeAttributes () {
         const theme = getTheme();
+        this.classList.forEach((name) => name.startsWith('theme-') && this.classList.remove(name));
         this.classList.add(`theme-${theme}`);
         this.setAttribute('data-converse-theme', theme);
         this.setAttribute('data-bs-theme', theme);

--- a/src/plugins/rootview/tests/background.js
+++ b/src/plugins/rootview/tests/background.js
@@ -1,0 +1,33 @@
+import mock from '../../../shared/tests/mock.js';
+import converse from '../../../../dist/converse.js';
+
+const u = converse.env.utils;
+
+describe('Converse Background Theme', function() {
+    it(
+        'clears old theme class and applies only the new one when theme changes',
+        mock.initConverse(converse, [], {
+                show_background: true,
+                theme: 'nordic',
+                dark_theme: 'nordic'
+            },
+            async (_converse) => {
+                const { api } = _converse;
+
+                await u.waitUntil(() => document.querySelector('converse-bg'));
+                const bg = document.querySelector('converse-bg');
+
+                await u.waitUntil(() => bg.classList.contains('theme-nordic'), 1000);
+                let bgClassList = Array.from(bg.classList).filter((c) => c.startsWith('theme-'));
+                expect(bgClassList).toEqual(['theme-nordic']);
+
+                api.settings.set('theme', 'dracula');
+                api.settings.set('dark_theme', 'dracula');
+                bg.setThemeAttributes();
+
+                bgClassList = Array.from(bg.classList).filter((c) => c.startsWith('theme-'));
+                expect(bgClassList).toEqual(['theme-dracula']);
+            }
+        )
+    );
+});


### PR DESCRIPTION
When changing the theme via the settings API, the background element did not clear out the previous theme class, resulting in theme CSS conflicts.

This change removes all `theme-` classes before applying the new theme, resolving the issue.


- [X] Add a changelog entry for your change in `CHANGES.md`
- [X] Please add a test for your change. Tests can be run in the commandline
      with `make check` or you can run them in the browser by running `make serve`
      and then opening `http://localhost:8000/tests.html`.
