### PR TITLE
feat: require current password when resetting password

### DIFF
--- a/src/plugins/profile/password-reset.js
+++ b/src/plugins/profile/password-reset.js
@@ -62,12 +62,14 @@ class PasswordReset extends CustomElement {
 
         const data = new FormData(ev.target);
         const password = data.get('password');
+        const current_password = data.get('current_password');
 
         const reset_iq = stx`
             <iq type="set" to="${domain}" xmlns="jabber:client">
                 <query xmlns="${Strophe.NS.REGISTER}">
                     <username>${username}</username>
                     <password>${password}</password>
+                    <old_password>${current_password}</old_password>
                 </query>
             </iq>`;
 
@@ -78,6 +80,8 @@ class PasswordReset extends CustomElement {
             this.alert_message = __('Your server does not allow password reset');
         } else if (sizzle(`error forbidden[xmlns="${Strophe.NS.STANZAS}"]`, iq_result).length) {
             this.alert_message = __('You are not allowed to change your password');
+        } else if (sizzle(`error not-authorized[xmlns="${Strophe.NS.STANZAS}"]`, iq_result).length) {
+            this.alert_message = __('Incorrect current password');
         } else if (u.isErrorStanza(iq_result)) {
             this.alert_message = __('You are not allowed to change your password');
         } else {

--- a/src/plugins/profile/templates/password-reset.js
+++ b/src/plugins/profile/templates/password-reset.js
@@ -3,12 +3,28 @@ import { html } from 'lit';
 
 export default el => {
     const i18n_submit = __('Submit');
+    const i18n_current_password = __('Current password');
     const i18n_passwords_must_match = __('The new passwords must match');
     const i18n_new_password = __('New password');
     const i18n_confirm_password = __('Confirm new password');
 
     return html`<form class="converse-form passwordreset-form" method="POST" @submit=${ev => el.onSubmit(ev)}>
         ${el.alert_message ? html`<div class="alert alert-danger" role="alert">${el.alert_message}</div>` : ''}
+
+        <div class="py-2">
+            <label for="converse_password_reset_current" class="form-label">${i18n_current_password}</label>
+            <input
+                class="form-control"
+                type="password"
+                value=""
+                name="current_password"
+                required="required"
+                id="converse_password_reset_current"
+                autocomplete="current-password"
+                minlength="8"
+                ?disabled="${el.alert_message}"
+            />
+        </div>
 
         <div class="py-2">
             <label for="converse_password_reset_new" class="form-label">${i18n_new_password}</label>

--- a/src/plugins/profile/tests/password-reset.js
+++ b/src/plugins/profile/tests/password-reset.js
@@ -13,6 +13,8 @@ async function submitPasswordResetForm(_converse) {
     modal.querySelector('#passwordreset-tab').click();
     const form = await u.waitUntil(() => modal.querySelector('.passwordreset-form'));
 
+    const current_pw_input = form.querySelector('input[name="current_password"]');
+    current_pw_input.value = 'current-password';
     const pw_input = form.querySelector('input[name="password"]');
     pw_input.value = 'secret-password';
     const pw_check_input = form.querySelector('input[name="password_check"]');
@@ -57,6 +59,7 @@ describe('The profile modal', function () {
                 <query xmlns="jabber:iq:register">
                     <username>romeo@montague.lit</username>
                     <password>secret-password</password>
+                    <old_password>current-password</old_password>
                 </query>
             </iq>`);
 
@@ -134,6 +137,7 @@ describe('The profile modal', function () {
                 <query xmlns="jabber:iq:register">
                     <username>romeo@montague.lit</username>
                     <password>secret-password</password>
+                    <old_password>current-password</old_password>
                 </query>
             </iq>`);
 
@@ -148,6 +152,46 @@ describe('The profile modal', function () {
 
             const alert = await u.waitUntil(() => modal.querySelector('.alert-danger'));
             expect(alert.textContent).toBe('You are not allowed to change your password');
+        }),
+    );
+
+    it(
+        "informs you if the current password is incorrect",
+        mock.initConverse(converse, [], {}, async function (_converse) {
+            const modal = await submitPasswordResetForm(_converse);
+
+            const sent_IQs = _converse.api.connection.get().IQ_stanzas;
+            const query_iq = await u.waitUntil(() =>
+                sent_IQs.filter((iq) => sizzle('query[xmlns="jabber:iq:register"]', iq).length).pop(),
+            );
+
+            _converse.api.connection.get()._dataRecv(
+                mock.createRequest(_converse, 
+                    u.toStanza(`
+                    <iq type='result' id='${query_iq.getAttribute('id')}'>
+                        <query xmlns='jabber:iq:register'>
+                            <username>romeo@montague.lit</username>
+                            <password/>
+                        </query>
+                    </iq>`),
+                ),
+            );
+
+            const set_iq = await u.waitUntil(() =>
+                sent_IQs.filter((iq) => sizzle('iq[type="set"] query[xmlns="jabber:iq:register"]', iq).length).pop(),
+            );
+
+            _converse.api.connection.get()._dataRecv(
+                mock.createRequest(_converse, 
+                    u.toStanza(`
+                <iq type='result' id="${set_iq.getAttribute('id')}">
+                    <error type="modify"><not-authorized xmlns="${Strophe.NS.STANZAS}"/></error>
+                </iq>`),
+                ),
+            );
+
+            const alert = await u.waitUntil(() => modal.querySelector('.alert-danger'));
+            expect(alert.textContent).toBe('Incorrect current password');
         }),
     );
 });


### PR DESCRIPTION
## Summary

This PR addresses issue #3120 by adding a current password field to the password reset form. Currently, anyone with access to the browser can change the user's password without knowing the current one, which is a security concern.

## Changes

- Added a "Current password" input field to the password reset form
- Updated the XMPP IQ stanza to include the `<old_password>` field when submitting the password change request
- Added handling for `not-authorized` error responses (shown when the current password is incorrect)
- Updated existing tests to include the current password field
- Added a new test case for incorrect current password scenarios

## Technical Details

The form now requires three fields:
1. **Current password** (required) - authenticates the user before allowing password change
2. **New password** (required) - the new password to set
3. **Confirm new password** (required) - ensures the user typed the new password correctly

When the form is submitted, the XMPP registration query includes both the new password and the old password, allowing the server to validate the current credentials before processing the change.

## Related Issues

- Fixes #3120
- References #326