### PR TITLE
Fix intermittent missing new message count badge (Issue #4110)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 15.0.0 (Unreleased)
 
+- #4110: Fix timing race where the contact unread message counter fails to synchronize on load
 - #194: Full support for XEP-0115: Entity capabilities
 
 ### Breaking changes:

--- a/src/headless/plugins/chat/tests/chat.js
+++ b/src/headless/plugins/chat/tests/chat.js
@@ -64,4 +64,60 @@ describe('A ChatBox', function () {
             expect(newest_msg.get('message')).toBe('This is a chat message');
         }),
     );
+
+    it(
+        'synchronizes the unread counter when the contact object finishes loading asynchronously',
+        mock.initConverse(converse, ['rosterInitialized', 'chatBoxesInitialized'], {}, async (_converse) => {
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+
+            const contact = _converse.state.roster.get(contact_jid);
+            expect(contact).toBeDefined();
+
+            // Prepare a promise we can resolve to simulate asynchronous loading of the contact
+            let resolve_contact;
+            const contact_promise = new Promise((resolve) => {
+                resolve_contact = resolve;
+            });
+
+            // Spy on api.contacts.get to return our deferred promise for this contact
+            const original_get = _converse.api.contacts.get;
+            _converse.api.contacts.get = async function (jids) {
+                if (jids === contact_jid) {
+                    return contact_promise;
+                }
+                return original_get.call(_converse.api.contacts, jids);
+            };
+
+            const ChatBox = _converse.exports.ChatBox;
+            const chatbox = new ChatBox({
+                jid: contact_jid,
+                type: 'chatbox'
+            }, {
+                collection: _converse.state.chatboxes
+            });
+
+            // The contact must not be set on the chatbox yet since it is resolving asynchronously
+            expect(chatbox.contact).toBeNull();
+
+            // A new message arrives (or we set unread count), updating num_unread on the chatbox
+            chatbox.set('num_unread', 2);
+
+            // The roster contact's unread count should be 0 at this point
+            expect(contact.get('num_unread')).toBe(0);
+
+            // Now, resolve the contact promise, simulating that the contact has loaded
+            resolve_contact(contact);
+
+            // Wait for the asynchronous tasks to complete
+            await contact_promise;
+            await chatbox.initialized;
+
+            // Verify that the contact's unread counter is synchronized to 2
+            expect(contact.get('num_unread')).toBe(2);
+
+            // Clean up
+            _converse.api.contacts.get = original_get;
+        })
+    );
 });

--- a/src/headless/shared/model-with-contact.js
+++ b/src/headless/shared/model-with-contact.js
@@ -67,6 +67,7 @@ export default function ModelWithContact(BaseModel) {
 
             if (contact) {
                 this.contact = contact;
+                this.updateContactUnreadCounter();
                 this.set('nickname', contact.get('nickname'));
 
                 this.listenTo(this.contact, 'vcard:add', (changed) => {


### PR DESCRIPTION
This fixes a timing race condition where the roster badge fails to update with new unread messages if they arrive before the linked roster contact object has finished loading asynchronously.

Changes :

Fix : Added a call to `this.updateContactUnreadCounter()` inside `setModelContact` in `src/headless/shared/model-with-contact.js` to sync the unread counter as soon as the contact resolves.

Test : Added a regression integration test in `src/headless/plugins/chat/tests/chat.js` that mock-delays the contact load, sets the unread count, and asserts that the contact's unread badge synchronizes correctly upon resolution.

Changelog : Added an entry for Issue #4110 in `CHANGES.md`.
