### PR TITLE
fix(utils): detect images by an image/* content-type, not video/*

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
   colour as the header itself.
 - fix(chatview): Show the contact's status message in the chat header again. It was read off the
   chat, while the presence handler keeps it on the contact, so it never rendered.
+- fix(utils): `isImageURL` checked the fetched `Content-Type` header for `video`, not `image`. With
+  `fetch_url_headers` on, extensionless image URLs weren't rendered at all and video URLs were
+  rendered as broken images.
 - fix(vcard): Don't eagerly refetch cached vcards when a session resumes.
 - fix(vcard): Don't fetch a MUC's own vCard in response to an occupant presence.
 - refactor(smacks): XEP-0198 Stream Management is now implemented natively by Strophe.js (see its

--- a/src/headless/utils/url.js
+++ b/src/headless/utils/url.js
@@ -104,7 +104,7 @@ export function isVideoURL(url, headers) {
  * @returns {boolean}
  */
 export function isImageURL(url, headers) {
-    if (headers?.get("content-type")?.startsWith("video")) {
+    if (headers?.get("content-type")?.startsWith("image")) {
         return true;
     }
     const regex = settings.get("image_urls_regex");

--- a/src/plugins/chatview/tests/message-images.js
+++ b/src/plugins/chatview/tests/message-images.js
@@ -5,6 +5,30 @@ const { sizzle, u } = converse.env;
 
 describe('A Chat Message', function () {
     it(
+        'will render images served from an extensionless URL with an image content-type',
+        mock.initConverse(converse, ['chatBoxesFetched'], { fetch_url_headers: true }, async function (_converse) {
+            const message = 'http://foo.bar/image-stream';
+            const original_fetch = window.fetch.bind(window);
+            spyOn(window, 'fetch').and.callFake(async (url, options) => {
+                if (String(url) !== message) return original_fetch(url, options);
+                return new Response('', {
+                    status: 200,
+                    headers: { 'Content-Type': 'image/png' },
+                });
+            });
+
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+            await mock.sendMessage(_converse, view, message);
+            await u.waitUntil(() => view.querySelectorAll('.chat-content .chat-image').length, 1000);
+            const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text').pop();
+            expect(msg.querySelector('img.chat-image').getAttribute('src')).toEqual(message);
+        }),
+    );
+
+    it(
         'will render images from their URLs',
         mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
             await mock.waitForRoster(_converse, 'current');

--- a/src/plugins/chatview/tests/message-videos.js
+++ b/src/plugins/chatview/tests/message-videos.js
@@ -5,6 +5,31 @@ const { sizzle, u } = converse.env;
 
 describe('A chat message containing video URLs', function () {
     it(
+        'will render video streams using the video player',
+        mock.initConverse(converse, ['chatBoxesFetched'], { fetch_url_headers: true }, async function (_converse) {
+            const message = 'http://foo.bar/stream';
+            const original_fetch = window.fetch.bind(window);
+            spyOn(window, 'fetch').and.callFake(async (url, options) => {
+                if (String(url) !== message) return original_fetch(url, options);
+                return new Response('', {
+                    status: 200,
+                    headers: { 'Content-Type': 'video/mp4' },
+                });
+            });
+
+            await mock.waitForRoster(_converse, 'current', 1);
+            const contact_jid = mock.cur_names[0].replace(/ /g, '.').toLowerCase() + '@montague.lit';
+            await mock.openChatBoxFor(_converse, contact_jid);
+            const view = _converse.chatboxviews.get(contact_jid);
+            await mock.sendMessage(_converse, view, message);
+            await u.waitUntil(() => view.querySelectorAll('.chat-content video').length, 1000);
+            const msg = sizzle('.chat-content .chat-msg:last .chat-msg__text').pop();
+            expect(msg.querySelector('video').getAttribute('src')).toEqual(message);
+            expect(msg.querySelector('img.chat-image')).toBe(null);
+        }),
+    );
+
+    it(
         'will render videos from their URLs',
         mock.initConverse(converse, ['chatBoxesFetched'], {}, async function (_converse) {
             await mock.waitForRoster(_converse, 'current');


### PR DESCRIPTION
`isImageURL` (`src/headless/utils/url.js:107`) tests the fetched `Content-Type` for `"video"` instead of `"image"` — a copy-paste of the check in `isVideoURL` directly above it, from f4dac965a.

So with `fetch_url_headers: true`, `getMetadataForURL` marks a `video/mp4` URL as both `is_image` and `is_video`, and never marks an `image/png` URL as `is_image`. `Texture.addHyperlinkTemplate` (`src/shared/texture/texture.js:129`) tests `is_image` first, so an extensionless video stream renders as a broken `<img>` and an extensionless image stream renders as a plain link. Extension-based detection is unaffected.

Two specs added, mirroring the existing `audio/mpeg` stream spec in `message-audio.js`.

Node 22.23.2, `npx vitest run --project main src/plugins/chatview/tests/message-{images,videos}.js`: with the fix reverted and the new specs kept, 2 failed | 12 passed; with the fix applied, 14 passed.

Worth flagging for anyone reproducing this: the specs import the built bundle from `dist/`, and the build is two-stage — reverting `src/headless/utils/url.js` changes nothing until both `src/headless/dist/converse-headless.js` and `dist/converse.js` are rebuilt. A single-stage rebuild silently keeps the fix in place and the tests pass either way.

I left the `is_image`-before-`is_video` ordering in `addHyperlinkTemplate` alone: reordering would hide the video symptom while leaving the image case broken, so it treats the display rather than the cause.

Not tested: no run against a real server, Vitest only, and I have not verified the full `npm test` suite on this branch — the numbers above are the scoped run only.

Written with AI assistance (Claude Code).
